### PR TITLE
Noting Headers do no accept integers in the JSON

### DIFF
--- a/source/API_Reference/Web_API/mail.html
+++ b/source/API_Reference/Web_API/mail.html
@@ -171,7 +171,7 @@ send
 
        <td>No</td>
 
-       <td>Must be in valid JSON format</td>
+       <td>Must be in valid JSON format without integers</td>
 
        <td>A collection of key/value pairs in JSON format. Each key represents a header
        name and the value the header value. Ex: {"X-Accept-Language": "en", "X-Mailer":


### PR DESCRIPTION
Ticket #183055 referenced integers in their custom headers but it
failed.
