### PR TITLE
Fix missing closing anchor element on User Guide index

### DIFF
--- a/source/User_Guide/index.html
+++ b/source/User_Guide/index.html
@@ -34,6 +34,6 @@ href="{{root_url}}/Apps/index.html" title="SendGrid Apps">apps</a>.</p>
 Marketers
 {% endanchor %}
 
-<p>Our marketing email feature lets you compose and send email campaigns from a powerful web-based tool. We provide list management, delivery scheduling, A/B split testing, and of course we provide analytics on the emails you send. You can take a look at our <a href="{{root_url}}/Marketing_Emails/index.html" title="Marketing Email Documentation" marketing email documentation</a> to learn more.</p>
+<p>Our marketing email feature lets you compose and send email campaigns from a powerful web-based tool. We provide list management, delivery scheduling, A/B split testing, and of course we provide analytics on the emails you send. You can take a look at our <a href="{{root_url}}/Marketing_Emails/index.html" title="Marketing Email Documentation">marketing email documentation</a> to learn more.</p>
 
-<p>We also provide a robust <a href="{{root_url}}/API_Reference/Marketing_Emails_API/index.html" title="Marketing Email API" marketing email API</a> if you want to integrate any of these features into your own application.</p>
+<p>We also provide a robust <a href="{{root_url}}/API_Reference/Marketing_Emails_API/index.html" title="Marketing Email API">marketing email API</a> if you want to integrate any of these features into your own application.</p>


### PR DESCRIPTION
there were a couple missing closing anchor elements (when reading through the docs), that made it read funny.
