### PR TITLE
Gives explanatory text having to do with Bcc field vs addTo

### DIFF
--- a/source/Code_Examples/php.html
+++ b/source/Code_Examples/php.html
@@ -124,11 +124,12 @@ File attachments are limited to 7 MB per file.
 $mail = new SendGrid\Mail();
 $mail->
   addTo('foo@bar.com')->
+  addTo('guy@other.com')->
   ...
   addAttachment("../path/to/file.txt");
 ?>
 {% endcodeblock %}
-
+<p><strong>Important Gotcha</strong>: setBcc is not supported with attachments. This is by design. Instead use multiple addTos. Each user will receive their own personalized email with that setup, and receive the attachment correctly.</p>
 {% anchor h3 %}
 Using Substitutions
 {% endanchor %}


### PR DESCRIPTION
https://github.com/sendgrid/sendgrid-php/issues/24

Adds some documentation about using bcc with attachments.
