### PR TITLE
Update email_error_messages.html

### DIFF
--- a/source/Delivery_Metrics/email_error_messages.html
+++ b/source/Delivery_Metrics/email_error_messages.html
@@ -6,46 +6,162 @@ navigation:
   show: true
 ---
 
-<p>When you send an email, it must be accepted by the recipients mail server before anything else happens. These mail servers will always respond with numerical error messages to tell you the reason a particular mail server handled the message the way it did. Different mail servers use different phrasing for error messages, but the numeric codes are always the same. </p>
+<p>Email is essentially computers talking to each other in simple codes to relay simple text messages. Being able to interpret the codes that these computers kick back when something goes wrong is a skill that doesn't always come naturally, so we've assembled a collection of common responses you're likely to see come back from recipient mail servers, as well as guidance on what to do with them.</p>
+<p><strong>Please note:</strong>This is only a small handful of the response codes that can be sent back. Every receiving mail server out there is unique, so the responses you see may differ from those below. Use the human-readable portion of the response code to get more info if you get stuck, or get in touch with our Support team!</p>
 
-<p>On the <a href="http://sendgrid.com/logs/index">Email Activity</a> page, you can expand specific events to see the messages returned by the receiving mail server. Remember you can filter by specific email addresses by using the search field provided. You may also filter your search to only populate specific event types such as Requests, Bounces, Deferrals and Drops.</p>
-
-<p><img src="{{root_url}}/images/email_error_messages.png" alt="" /></p>
-
-<p>You can also use the <a href="http://sendgrid.com/bounces/">Email Lists</a> to view the messages returned for the specific event categories listed there.</p>
-
-<p>Listed below are some examples of messages you are likely to see, along with a brief description of what caused the error to be returned.</p>
-
- {% anchor h2 %}
-200's 
+{% anchor h2 %}
+250 
+{% endanchor %}
+<p>The best mail server response code you can get. When you see this, everything has gone according to plan! This response is what results in a 'Delivered' event within your Sendgrid stats, and indicates that the recipient server has accepted the message.</p>
+{% anchor h3 %}
+Examples:
 {% endanchor %}
 <ul>
- <li>250 – Requested action taken and completed. This message is your friend.</li>
- <li>251 – The recipient is not local to the server, but the server will accept and forward the message.</li>
- <li>252 – The recipient cannot be VRFYed, but the server accepts the message and attempts delivery.</li>
+<li>250 2.0.0 OK 1376056636 i3si9508927obz.16 - gsmtp</li>
+<li>250 ok dirdel</li>
+<li>250 &lt;4798911130a2069f3483fda756b8e81c@www.example.com&gt; Queued mail for delivery</li>
 </ul>
- {% anchor h2 %}
-400's 
+<p><strong><em>What to do with this response</em></strong><em>:</em>Nothing, all is well with the cosmos. If you want, you could always print it out and frame it. Do keep in mind that messages that contain things like "Queued mail for delivery" is still indicative of a successful handoff to the recipient server, but there may still be internal queueing on the far end.</p>
+
+
+
+<h2>Temporary Failures - “If at first you don’t succeed..."</h2>
+<p>A 400-style message is usually returned when some sort of transient error is encountered during the message transaction. These types of responses are usually not a cause for alarm as most of these will iron themselves out given a little time.</p>
+
+{% anchor h2 %}
+421
+{% endanchor %}
+<p>Messages are temporarily deferred because of recipient server policy reasons. Usually because of too many messages or connections in too short a timeframe.</p>
+{% anchor h3 %}
+Examples:
 {% endanchor %}
 <ul>
- <li>421 – The service is not available and the connection will be closed.</li>
- <li>450 – The requested command failed because the user's mailbox was unavailable.</li>
- <li>451 – The command has been aborted due to a server error on the recipient side.</li>
- <li>452 – The command has been aborted because the server has insufficient system storage.</li>
+<li>421 4.7.0 [GL01] Message from (X.X.X.X) temporarily deferred</li>
+<li>421 4.7.1 : (DYN:T1)http://postmaster.info.aol.com/errors/421dynt1.html (throttled) </li>
+<li>421 4.7.0 [GL01] Message from (X.X.X.X) temporarily deferred - 4.16.50. Please refer to http://postmaster.yahoo.com/errors/postmaster-21.html</li>
 </ul>
- {% anchor h2 %}
-500's 
+<p><strong><em>What to do with this response</em></strong><strong><em>:</em></strong> We’ll continue to retry deferred messages for up to 72 hours for a response like this, but you may consider temporarily easing off the throttle when sending messages to a domain that is returning this code, just so you don’t further delay your messages currently being tried.</p>
+
+{% anchor h2 %}
+450 
+{% endanchor %}
+<p>The message failed because the user's mailbox was unavailable, perhaps because it was locked or was not routable at the time.</p>
+{% anchor h3 %}
+Examples:
 {% endanchor %}
 <ul>
- <li>500 – The server could not recognize the command due to a syntax error.</li>
- <li>501 – A syntax error was encountered in command arguments.</li>
- <li>502 – This command is not implemented.</li>
- <li>503 – The server has encountered a bad sequence of commands.</li>
- <li>504 – A command parameter is not implemented.</li>
- <li>550 – The requested command failed because the user's mailbox was unavailable</li>
- <li>551 – The recipient is not local to the mail server.</li>
- <li>552 – The action was aborted due to storage capacity allowances.</li>
- <li>553 – The command was aborted because the mailbox name is invalid.</li>
- <li>554 – The transaction failed, often for reasons unknown.</li>
+<li>450 4.2.1 The user you are trying to contact is receiving mail too quickly. Please resend your message at a later time. If the user is able to receive mail at that time, your message will be delivered.</li>
+<li>450 too frequent connects from 198.37.147.135, please try again later. (throttled)</li>
 </ul>
-<p> The messages you see may vary from domain to domain, so be sure to read the error reasons in addition to referencing this list.</p>
+<p><strong><em>What to do with this response</em></strong><em>:</em>We’ll continue to retry deferred messages for up to 72 hours for a response like this. Generally this is based on a large influx of messages that you send, or if you've sent at a rate that the recipient server deems worthy of slowing down.</p>
+
+{% anchor h2 %}
+451
+{% endanchor %}
+<p>The message simply failed, usually due to a far-end server error. This is unlikely anything you’ve done, remember we’ll keep retrying for 72 hours, so just keep an eye on it.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<li>451 mta1012.mail.gq1.yahoo.com Resources temporarily unavailable. Please try again later [#4.16.1].</li>
+<li>451 Temporary local problem - please try later</li>
+</ul>
+<p><strong><em>What to do with this response</em></strong>: We’ll continue to retry deferred messages for up to 72 hours for a response like this. Just keep your eyes peeled to see if the response to our retry attempts change.</p>
+
+{% anchor h2 %}
+452 
+{% endanchor %}
+<p>The message has been deferred due to insufficient system storage. Not your fault, they'll probably accept the mail later on once there's more space.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<li>452 Too many recipients received this hour (throttled)</li>
+<li>452. 4.3.1 Insufficient system storage (throttled)</li>
+<li>452 4.2.2 Over Quota</li>
+</ul>
+<p><strong><em>What to do with this response</em></strong>:We’ll continue to retry deferred messages for up to 72 hours for a response like this. Just keep your eyes peeled to see if the response to our retry attempts change.</p>
+
+
+
+<h2>Hard Failures - "Return to Sender..."</h2>
+<p>A Hard, or Immediate, failure is anything that gets 500-style message as the result of trying to hand off a message. This typically indicates that some sort of permanent error occurred, this can range from systemic errors on the far-end server that just flat out prevents mail from coming in, all the way to policy-related blocks pertaining to content or other such factors. The examples below will give a taste of some of the myriad reasons a 500-style NDR(non-delivery response) can get returned for.</p>
+
+{% anchor h2 %}
+550
+{% endanchor %}
+<p>The user's mailbox was unavailable. Usually because it could not be found, or because of incoming policy reasons.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<li>550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.</li>
+<li>550 Requested action not taken: mailbox unavailable</li>
+<li>550 5.1.1 &lt;address@aol.com&gt;: Recipient address rejected: aol.com</li>
+</ul>
+<p><strong><em>What to do with this response</em></strong>:It's probably a good idea to take addresses that throw this response off of your main list, as it's likely a bogus address or one that was mistyped.</p>
+
+{% anchor h2 %}
+551 
+{% endanchor %}
+<p>The intended mailbox does not exist on this recipient server. This response will sometimes include a forward address to try if the server knows where the intended mailbox is.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<li>551 not our customer</li>
+<li>551 user does not exist</li>
+</ul>
+<p><strong><em>What to do with this response</em></strong>: Don’t bother re-sending, the recipient server does not recognize the recipient address as being one of it’s own. Keep any eye on the human readable portion of the response, as it may include a forwarding address.</p>
+
+{% anchor h2 %}
+552 
+{% endanchor %}
+<p>The intended mailbox has exceeded its storage limits.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<li>552 5.2.2 This message is larger than the current system limit or the recipient's mailbox is full. Create a shorter message body or remove attachments and try sending it again.</li>
+</ul>
+<p><strong><em>What to do with this response</em></strong><em>:</em>It’s at your discretion if you want to try re-sending, but there's a pretty good chance that it's a defunct address. We don't resend messages with this error code, so refer to the human readable portion for more guidance.</p>
+
+{% anchor h2 %}
+553 
+{% endanchor %}
+<p>The message was refused because the mailbox name is either malformed or does not exist.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<ul>
+<li>553 sorry, that domain isn't in my list of allowed rcpthosts (#5.7.1)</li>
+<li>553 Invalid/inactive user.</li>
+</ul>
+</ul>
+<p><strong><em>What to do with this response</em></strong><strong><em>:</em></strong>Don’t retry sending to this address, it’s fairly likely that it’s a bogus or mistyped address.</p>
+
+{% anchor h2 %}
+554 
+{% endanchor %}
+<p>The message failed. This response is a ‘default’ of sorts, but can be attributed to anything from planetary alignment, tides of the moon or gypsy curses. Generally a very vague NDR, but refer to the human-readable portion of the message for further instruction.</p>
+{% anchor h3 %}
+Examples:
+{% endanchor %}
+<ul>
+<ul>
+<li>554 5.7.1 - ERROR: Mail refused</li>
+<li>554 5.7.1 [P4] Message blocked due to spam content in the message.</li>
+</ul>
+</ul>
+<p><strong><em>What to do with this response</em></strong><em>:</em>Use the human readable portion of the message for further guidance, if you’re not sure what to do, just consider the address “bad” unless the recipient contacts you.</p>
+
+
+{% anchor h2 %}
+Other
+{% endanchor %}
+<p>Sendgrid will also display a code when the recipient server has responded with a literally blank reason code. Rather than leave you to ponder what a blank field might mean, the below message is displayed instead, letting you know that that far end was not able to response intelligently to our request.</p>
+<ul>
+<li>Delayed Bounce - Unable to Parse Server Reason</span></li>
+</ul>
+<p><strong><em>What to do with this response</em></strong><em>: </em>Your best bet is to contact the mail administrator for the intended recipient's mail domain to see if they have any more info on what may have happened.</p>


### PR DESCRIPTION
Updating to include more common reasons and example, as well as guidance. Also included description for new 'Delayed Bounce - Unable to Parse Server Reason' reason for blank NDRs
