### PR TITLE
Update email_error_messages.html

### DIFF
--- a/source/Delivery_Metrics/email_error_messages.html
+++ b/source/Delivery_Metrics/email_error_messages.html
@@ -6,14 +6,6 @@ navigation:
   show: true
 ---
 
----
-layout: page
-weight: 0
-title: Email Error Messages
-navigation:
-  show: true
----
-
 <p>Email is essentially computers talking to each other in simple codes to relay simple text messages. Being able to interpret the codes that these computers kick back when something goes wrong is a skill that doesn't always come naturally, so we've assembled a collection of common responses you're likely to see come back from recipient mail servers, as well as guidance on what to do with them.</p>
 <p><strong>Please note:</strong>This is only a small handful of the response codes that can be sent back. Every receiving mail server out there is unique, so the responses you see may differ from those below. Use the human-readable portion of the response code to get more info if you get stuck, or get in touch with our Support team!</p>
 


### PR DESCRIPTION
Updating to include more common reasons and example, as well as guidance. Also included description for new 'Delayed Bounce - Unable to Parse Server Reason' reason for blank NDRs
