### PR TITLE
Inform about the encoding of the POST request for the inbound parse webh...

### DIFF
--- a/source/API_Reference/Webhooks/parse.html
+++ b/source/API_Reference/Webhooks/parse.html
@@ -32,6 +32,10 @@ Setup
 
 <p>The following parameters will be included in the POST to your callback URL.</p>
 
+{% info %}
+The request that will be sent to the HTTP endpoint will be enconded as multipart/form-data.</p>
+{% endinfo %}
+
 <table class="table table-striped table-bordered">
    <tbody>
      <tr>


### PR DESCRIPTION
Hello,

I was in the API hack day event in Rio de Janeiro this weekend [1] and since sendgrid was one of the sponsors, part of the hack was to use the sendgrid API. My group used the inbound parse API and for some reason, when reading the documentation I concluded that the **whole** POST would be JSON-encoded, after struggling for some time I realized that only some fields were JSON and that the request was `multipart/form-data` encoded.

This pull request just clarifies this, as it can help others to understand better how the POST is made.

Note: I couldn't build the docs locally due to a configuration problem in my environment and since I'm not a ruby expert I could not check to see if the doc will look good.

Hope it helps improve the docs.

[1] http://www.eventbrite.com/event/8247246737/efblike
