### PR TITLE
Update whitelabel_wizard.html

### DIFF
--- a/source/User_Guide/whitelabel_wizard.html
+++ b/source/User_Guide/whitelabel_wizard.html
@@ -143,7 +143,7 @@ DNS Records
 
        <td>TXT</td>
 
-       <td>v=spf1 a mx include:sendgrid.net ~all</td>
+       <td>v=spf1 include:sendgrid.net ~all</td>
      </tr>
 
      <tr>


### PR DESCRIPTION
Changed example on SPF record to remove 'a' and 'mx' tags, since the Whitelabel Wizard itself does not have them on the UI.
