### PR TITLE
start_tls is not a valid postfix configuration parameter

### DIFF
--- a/source/Integrate/Mail_Servers/postfix.html
+++ b/source/Integrate/Mail_Servers/postfix.html
@@ -14,8 +14,7 @@ navigation:
 smtp_sasl_auth_enable = yes 
 smtp_sasl_password_maps = static:yourSendGridUsername:yourSendGridPassword 
 smtp_sasl_security_options = noanonymous 
-smtp_tls_security_level = may
-start_tls = yes
+smtp_tls_security_level = encrypt
 header_size_limit = 4096000
 relayhost = [smtp.sendgrid.net]:587
 {% endcodeblock %}


### PR DESCRIPTION
Having it in there generates "unused parameter" warnings. See: http://serverfault.com/questions/465633/postfix-warning-unused-parameter-start-tls-yes
