### PR TITLE
Fixes some typos in webhook section

### DIFF
--- a/source/API_Reference/Webhooks/debug.html
+++ b/source/API_Reference/Webhooks/debug.html
@@ -60,7 +60,7 @@ ngrok
 {% endanchor %}
 <p><a href="https://ngrok.com/">ngrok</a> is a tool for creating a local tunnel to your machine, it makes testing webhooks locally extremely easy.</p>
 
-<p>Start by <a href="https://ngrok.com/dashboard">signing up</a> so you can use all the features available. In particular, the ability to use custom subdomains. This will remove the need to ammend your webhook settings each time you run ngrok.</p>
+<p>Start by <a href="https://ngrok.com/dashboard">signing up</a> so you can use all the features available. In particular, the ability to use custom subdomains. This will remove the need to amend your webhook settings each time you run ngrok.</p>
 
 {% anchor h3 %}
 Setup
@@ -71,7 +71,7 @@ Setup
 $ ngrok 3000
 {% endcodeblock %}
 
-<p>This would open up a connection to port 3000 on your local machine, at a URL like <code>http://3a4bfceb.ngrok.com</code>. you may then put this URL as your the URL for your Parse Webhook or Event Webhook.</p>
+<p>This would open up a connection to port 3000 on your local machine, at a URL like <code>http://3a4bfceb.ngrok.com</code>. You may then put this URL as your the URL for your Parse Webhook or Event Webhook.</p>
 
 <p>Rather than having to change this every time you restart ngrok, specify the subdomain flag:</p>
 

--- a/source/API_Reference/Webhooks/event.html
+++ b/source/API_Reference/Webhooks/event.html
@@ -6,7 +6,7 @@ navigation:
   show: true
 ---
 {% info %}
-Available to Silver and higher packages or to our free demo accounts. 
+Available to Silver and higher packages or to our free demo accounts.
 {% endinfo %}
 
 <p>SendGrid's Event Webhook will notify a URL of your choice via HTTP POST with information about events that
@@ -16,31 +16,31 @@ identify bounced email addresses or create advanced analytics of your email prog
 Category parameters, you can insert dynamic data that will help build a sharp, clear image of your mailings. </p>
 
 {% info %}
-If you'd like to see how one of our customers uses the Event Webhook, check out 
+If you'd like to see how one of our customers uses the Event Webhook, check out
 <a href="http://blog.sendgrid.com/leveraging-sendgrids-event-api/">Leveraging SendGrid's Event API</a>.
 {% endinfo %}
 
 {% anchor h2 %}
-Setup 
+Setup
 {% endanchor %}
 
 {% warning %}
 If you enabled the Event Webhook prior to September 6, 2013 you will see a dropdown allowing you to select
-Version 1, 2 or 3 of the webhook. Version 3 is the recommended option and the only option available to new users. 
+Version 1, 2 or 3 of the webhook. Version 3 is the recommended option and the only option available to new users.
 You can read about the older versions on the
-<a href="{{root_url}}/API_Reference/Webhooks/event_deprecated.html">Event Webhook (deprecated)</a> page. 
+<a href="{{root_url}}/API_Reference/Webhooks/event_deprecated.html">Event Webhook (deprecated)</a> page.
 {% endwarning %}
 
-<p>To setup the Event Webhook via our web interface, login and go to the <a href="http://sendgrid.com/app">apps page</a>, 
-click on Show Disabled Apps, click the Event Notification app, and click on settings. Check the boxes next to the 
-type of events you want posted to your web server, then enter in the URL you have setup to receive POSTs from our 
+<p>To setup the Event Webhook via our web interface, login and go to the <a href="http://sendgrid.com/app">apps page</a>,
+click on Show Disabled Apps, click the Event Notification app, and click on settings. Check the boxes next to the
+type of events you want posted to your web server, then enter in the URL you have setup to receive POSTs from our
 servers when an event occurs.</p>
 
 <p>The Event Webhook may also be setup by using our <a href="{{root_url}}/API_Reference/Web_API/filter_settings.html#-Event-Notification">Filter Settings Endpoint</a>.</p>
 
 {% info %}
-We support basic HTTP authentication in our Event API. Those who wish to implement can provide credentials 
-in the post event url field on the app settings page. Below is an example of the post url with authentication included. 
+We support basic HTTP authentication in our Event API. Those who wish to implement can provide credentials
+in the post event url field on the app settings page. Below is an example of the post url with authentication included.
 {% endinfo %}
 
 {% codeblock lang:html %}
@@ -52,13 +52,13 @@ If you wish to receive encrypted posts, we require that your callback URL suppor
 {% endwarning %}
 
 {% anchor h2 %}
-Requests 
+Requests
 {% endanchor %}
-<p>You will receive a <strong>HTTP POST</strong> containing a JSON array of multiple events in one request after a 
+<p>You will receive a <strong>HTTP POST</strong> containing a JSON array of multiple events in one request after a
 very short delay. These POSTs will be sent to the URL you have defined in the Event Notification app options. </p>
 
 {% info %}
-Events currently post every 1 second or when the batch size reaches 1MB (one megabyte), whichever occurs first. 
+Events currently post every 1 second or when the batch size reaches 1MB (one megabyte), whichever occurs first.
 This is per server, so the webhook URL may receive tens of posts per second.
 {% endinfo %}
 
@@ -93,10 +93,10 @@ Event POST Example
 <p>You can test your endpoint by clicking the "Test Your Integration" button on the setup screen. SendGrid will send
 a simulated POST of events to your callback url.</p>
 
-<p>SendGrid expects a 200 HTTP response to the POST, otherwise the event notification will be retried. 
+<p>SendGrid expects a 200 HTTP response to the POST, otherwise the event notification will be retried.
 If your URL returns a non-200 HTTP code it will be deferred and retried for 24 hours.
-The maximum number of deferred POSTs in the retry queue is 100,000. 
-If the queue is full, the oldest request in the queue will be removed to make room for the newest deferred POST. 
+The maximum number of deferred POSTs in the retry queue is 100,000.
+If the queue is full, the oldest request in the queue will be removed to make room for the newest deferred POST.
 Events that cannot be submitted within the maximum retry period or events removed from the defer queue will be lost.</p>
 
 {% warning %}
@@ -106,7 +106,7 @@ can easily overload a web server if not configured properly. You can load test y
 {% endwarning %}
 
 {% anchor h2 %}
-Event Types 
+Event Types
 {% endanchor %}
 <p>The following lists the events generated by SendGrid.</p>
 <table class="table table-striped table-bordered">
@@ -170,7 +170,7 @@ Event Types
 </tr>
 <tr>
 <td>Unsubscribe</td>
-<td>Recipient clicked on messages's subscription management link.</td>
+<td>Recipient clicked on message's subscription management link.</td>
 </tr>
 </tbody>
 </table>
@@ -238,12 +238,12 @@ Some events may include additional parameters.</p>
 </table>
 
 {% anchor h2 %}
-Unique Arguments and Categories 
+Unique Arguments and Categories
 {% endanchor %}
-<p>Events generated by SendGrid can also include unique arguments. To define and receive custom parameters in your URL 
-the <a href="{{root_url}}/API_Reference/SMTP_API/index.html">SMTP API</a> must be used when sending emails using 
-the <em>unique_args</em> argument. For example, if you have an application and want to receive custom parameters such 
-as the <code>userid</code> and the email <code>template</code>, you would submit them in the SMTP API header or parameter, as described on the <a href="{{root_url}}/API_Reference/SMTP_API/unique_arguments.html">Unique Arugments documentation page</a>, they would then be returned in the events like so:</p>
+<p>Events generated by SendGrid can also include unique arguments. To define and receive custom parameters in your URL
+the <a href="{{root_url}}/API_Reference/SMTP_API/index.html">SMTP API</a> must be used when sending emails using
+the <em>unique_args</em> argument. For example, if you have an application and want to receive custom parameters such
+as the <code>userid</code> and the email <code>template</code>, you would submit them in the SMTP API header or parameter, as described on the <a href="{{root_url}}/API_Reference/SMTP_API/unique_arguments.html">Unique Arguments documentation page</a>, they would then be returned in the events like so:</p>
 
 {% codeblock lang:json %}[
   {
@@ -255,10 +255,10 @@ as the <code>userid</code> and the email <code>template</code>, you would submit
     "template": "welcome"
   }
 ]
-{% endcodeblock %} 
+{% endcodeblock %}
 
 {% anchor h2 %}
-Categories 
+Categories
 {% endanchor %}
 <p>If <a href="{{root_url}}/Delivery_Metrics/categories.html">categories</a> are used over the SMTP API they will be returned by the Event Webhook as such:</p>
 
@@ -305,7 +305,7 @@ echo "ok";
 {% endcodeblock %}
 
 {% anchor h2 %}
-Parameter Details 
+Parameter Details
 {% endanchor %}
 <p>The following shows each type of event that can be posted along with the specific parameters that go along with the
 event.
@@ -317,7 +317,7 @@ is posted as a separate post parameter, similar to the category listed below, bu
 {% endinfo %}
 
 {% anchor h2 %}
-Processed 
+Processed
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -336,7 +336,7 @@ Processed
 </tbody>
 </table>
 {% anchor h2 %}
-Deferred 
+Deferred
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -352,14 +352,14 @@ Deferred
 <tr>
 <td>deferred</td>
 <td>Message recipient</td>
-<td>Full reponse from MTA</td>
+<td>Full response from MTA</td>
 <td>Delivery attempt #</td>
 <td>The category you assigned</td>
 </tr>
 </tbody>
 </table>
 {% anchor h2 %}
-Delivered 
+Delivered
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -374,13 +374,13 @@ Delivered
 <tr>
 <td>delivered</td>
 <td>Message recipient</td>
-<td>Full reponse from MTA</td>
+<td>Full response from MTA</td>
 <td>The category you assigned</td>
 </tr>
 </tbody>
 </table>
 {% anchor h2 %}
-Open 
+Open
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -399,7 +399,7 @@ Open
 </tbody>
 </table>
 {% anchor h2 %}
-Click 
+Click
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -420,7 +420,7 @@ Click
 </tbody>
 </table>
 {% anchor h2 %}
-Bounce 
+Bounce
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -445,7 +445,7 @@ Bounce
 </tbody>
 </table>
 {% anchor h2 %}
-Drop 
+Drop
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -466,7 +466,7 @@ Drop
 </tbody>
 </table>
 {% anchor h2 %}
-Spam Report 
+Spam Report
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -485,7 +485,7 @@ Spam Report
 </tbody>
 </table>
 {% anchor h2 %}
-Unsubscribe 
+Unsubscribe
 {% endanchor %}
 <table class="table table-striped table-bordered">
 <thead>
@@ -529,11 +529,11 @@ Marketing Email Unsubscribes
 {% endcodeblock %}
 
 {% anchor h2 %}
-Troubleshooting 
+Troubleshooting
 {% endanchor %}
 <p>Ensure that your web server is returning a 200 response to our servers. Any other response type will result in our
 server retrying a POST until we receive a 200 response or the maximum time has expired. All events are retried at
-increasing intervals for up to 24 hours after the event occurs. Make sure you are not blocking our IPs that are trying 
+increasing intervals for up to 24 hours after the event occurs. Make sure you are not blocking our IPs that are trying
 to POST to your server. Our IPs change often since we constantly add more machines.</p>
 
 <p>You can use the "Test Your Integration" button on the Event Notifications settings page to send simulated events to

--- a/source/API_Reference/Webhooks/parse.html
+++ b/source/API_Reference/Webhooks/parse.html
@@ -7,7 +7,7 @@ navigation:
 ---
 
 {% info %}
-Available to Silver and higher packages or to our free demo accounts. 
+Available to Silver and higher packages or to our free demo accounts.
 {% endinfo %}
 
 
@@ -22,7 +22,7 @@ If you don't want email messages to be retried in case of an error in delivery, 
 <p>In order to avoid returning an error your link is required to return a 200 HTTP code when the email is received. This lets our system know that your link has received the email response.  It is then removed from our send queue. If we do <strong>not</strong> get a valid 200 HTTP response, our servers will believe they have failed to deliver your message and will continue trying to send it. Messages that cannot be delivered after 3 days will be dropped.</p>
 
 {% anchor h2 %}
-Setup 
+Setup
 {% endanchor %}
 <p>The following steps are required to begin parsing email:</p>
 
@@ -146,7 +146,7 @@ The total message size limit, including the message itself and any number of att
 {% endinfo %}
 
 {% anchor h2 %}
-Character Sets and Header Decoding 
+Character Sets and Header Decoding
 {% endanchor %}
 <p>If you will be receiving email which is not in ASCII only format, you will want to read this section.</p>
 


### PR DESCRIPTION
This PR fixes the following typos:
### @debug.html:
- ammend --> amend
- . you --> . You
### @event.html
- messages's --> message's
- arugments --> arguments
- reponse --> response.

It also removes some white spaces that are not being used at the end of some lines of code. This doesn't affect the html result as `newline` turns into `white space` when inside a paragraph.

``` html
<p>firstline
second
third</p>
```

generates

```
firstline second third
```
