### PR TITLE
Update bounces.html

### DIFF
--- a/source/API_Reference/Web_API/bounces.html
+++ b/source/API_Reference/Web_API/bounces.html
@@ -6,6 +6,7 @@ navigation:
   show: true
 ---
 
+
 <p>This endpoint allows you to retrieve and delete entries in the Bounces list.</p>
 
 
@@ -213,6 +214,14 @@ delete
 <td>Must be a valid user account email</td>
 <td>Email bounce address to remove</td>
 </tr>
+<tr> 
+      <td>delete_all</td> 
+      <td>No</td> 
+      <td>value=1</td> 
+      <td>This will delete the bounce list and will not be retrievable</td> 
+    </tr>
+
+
 <tr></tr>
 </tbody>
 </table>


### PR DESCRIPTION
the existing caution is no longer an issue. We now return the response below

{"error": "error in email: no valid parameters provided. Use delete_all=1 to remove everything"}
