### PR TITLE
Updated the Larvel docs

### DIFF
--- a/source/Integrate/Frameworks/laravel.html
+++ b/source/Integrate/Frameworks/laravel.html
@@ -6,7 +6,7 @@ navigation:
   show: true
 ---
 
-<p>Laravel comes with an email sending library built in. See more information on how to <a href="http://four.laravel.com/docs/mail">use Laravel with SendGrid</a>.
+<p>Laravel comes with an email sending library built in, so we just need to set it to use SendGrid's STMP API. Check out the docs for <a href="http://laravel.com/docs/mail">Laravel's mailer</a> for details.
 </p>
 
 In <code>app/config/mail.php</code> you need to configure these settings:


### PR DESCRIPTION
At some point, I'd like to build a Laravel addon that utilizes SendGrid's HTTP API, but I'll need to look into how modular Larvel's email code is.

Until then, I updated the docs with a fixed link to Laravel's documentation and reworded it a bit.
