### PR TITLE
Added missing 'allows'.

### DIFF
--- a/source/API_Reference/SMTP_API/unique_arguments.html
+++ b/source/API_Reference/SMTP_API/unique_arguments.html
@@ -6,7 +6,7 @@ navigation:
   show: true
 ---
 
-<p>The SMTP API JSON string you to attach an unlimited number of unique arguments to your email. The arguments are used only for tracking. They can be retrieved through the <a href="{{root_url}}/API_Reference/Webhooks/event.html">Event API</a> or the <a href="{{root_url}}/Delivery_Metrics/email_activity.html">Email Activity</a> page.</p> 
+<p>The SMTP API JSON string allows you to attach an unlimited number of unique arguments to your email. The arguments are used only for tracking. They can be retrieved through the <a href="{{root_url}}/API_Reference/Webhooks/event.html">Event API</a> or the <a href="{{root_url}}/Delivery_Metrics/email_activity.html">Email Activity</a> page.</p> 
 
 <p>These arguments can be added using a JSON string like this:</p>
 


### PR DESCRIPTION
The first sentence was missing "allows". Vim also fixed the "no newline at end of file".
