### PR TITLE
MEME-2032 Updated Template Engine API with current template and version response format

### DIFF
--- a/source/API_Reference/Template_Engine_API/templates.md
+++ b/source/API_Reference/Template_Engine_API/templates.md
@@ -20,11 +20,12 @@ Retrieve all templates.
     "templates": [
         {
             "id": "e8ac01d5-a07a-4a71-b14c-4721136fe6aa",
-            "default_version_id": "",
             "name": "example template name",
             "versions": [
                 {
                     "id": "5997fcf6-2b9f-484d-acd5-7e9a99f0dc1f",
+                    "template_id": "9c59c1fb-931a-40fc-a658-50f871f3e41c",
+                    "active": 1,
                     "name": "example version name",
                     "updated_at": "2014-03-19 18:56:33"
                 }
@@ -46,15 +47,20 @@ Retrieve a single template.
     "templates": [
         {
             "id": "e8ac01d5-a07a-4a71-b14c-4721136fe6aa",
-            "default_version_id": "",
             "name": "example template name",
             "versions": [
-                {
-                    "id": "5997fcf6-2b9f-484d-acd5-7e9a99f0dc1f",
-                    "name": "example version name",
-                    "updated_at": "2014-03-19 18:56:33"
-                }
-            ]
+            {
+                "id": "de37d11b-082a-42c0-9884-c0c143015a47",
+                "user_id": 1234,
+                "template_id": "d51480ba-ca3f-465c-bc3e-ceb71d73c38d",
+                "active": 1,
+                "name": "example version",
+                "html_content": "<%body%><strong>Click to Reset</strong>",
+                "plain_content": "Click to Reset<%body%>",
+                "subject": "<%subject%>",
+                "updated_at": "2014-05-22 20:05:21"
+             }
+          ]
         }
     ]
 }
@@ -77,7 +83,6 @@ HTTP/1.1 201 OK
 
 {
     "id": "733ba07f-ead1-41fc-933a-3976baa23716",
-    "default_version_id": "",
     "name": "example_name",
     "versions": []
 }
@@ -91,16 +96,14 @@ Edit a template.
 
 {% parameters patch %}
   {% parameter name true 'String with fewer than 100 characters' 'The name of the new template' %}
-  {% parameter default_version_id false 'An existing version id' 'The version of the template to set as active and use' %}
 {% endparameters %}
 
-{% apiv3example patch PATCH https://api.sendgrid.com/v3/templates/:template_id name=new_example_name&default_version_id=5997fcf6-2b9f-484d-acd5-7e9a99f0dc1f %}
+{% apiv3example patch PATCH https://api.sendgrid.com/v3/templates/:template_id name=new_example_name %}
   {% v3response %}
-HTTP/1.1 201 OK
+HTTP/1.1 200 OK
 
 {
     "id": "733ba07f-ead1-41fc-933a-3976baa23716",
-    "default_version_id": "",
     "name": "new_example_name",
     "versions": []
 }

--- a/source/API_Reference/Template_Engine_API/versions.md
+++ b/source/API_Reference/Template_Engine_API/versions.md
@@ -14,8 +14,8 @@ GET]({{root_url}}/API_Reference/Template_Engine_API/templates.html#-GET)
 method. Versions are returned as nested resources of the template
 resource.
 
-To set which version is active, use the [template PATCH]({{root_url}}/API_Reference/Template_Engine_API/templates.html#-PATCH) method to set the
-default_version_id of a template.
+To set which version is active, use the [version PATCH]({{root_url}}/API_Reference/Template_Engine_API/versions.html#-PATCH) method to set the
+active field to 1.
 
 {% anchor h2 %}
 GET
@@ -28,6 +28,8 @@ HTTP/1.1 200 OK
 
 {
     "id": "5997fcf6-2b9f-484d-acd5-7e9a99f0dc1f",
+    "template_id": "d51480ca-ca3f-465c-bc3e-ceb71d73c38d"
+    "active": 1
     "name": "version 1 name",
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
@@ -47,19 +49,22 @@ Create a new version.
   {% parameter subject true 'Requires a <%subject%> tag to be present' 'The subject for the new version' %}
   {% parameter html_content true 'Requires a <%body%> tag inside the content. There is a maximum of 1048576 bytes allowed for html content.' 'The HTML content of the new version.' %}
   {% parameter plain_content true 'Requires a <%body%> tag inside the content. There is a maximum of 1048576 bytes allowed for plain content.' 'The text/plain content of the new version.' %}
-
+  {% parameter active false '0=Inactive, 1=Active' 'Sets the active version associated with a template. Only one version of template can be active. The first version created for a template will automatically be set to Active.' %}
 {% endparameters %}
 
-{% apiv3example post POST https://api.sendgrid.com/v3/templates/:template_id/versions name=example_version_name&html_content=%3C%25body%25%3E&plain_content=%3C%25body%25%3E&subject=%3C%25subject%25%3E %}
+{% apiv3example post POST https://api.sendgrid.com/v3/templates/:template_id/versions name=example_version_name&html_content=%3C%25body%25%3E&plain_content=%3C%25body%25%3E&subject=%3C%25subject%25%3E&active=1%}
   {% v3response %}
 HTTP/1.1 201 OK
 
 {
     "id": "8aefe0ee-f12b-4575-b5b7-c97e21cb36f3",
+    "template_id": "ddb96bbc-9b92-425e-8979-99464621b543",
+    "active": 1,
     "name": "example_version_name",
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
-    "subject": "<%subject%>"
+    "subject": "<%subject%>",
+    "updated_at": "2014-03-19 18:56:33"
 }
   {% endv3response %}
 {% endapiv3example %}
@@ -74,6 +79,7 @@ Edit a version.
   {% parameter subject false 'Requires a <%subject%> tag to be present' 'The updated subject for the new version' %}
   {% parameter html_content false 'Requires a <%body%> tag inside the content. There is a maximum of 1048576 bytes allowed for html content.' 'The HTML content of the new version.' %}
   {% parameter plain_content false 'Requires a <%body%> tag inside the content. There is a maximum of 1048576 bytes allowed for plain content.' 'The text/plain content of the new version.' %}
+  {% parameter active false '0=Inactive, 1=Active' 'Sets the active version associated with a template. Only one version of template can be active.' %}
 {% endparameters %}
 
 {% apiv3example patch PATCH https://api.sendgrid.com/v3/templates/:template_id/versions/:version_id name=updated_example_name%}
@@ -82,10 +88,13 @@ HTTP/1.1 200 OK
 
 {
     "id": "8aefe0ee-f12b-4575-b5b7-c97e21cb36f3",
+    "template_id": "ddb96bbc-9b92-425e-8979-99464621b543",
+    "active": 1,
     "name": "updated_example_name",
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
-    "subject": "<%subject%>"
+    "subject": "<%subject%>",
+    "updated_at": "2014-03-19 18:56:33"
 }
 {% endv3response %}
 {% endapiv3example %}


### PR DESCRIPTION
This is for Jira issue MEME-2032, removing the default_version_id field from template operations. I did some additional cleanup to ensure that the documentation reflects the current API.

https://jira.sendgrid.net/browse/MEME-2032

Note that these changes reflect the current API in production and do not reflect the Template Engine changes documented separately in https://github.com/sendgrid/docs/pull/431 (that change is not yet live). 
