### PR TITLE
Fixing another obsolete default_version_id reference

### DIFF
--- a/source/API_Reference/Template_Engine_API/smtpapi.md
+++ b/source/API_Reference/Template_Engine_API/smtpapi.md
@@ -31,8 +31,8 @@ the x-smtpapi parameter of a [mail.send API
 call]({{root_url}}/API_Reference/Web_API/mail.html).
 
 {% info %}
-Make sure that the version of the template you want to use is to active
-by specifying it as the default_version_id or by activating it in the
+Make sure that the version of the template you want to use is set to active
+by using the activate endpoint or by activating it in the
 UI.
 {% endinfo %}
 


### PR DESCRIPTION
Removed another reference to the obsolete default_version_id field in the Template Engine API. The update refers to the new functionality added by https://github.com/sendgrid/teslago/pull/106, so this PR should go in after the Teslago functionality is in production; it can be merged along with https://github.com/sendgrid/docs/pull/428
