### PR TITLE
Add sendgrid-ruby to library list

### DIFF
--- a/source/Integrate/libraries.html
+++ b/source/Integrate/libraries.html
@@ -154,6 +154,7 @@ Ruby
 	<li><a href="http://github.com/PavelTyk/sendgrid-rails">sendgrid-rails</a> <em>by Pavel Tsiukhtsiayeu</em> - Extends ActionMailer with SendGrid methods</li>
 	<li><a href="http://github.com/okrb/gatling_gun">gatling_gun</a> <em>by James Edward Gray II</em> - Simple wrapper over SendGrid's Marketing Email API.</li>
 	<li><a href="http://github.com/markedmondson/sendgrid_api">sendgrid_api</a> <em>by Mark Edmondson</em> - Implements an ActionMailer that delivers through the SendGrid Web API.</li>
+	<li><a href="https://github.com/SendGridJP/sendgrid-ruby">sendgrid-ruby</a> <em>by SendGridJP</em> - SendGrid rubygem for SendGrid Web API that aims the same functionality with official library.</li>
 </ul>
 {% anchor h3 %}
 Titanium


### PR DESCRIPTION
Add SendGrid rubygem for SendGrid Web API that aims the same functionality with official library.
