### PR TITLE
add EventKit to event webhook docs

### DIFF
--- a/source/API_Reference/Webhooks/event.html
+++ b/source/API_Reference/Webhooks/event.html
@@ -21,6 +21,11 @@ If you'd like to see how one of our customers uses the Event Webhook, check out
 {% endinfo %}
 
 {% info %}
+Get the Event Webhook up and running easily with our awesome open source app, EventKit
+<a href="http://sendgrid.github.io/eventkit/setup.html/">Chick here to get setup</a>.
+{% endinfo %}
+
+{% info %}
 There are a number of pre-made integrations for the SendGrid Event Webhook, to make processing events easy, find them in the <a href="{{root_url}}/Integrate/libraries.html#-Webhook-Libraries">Library Index</a>.
 {% endinfo %}
 


### PR DESCRIPTION
_Creating the PR as a place for discussion about adding EventHook to the Event Webhook Docs._

This reverts commit 3b933001d0c51f4aedf4e936aff03feea65e6095, thus, adding EventKit to the event webhook docs.
