### PR TITLE
Wrong delete call to unassign lists

### DIFF
--- a/source/API_Reference/Marketing_Emails_API/recipients.html
+++ b/source/API_Reference/Marketing_Emails_API/recipients.html
@@ -142,9 +142,8 @@ get
 <hr/>
 
 
-
 {% anchor h2 %}
-delete 
+recipients/delete 
 {% endanchor %}
 <p>Remove assigned lists from marketing email</p>
 
@@ -175,7 +174,7 @@ delete
 </table>
 
   
-{% apiexample delete POST https://api.sendgrid.com/api/newsletter/delete name=SendGrid%20NL%20Test1&list=test&api_user=your_sendgrid_username&api_key=your_sendgrid_password %}
+{% apiexample delete POST https://api.sendgrid.com/api/newsletter/recipients/delete name=SendGrid%20NL%20Test1&list=test&api_user=your_sendgrid_username&api_key=your_sendgrid_password %}
   {% response json %}
 //success
 {


### PR DESCRIPTION
https://api.sendgrid.com/api/newsletter/delete.json

should be

https://api.sendgrid.com/api/newsletter/recipients/delete.json

?
