### PR TITLE
Teslago uses unix timestamps for all date fields

### DIFF
--- a/source/API_Reference/Template_Engine_API/templates.md
+++ b/source/API_Reference/Template_Engine_API/templates.md
@@ -27,7 +27,7 @@ Retrieve all templates.
                     "template_id": "9c59c1fb-931a-40fc-a658-50f871f3e41c",
                     "active": 1,
                     "name": "example version name",
-                    "updated_at": "2014-03-19 18:56:33"
+                    "updated_at": 1404309421
                 }
             ]
         }
@@ -58,7 +58,7 @@ Retrieve a single template.
                 "html_content": "<%body%><strong>Click to Reset</strong>",
                 "plain_content": "Click to Reset<%body%>",
                 "subject": "<%subject%>",
-                "updated_at": "2014-05-22 20:05:21"
+                "updated_at": 1399039021
              }
           ]
         }

--- a/source/API_Reference/Template_Engine_API/versions.md
+++ b/source/API_Reference/Template_Engine_API/versions.md
@@ -34,7 +34,7 @@ HTTP/1.1 200 OK
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
     "subject": "<%subject%>",
-    "updated_at": "2014-03-19 18:56:33"
+    "updated_at": 1393768621
 }
 {% endv3response %}
 {% endapiv3example %}
@@ -64,7 +64,7 @@ HTTP/1.1 201 OK
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
     "subject": "<%subject%>",
-    "updated_at": "2014-03-19 18:56:33"
+    "updated_at": 1393768621
 }
   {% endv3response %}
 {% endapiv3example %}
@@ -86,7 +86,7 @@ HTTP/1.1 200 OK
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
     "subject": "<%subject%>",
-    "updated_at": "2014-06-12 11:33:00"
+    "updated_at": 1396447021
 }
   {% endv3response %}
 {% endapiv3example %}
@@ -116,7 +116,7 @@ HTTP/1.1 200 OK
     "html_content": "<%body%>",
     "plain_content": "<%body%>",
     "subject": "<%subject%>",
-    "updated_at": "2014-03-19 18:56:33"
+    "updated_at": 1396447021
 }
 {% endv3response %}
 {% endapiv3example %}


### PR DESCRIPTION
Should be deployed along with the APId, Tesla and NLVX changes: 
- [ ] APId PR: https://github.com/sendgrid/apid/pull/445
- [ ] TeslaGo PR: https://github.com/sendgrid/teslago/pull/115
- [ ] NLVX PR: https://github.com/sendgrid/nlvx/pull/877
