### PR TITLE
SMTPAPI Filters use "enable"

### DIFF
--- a/source/API_Reference/SMTP_API/apps.html
+++ b/source/API_Reference/SMTP_API/apps.html
@@ -36,7 +36,7 @@ Filter: <code>bcc</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -53,7 +53,7 @@ Filter: <code>bcc</code>
   "filters" : {
     "bcc" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "email" : "you@example.com"
       }
     }
@@ -77,7 +77,7 @@ Filter: <code>bypass_list_management</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -89,7 +89,7 @@ Filter: <code>bypass_list_management</code>
   "filters" : {
     "bypass_list_management" : {
       "settings" : {
-        "enabled" : 1
+        "enable" : 1
       }
     }
   }
@@ -112,7 +112,7 @@ Filter: <code>clicktrack</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -125,7 +125,7 @@ Filter: <code>clicktrack</code>
   "filters" : {
     "clicktrack" : {
       "settings" : {
-        "enabled" : 1
+        "enable" : 1
       }
     }
   }
@@ -195,7 +195,7 @@ e-mail. For more info, check out these <a href="{{root_url}}/Apps/domain_keys.ht
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -218,7 +218,7 @@ e-mail. For more info, check out these <a href="{{root_url}}/Apps/domain_keys.ht
   "filters" : {
     "domainkeys" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "domain" : "example.com",
         "sender" : 1
       }
@@ -243,7 +243,7 @@ Filter: <code>footer</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -266,7 +266,7 @@ Filter: <code>footer</code>
   "filters" : {
     "footer" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "text/html" : "<p>Thanks,<br />The SendGrid Team<p>",
         "text/plain" : "Thanks,\n The SendGrid Team"
       }
@@ -290,7 +290,7 @@ Filter: <code>forwardspam</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -307,7 +307,7 @@ Filter: <code>forwardspam</code>
   "filters" : {
     "forwardspam" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "email" : "you@example.com"
       }
     }
@@ -332,7 +332,7 @@ Filter: <code>ganalytics</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -370,7 +370,7 @@ Filter: <code>ganalytics</code>
   "filters" : {
     "ganalytics" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "utm_source" : "Transactional Email",
         "utm_medium" : "email",
         "utm_content" : "Reset Your Password",
@@ -396,7 +396,7 @@ Filter: <code>gravatar</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -409,7 +409,7 @@ Filter: <code>gravatar</code>
   "filters" : {
     "gravatar" : {
       "settings" : {
-      "enabled" : 1
+      "enable" : 1
       }
     }
   }
@@ -432,7 +432,7 @@ Filter: <code>opentrack</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -445,7 +445,7 @@ Filter: <code>opentrack</code>
   "filters" : {
     "opentrack" : {
       "settings" : {
-        "enabled" : 1
+        "enable" : 1
       }
     }
   }
@@ -468,7 +468,7 @@ Filter: <code>spamcheck</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -491,7 +491,7 @@ Filter: <code>spamcheck</code>
   "filters" : {
     "spamcheck" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "maxscore" : 3.5,
         "url" : "http://example.com/compliance"
       }
@@ -517,7 +517,7 @@ Filter: <code>subscriptiontrack</code>
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -547,7 +547,7 @@ Filter: <code>subscriptiontrack</code>
             "settings": {
                 "text/html": "If you would like to unsubscribe and stop receiving these emails <% click here %>.",
                 "text/plain": "If you would like to unsubscribe and stop receiving these emails click here: <% %>.",
-                "enabled": 1
+                "enable": 1
             }
         }
     }
@@ -575,7 +575,7 @@ This app is our new <a href="{{root_url}}/API_Reference/Template_Engine_API/inde
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -593,7 +593,7 @@ This app is our new <a href="{{root_url}}/API_Reference/Template_Engine_API/inde
   "filters": {
     "templates": {
       "settings": {
-        "enabled": 1,
+        "enable": 1,
         "template_id": "5997fcf6-2b9f-484d-acd5-7e9a99f0dc1f"
       }
     }
@@ -622,7 +622,7 @@ This app is our original Email Template app, today we have a more full featured 
 <th>Parameter Description</th>
 </tr>
 <tr>
-<td>enabled</td>
+<td>enable</td>
 <td><code>0</code> | <code>1</code></td>
 <td>Disable or enable this App</td>
 </tr>
@@ -640,7 +640,7 @@ This app is our original Email Template app, today we have a more full featured 
   "filters" : {
     "template" : {
       "settings" : {
-        "enabled" : 1,
+        "enable" : 1,
         "text/html" : "<html><head></head><body bgcolor='pink'><div style='width:200px' bgcolor='#FFF'><% body %></div></body></html>"
       }
     }


### PR DESCRIPTION
Toggling filters on and off is done with the `enable` key, not `enabled`.

If an `enable` key isn't present, the SMTPAPI assumes you're trying to enable it, and turns it on. This is why `enabled` will work when trying to turn on an app that is normally off, but will not work when trying to turn off an app that is normally on.
