### PR TITLE
Change "enabled" to "enable"

### DIFF
--- a/source/API_Reference/SMTP_API/index.html
+++ b/source/API_Reference/SMTP_API/index.html
@@ -94,7 +94,7 @@ The X-SMTPAPI Header
     "footer": {
       "settings":
         {
-          "enabled": 1,
+          "enable": 1,
           "text/plain": "Thank you for your business"
         }
     }
@@ -133,7 +133,7 @@ All of the above examples can then be combined into one larger JSON string place
   "filters": {
     "footer": {
       "settings": {
-        "enabled": 1,
+        "enable": 1,
         "text/plain": "Thank you for your business"
       }
     }


### PR DESCRIPTION
Found another instance where `enabled` was specified when it should actually be `enable`.
