### PR TITLE
[CR] RES-1294: Deprecates Retrieve Usage calls in Reseller API

### DIFF
--- a/source/API_Reference/Reseller_API/billing_retrieving_as_you_go_usage.md
+++ b/source/API_Reference/Reseller_API/billing_retrieving_as_you_go_usage.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 weight: 0
-title: Retrieving As-You-Go Usage
+title: Retrieving As-You-Go Usage (deprecated)
 navigation:
    show: true
 ---
@@ -14,7 +14,7 @@ Retrieve invoices/usages from end users before your scheduled billing date.
 {% endparameters %}
 
 
-{% apiexample get POST https://api.sendgrid.com/apiv2/reseller.billing api_user=your_sendgrid_username&api_key=your_sendgrid_password&number=2010010001&task=curren %}
+{% apiexample get POST https://api.sendgrid.com/apiv2/reseller.billing api_user=your_sendgrid_username&api_key=your_sendgrid_password&number=2010010001&task=current %}
   {% response json %}
 {
   "number": "201001000100",

--- a/source/API_Reference/Reseller_API/billing_retrieving_end_users_invoices_usage.md
+++ b/source/API_Reference/Reseller_API/billing_retrieving_end_users_invoices_usage.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 weight: 0
-title: Retrieving Invoice Usage
+title: Retrieving Invoice Usage (deprecated)
 navigation:
    show: true
 ---
@@ -15,7 +15,7 @@ Retrieve invoices/usages from customers.
 {% endparameters %}
 
 
-{% apiexample get POST https://api.sendgrid.com/apiv2/reseller.billing api_user=your_sendgrid_username&api_key=your_sendgrid_password&number=2010010001&task=usag %}
+{% apiexample get POST https://api.sendgrid.com/apiv2/reseller.billing api_user=your_sendgrid_username&api_key=your_sendgrid_password&number=2010010001&task=usage %}
   {% response json %}
 {
   "number": "2010010001",


### PR DESCRIPTION
# Summary

Marked two api calls from Reseller API as deprecated because they do not work anymore.
- Retrieving As-You-Go Usage
- Retrieving Invoice Usage
## PR - Merge Checklist:
- [ ] CR’d 
- [x] README updated or N/A
- [ ] Repo/unit tests pass
- [x] Dependencies satisfied 
- [ ] Acceptance criteria verified by QE
- [ ] End to end testing completed by QE
## Dependencies:
