### PR TITLE
Add new ruby library(sendgrid4r)

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -148,7 +148,7 @@ Ruby
 -   [gatling_gun](http://github.com/okrb/gatling_gun) *by James Edward Gray II* - Simple wrapper over SendGrid's Marketing Email API.
 -   [sendgrid_api](http://github.com/markedmondson/sendgrid_api) *by Mark Edmondson* - Implements an ActionMailer that delivers through the SendGrid Web API.
 -   [sendgrid-ruby](https://github.com/SendGridJP/sendgrid-ruby) *by SendGridJP* - SendGrid rubygem for SendGrid Web API that aims the same functionality with official library.
--   [sendgrid_template_engine_ruby](https://github.com/awwa/sendgrid_template_engine_ruby) *by Wataru Sato* - Ruby wrapper for the SendGrid Template Engine API.
+-   [sendgrid4r](https://github.com/awwa/sendgrid4r) *by Wataru Sato* - Ruby wrapper for the SendGrid Web API v3.
 
 {% anchor h3 %}
 Titanium 


### PR DESCRIPTION
The sendgrid_template_engine library has been deprecated.
Please use [sendgrid4r](https://github.com/awwa/sendgrid4r) instead.
