### PR TITLE
Cleanup SMTP API Overview

### DIFF
--- a/source/API_Reference/SMTP_API/index.html
+++ b/source/API_Reference/SMTP_API/index.html
@@ -29,7 +29,7 @@ The X-SMTPAPI Header
 <p>The X-SMTPAPI header is a JSON-encoded associative array consisting of several sections, below are examples of JSON strings using each section. This header can be added to any SMTP message sent to SendGrid and the instructions in the header will be interpreted and applied to that message's transaction.</p>
 
 <p>
-	<b>To:</b> An array of addresses to send the message to, optionally including the display name. <em>See [limitations](#-Requirements-and-Limitations) below.</em>
+	<b>To:</b> An array of addresses to send the message to, optionally including the display name. <em>See <a href="#-Requirements-and-Limitations">limitations</a> below.</em>
 </p>
 {% codeblock lang:json %}{
   "to": [
@@ -195,5 +195,5 @@ While there is a hard limit of 10,000 addresses that can be sent to in a multipl
 
 <p>Ensure that the header is limited to a maximum total line length of 1,000 characters. Failure to do this can cause intermediate MTA's to split the header for you on non-space boundaries, which will cause spaces to be inserted in the final resulting e-mail. In addition, if your e-mail is going through another MTA before reaching SendGrid, it is likely to have an even lower setting for maximum header length and may truncate the header.</p>
 
-<p>When using the API, if our system encounters a parsing error, the message will be bounced to the address specified in the MAIL FROM portion of the SMTP session. The MAIL FROM address is re-written when we send e-mail out for final delivery, so it is safe to set this to an address that can receive the bounces so that you will be alerted on errors. More info: [Bounce Forwarding](https://support.sendgrid.com/hc/en-us/articles/200181478-How-to-set-up-bounce-forwarding-to-go-to-the-email-s-FROM-address) </p>
+<p>When using the API, if our system encounters a parsing error, the message will be bounced to the address specified in the MAIL FROM portion of the SMTP session. The MAIL FROM address is re-written when we send e-mail out for final delivery, so it is safe to set this to an address that can receive the bounces so that you will be alerted on errors. More info: <a href="https://support.sendgrid.com/hc/en-us/articles/200181478-How-to-set-up-bounce-forwarding-to-go-to-the-email-s-FROM-address"></a>Bounce Forwarding</a> </p>
 


### PR DESCRIPTION
- Added code block specific header
- Make ""to:"" and other header names bold
- Add a link to limitations on the ""to"" section or reference the 10,000 email limit
- Remove this statement "When setting filters via SMTPAPI, all filter names and setting names must be lowercase."  -- it will be moved to Filters page
- MAIL FROM - give an example or link to a place that explains this more fully
- Remove "For substitution tags, it is best to avoid characters that have special meaning in html, such as <,>, and &. These might end up encoded and will not be properly substituted." --will be moved to the substitutions section
