### PR TITLE
Moved comment about html tags

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.html
+++ b/source/API_Reference/SMTP_API/substitution_tags.html
@@ -24,7 +24,7 @@ Substitution tags will work in the Subject line as well as the body of the email
 {% endinfo %}
 
 {% info %}
-How you format your substitution tags may depend on the library you use to create your SMTP connection, the language you are writing your code in, or any intermediate mail servers that your servers will send mail through. In some cases -subVal- may be the best choice while in other %subVal% or #subVal# may make more sense.
+How you format your substitution tags may depend on the library you use to create your SMTP connection, the language you are writing your code in, or any intermediate mail servers that your servers will send mail through. In some cases -subVal- may be the best choice while in other %subVal% or #subVal# may make more sense. It is best to avoid characters that have special meaning in html, such as <,>, and &. These might end up encoded and will not be properly substituted.
 {% endinfo %}
 
 {% warning %}


### PR DESCRIPTION
This comment about HTML tags was found on the SMTP API Overview and not in context on the page where it makes the most sense to have this message.
