### PR TITLE
In depth explanation of nesting

### DIFF
--- a/source/API_Reference/SMTP_API/section_tags.md
+++ b/source/API_Reference/SMTP_API/section_tags.md
@@ -6,7 +6,7 @@ navigation:
   show: true
 ---
 
-Section tags are an extension of [substitution tags]({{root_url}}/API_Reference/SMTP_API/substitution_tags.html) that allow a user to specify text blocks that will be customized on a per user basis. This is useful for sending dynamic content where large portions of the body will be similar across several users, as opposed to duplicating that text each time.
+Section tags are an extension of [substitution tags]({{root_url}}/API_Reference/SMTP_API/substitution_tags.html), meaning that a section tag is added to your email content within the value parameter of a substitution tag. Section tags allow a user to specify text blocks that will be customized on a per user basis. This is useful for sending dynamic content where large portions of the body will be similar across several users, as opposed to duplicating that text each time.
 
 The format of the SMTP API section tag has the form:
 
@@ -19,9 +19,11 @@ The format of the SMTP API section tag has the form:
 }
 {% endcodeblock %}
 
-Typical usage is to have a tag in the body of your email that references a per user substitution tag. This user tag will contain a reference to a section tag. Section text may contain references to per recipient substitution variables.
+Typical usage is to have a substitution tag in the body of your email that contains a reference to a section tag in it's value parameter.  Section tag values may also contain references to per recipient substitution variables. See [Section Tag Example Explained](#-Section-Tag-Example-Explained) below.
 
-### Section Tag Example
+{% anchor h2 %}
+Section Tag Example
+{% endanchor %}
 
 Message body: 
 
@@ -65,7 +67,7 @@ An accompanying X-SMTPAPI JSON header body might look something like this:
 }
 {% endcodeblock %}
 
- The final email for Jane would look like this: 
+The final email for Jane would look like this: 
 
 {% codeblock lang:html %}
 <html>
@@ -78,7 +80,7 @@ An accompanying X-SMTPAPI JSON header body might look something like this:
 </html>
 {% endcodeblock %}
 
- The final email for John would look like this: 
+The final email for John would look like this: 
 
 {% codeblock lang:html %}
 <html>
@@ -90,4 +92,65 @@ An accompanying X-SMTPAPI JSON header body might look something like this:
  </body>
 </html>
 {% endcodeblock %}
+
+{% anchor h3 %}
+Section Tag Example Explained
+{% endanchor %}
+
+Our example uses nested substitution and section tags in order to demonstrate the possible complexity that can be used to create extremely customizable emails for your users.
+
+For John the substitution process looks like this: 
+
+<table class="table table-striped table-bordered">
+<tbody>
+<tr>
+<th>Tag</th>
+<th>Tag Type</th>
+<th>Replaced By</th>
+</tr>
+<tr>
+<td>-intro-</td>
+<td>Substitution Tag</td>
+<td>-greetGuy-</td>
+</tr>
+<tr>
+<td>-greetGuy-</td>
+<td>Section Tag</td>
+<td>Mr. -name-</td>
+</tr>
+<tr>
+<td>-name-</td>
+<td>Substitution Tag</td>
+<td>John</td>
+</tr>
+</tbody>
+</table>
+
+For Jane the substitution process looks like this:
+
+<table class="table table-striped table-bordered">
+<tbody>
+<tr>
+<th>Tag</th>
+<th>Tag Type</th>
+<th>Replaced By</th>
+</tr>
+<tr>
+<td>-intro-</td>
+<td>Substitution Tag</td>
+<td>-greetGirl-</td>
+</tr>
+<tr>
+<td>-greetGirl-</td>
+<td>Section Tag</td>
+<td>Ms. -name-</td>
+</tr>
+<tr>
+<td>-name-</td>
+<td>Substitution Tag</td>
+<td>Jane | the second name</td>
+</tr>
+</tbody>
+</table>
+
 


### PR DESCRIPTION
I was originally confused by the statement "Section tags are an extension of substitution tags". I assumed that this meant "it works the same way" rather than "you must nest sections tags in substitution tags". These changes are added in order to attempt to clear up this confusion by changing the wording around and adding very specific substitution value tables to show what was replaced, how, and when by the API.
