### PR TITLE
added default to show in navigation

### DIFF
--- a/_config.sample.yml
+++ b/_config.sample.yml
@@ -31,6 +31,9 @@ highlighter: pygments # default python pygments have been replaced by pygments.r
 
 titlecase: true       # Converts page and post titles to titlecase
 
+navigation:	#creates a default for showing navigation unless otherwise overridden in individual file's frontmatter
+  show: true
+
 # list each of the sidebar modules you want to include, in the order you want them to appear.
 # To add custom asides, create files in /source/_includes/custom/asides/ and add them to the list like 'custom/asides/custom_aside_name.html'
 default_asides: [asides/page_navigation.html]


### PR DESCRIPTION
This is only in the _config.sample.yml, for anyone to apply this to their own build of docs they will need to copy this change to their own _config.yml

Closes #113 because it will be available by default going forward for any new builds of docs, creating their own _config.yml from the sample
