### PR TITLE
updated to mkt-api v2 footer

### DIFF
--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -1,1 +1,1 @@
-<iframe id="footer-iframe" src="//sendgrid.com/mkt-api/v1/header-footer?footer=1&css=1&js=1&iframe=1"></iframe>
+<iframe id="footer-iframe" src="//sendgrid.com/mkt-api/v2/footer?key=71ab8b6afb1bae3df247e0286da35e0da16564ff"></iframe>


### PR DESCRIPTION
Hey @mbernier, I noticed docs was still using the old v1 footer. I bumped up the version. This will also help me fix a SnapEngage sales chat bug, so the sooner we get this out the better. Thank you!
