### PR TITLE
Making the JSON example complete as though you were reading the raw head...

### DIFF
--- a/source/API_Reference/SMTP_API/index.html
+++ b/source/API_Reference/SMTP_API/index.html
@@ -12,12 +12,14 @@ seo:
 
 <p>SendGrid's SMTP API allows developers to specify custom handling instructions for e-mail. This is accomplished through a header, X-SMTPAPI, that is inserted into the message. The header is a JSON encoded list of instructions and options for that email.</p>
 
+<p>The X-SMTPAPI header will be stripped from the final email, so <u>do not expect to see it in the email upon receipt by the recipient</u>.</p>
+
 {% anchor h4 %} 
 An example X-SMTPAPI header
 {% endanchor %}
 
 {% codeblock lang:json %}{
-  "category": "newuser"
+  X-SMTPAPI: { "category": [ "newuser" ] }
 }
 {% endcodeblock %}
 <p>In this case, the header is telling the processing routine to assign this email the <a href="{{root_url}}/Delivery_Metrics/categories.html">category</a> of "newuser".</p>


### PR DESCRIPTION
Making the JSON example complete as though you were reading the raw headers themselves in the email's source

Adding an explicit example, and also telling developers the headers will be STRIPPED FROM THE FINAL EMAIL and to not expect the headers to be visible in the email's source upon receipt.
