### PR TITLE
Keanon O'Keefe : Item# 636

### DIFF
--- a/source/API_Reference/Marketing_Emails_API/categories.md
+++ b/source/API_Reference/Marketing_Emails_API/categories.md
@@ -94,10 +94,15 @@ Remove specific categories, or all categories from a Marketing Email.\\
 
 * * * * *
 
-{% anchor h2 %}
+{% anchor h2 %} 
 list 
 {% endanchor %}
 
-To pull a list of all your exisiting Categories or to look to see if a specific Category exists use our [General Statistics API](https://sendgrid.com/docs/API_Reference/Web_API/Statistics/index.html#-Category-List).
+List all categories.
 
-* * * * *
+{% parameters list %} {% parameter 'category[ ]' 'No' 'Must be an existing Category' 'Search to see if a specific Category exists rather than a list of all Categories.' %} 
+{% endparameters %}
+
+{% apiexample list POST https://api.sendgrid.com/api/newsletter/category/list api_user=your_sendgrid_username&api_key=your_sendgrid_password %} {% response json %} [ { "category": "CATEGORY" }, { "category": "CATEGORY2" } ] {% endresponse %} {% response xml %} CATEGORY CATEGORY2
+
+{% endresponse %} {% endapiexample %}


### PR DESCRIPTION
The NL Category API call does not work when passing it a specific category. It truncates the category provided and then errors out. Since there is no such thing as a Newsletter specific Category:

Removed NL Stats API call as it doesnt function properly. 
Replaced it with a link to the General Statistics API call that works properly.
