### PR TITLE
Docs Fix # 503

### DIFF
--- a/source/API_Reference/Customer_Subuser_API/v1_(deprecated)/subuser_unsubscribes.html
+++ b/source/API_Reference/Customer_Subuser_API/v1_(deprecated)/subuser_unsubscribes.html
@@ -6,6 +6,10 @@ navigation:
    show: true
 ---
 
+{% warning %}
+This feature is deprecated, please go to the v2 Customer Subuser API <a href="https://sendgrid.com/docs/API_Reference/Customer_Subuser_API/subuser_unsubscribes.html">Subuser Unsubscribes</a> page.
+{% endwarning %}
+
   {% anchor h2 %}
 Retrieve Unsubscribes 
 {% endanchor %}


### PR DESCRIPTION
"Add a warning block at the top of the page

 Should say ""this feature is deprecated, please go to the v2 Customer
Subuser API Subuser Unsubscribes page""
 (link to the correct page)"
