### PR TITLE
Update index.html

### DIFF
--- a/source/API_Reference/SMTP_API/index.html
+++ b/source/API_Reference/SMTP_API/index.html
@@ -19,7 +19,9 @@ An example X-SMTPAPI header
 {% endanchor %}
 
 {% codeblock lang:json %}{
-   "category":  "newuser"
+    "category": [
+        "newuser"
+    ]
 }
 {% endcodeblock %}
 <p>In this case, the header is telling the processing routine to assign this email the <a href="{{root_url}}/Delivery_Metrics/categories.html">category</a> of "newuser".</p>


### PR DESCRIPTION
According to the SMTPAPI validator (https://sendgrid.com/docs/API_Reference/SMTP_API/smtpapi_validator.html), the above example is invalid. Fixing it to use the expected list form.
