### PR TITLE
update delete ip from pool endpoint to reflect reality

### DIFF
--- a/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
+++ b/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
@@ -79,11 +79,7 @@ DELETE
 {% endanchor %}		
 Remove an IP address from a pool.		
 		
-{% parameters post %}		
-  {% parameter ip Yes 'Valid IP address' 'IP address to remove from the pool' %}		
-{% endparameters %}		
-		
-{% apiv3example delete DELETE https://api.sendgrid.com/v3/ips/pools/:pool_name/ips ip=0.0.0.0 %}		
+{% apiv3example delete DELETE https://api.sendgrid.com/v3/ips/pools/:pool_name/ips/:ip %}		
   {% v3response %}		
 HTTP/1.1 204 NO CONTENT (OK)		
   {% endv3response %}		


### PR DESCRIPTION
Docs for removing an ip from a pool do not work, the endpoint takes a resource as part of the URI not inside the request body.

Current docs api:

``` bash
curl -X DELETE https://api.sendgrid.com/v3/ips/pools/earthbound/ips -d '{"ip": "0.0.0.0"}
>>  {"errors":[{"field":null,"message":"method not allowed"}]}
```

Correct way

``` bash
curl -X DELETE https://api.sendgrid.com/v3/ips/pools/earthbound/ips/0.0.0.0
>> (No content, returns 204)
```
