### PR TITLE
Reserved unique arguments names

### DIFF
--- a/source/API_Reference/SMTP_API/unique_arguments.md
+++ b/source/API_Reference/SMTP_API/unique_arguments.md
@@ -59,3 +59,20 @@ To apply different unique arguments to individual emails, you may use [substitut
   }
 }
 {% endcodeblock %}
+
+<h4>Reserved Words</h4>
+
+Don't use uniq arguments matching those that are returned by Sengrid JSON by default (such as `name`, `event`, `timestamp`). Those arguments will be overriden by Sendgrid. Email will be delivered sucessfully
+
+{% codeblock lang:json %}
+{
+  "unique_args": {
+    "customerAccountNumber": "55555",
+    "event": "ignored_by_Sendgrid",
+    "email": "some-different-email-then-email-sender@ignored-by.sendgrid",
+  }
+}
+{% endcodeblock %}
+
+
+

--- a/source/API_Reference/SMTP_API/unique_arguments.md
+++ b/source/API_Reference/SMTP_API/unique_arguments.md
@@ -69,7 +69,7 @@ Don't use uniq arguments matching those that are returned by Sengrid JSON by def
   "unique_args": {
     "customerAccountNumber": "55555",
     "event": "ignored_by_Sendgrid",
-    "email": "some-different-email-then-email-sender@ignored-by.sendgrid",
+    "email": "some-different-email-then-email-sender@ignored-by.sendgrid"
   }
 }
 {% endcodeblock %}


### PR DESCRIPTION
https://sendgrid.com/docs/API_Reference/SMTP_API/unique_arguments.html

The documentation doesn't say anything about Reserved words such as "event" or "email" or "smtp-id"

e.g.:

 what would happen if I used

```
{
  "unique_args": {
    "customerAccountNumber": "55555",
    "event": "user_registration",
    "email": "some-different-email-then-email-sender@test.com",
  }
}
```

what would happen ? will Sendgrid ignore these arguments ? , will these arguments take precedence of those that sendgrid provides ? will the SMTP request ended up in error ?

I've tested it on my app and looks like Sendgrid ignorse/override those both in Sendgrid UI and Event Webhook JSON POST request.
