### PR TITLE
issue-921: Add text to bullets on Web API v3 stats overview page

### DIFF
--- a/source/API_Reference/Web_API_v3/Stats/index.html
+++ b/source/API_Reference/Web_API_v3/Stats/index.html
@@ -13,7 +13,7 @@ navigation:
 The available endpoints are:
 
 <ul>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/advanced.html">/v3/:data_type/stats</a>testing</li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/advanced.html">/v3/:data_type/stats</a></li>
   <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/categories.html">/v3/categories/stats</a></li>
   <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/global.html">/v3/stats</a></li>
   <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/parse.html">/v3/parse/stats</a></li>

--- a/source/API_Reference/Web_API_v3/Stats/index.html
+++ b/source/API_Reference/Web_API_v3/Stats/index.html
@@ -13,11 +13,11 @@ navigation:
 The available endpoints are:
 
 <ul>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/advanced.html"></a></li>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/categories.html"></a></li>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/global.html"></a></li>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/parse.html"></a></li>
-  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/subusers.html"></a></li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/advanced.html">/v3/:data_type/stats</a>testing</li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/categories.html">/v3/categories/stats</a></li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/global.html">/v3/stats</a></li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/parse.html">/v3/parse/stats</a></li>
+  <li><a href="{{root_url}}/API_Reference/Web_API_v3/Stats/subusers.html">/v3/subusers/stats</a></li>
 </ul>
 
 {% info %}


### PR DESCRIPTION
https://github.com/sendgrid/docs/issues/921

@mbernier I'm not sure who checks these. Is this what we want?
I'm not sure on the ":data_type" part.

**tl;dr: I can't actually view the change to see if it's correct**

I can't seem to get nokogiri-1.6.1 to install, I believe it's a dependency of  mini_portile 0.5.3 from "bundle install"
The fix's seem to say to install all of xcode. I'm hoping for a better way.

Edit: ./bin/preview seems to work even though bundle install failed, so I can see what changes look like!