### PR TITLE
issue-689: escape [] in curl command for file attachments

### DIFF
--- a/source/API_Reference/Web_API/mail.md
+++ b/source/API_Reference/Web_API/mail.md
@@ -129,7 +129,7 @@ Send to one email recipient
 {% endanchor %}
 
 {% codeblock lang:bash %}
-$ curl -d 'to=destination@example.com&amp;toname=Destination&amp;subject=Example Subject&amp;text=testingtextbody&amp;from=info@domain.com&amp;api_user=your_sendgrid_username&amp;api_key=your_sendgrid_password' https://api.sendgrid.com/api/mail.send.json
+curl -d 'to=destination@example.com&amp;toname=Destination&amp;subject=Example Subject&amp;text=testingtextbody&amp;from=info@domain.com&amp;api_user=your_sendgrid_username&amp;api_key=your_sendgrid_password' https://api.sendgrid.com/api/mail.send.json
 {% endcodeblock %}
 
 {% anchor h4 %}
@@ -137,7 +137,7 @@ Send to multiple email recipients
 {% endanchor %}
 
 {% codeblock lang:bash %}
-$ curl -d 'to[]=destination@example.com&amp;toname[]=Destination&amp;to[]=destination2@example.com&amp;toname[]=Destination2&amp;subject=Example Subject&amp;text=testingtextbody&amp;from=info@domain.com&amp;api_user=your_sendgrid_username&amp;api_key=your_sendgrid_password' https://api.sendgrid.com/api/mail.send.json
+curl -d 'to[]=destination@example.com&amp;toname[]=Destination&amp;to[]=destination2@example.com&amp;toname[]=Destination2&amp;subject=Example Subject&amp;text=testingtextbody&amp;from=info@domain.com&amp;api_user=your_sendgrid_username&amp;api_key=your_sendgrid_password' https://api.sendgrid.com/api/mail.send.json
 {% endcodeblock %}
 
 {% anchor h4 %}
@@ -145,7 +145,7 @@ Send a test with attachment
 {% endanchor %}
 
 {% codeblock lang:bash %}
-$ curl https://api.sendgrid.com/api/mail.send.json \
+curl https://api.sendgrid.com/api/mail.send.json \
 -F to=recipient@domain.com -F toname=test -F subject="Example Subject" \
 -F text="testing text body" --form-string html="<strong>testing html body</strong>" \
 -F from=test@yourdomain.com -F api_user=your_sendgrid_username -F api_key=your_sendgrid_password \
@@ -159,7 +159,7 @@ Send a test specifying the file content type by appending ';type=<mime type>' to
 {% endanchor %}
 
 {% codeblock lang:bash %}
-$ curl https://api.sendgrid.com/api/mail.send.json \
+curl https://api.sendgrid.com/api/mail.send.json \
 -F to=recipient@domain.com -F toname=test -F subject="Example Subject" \
 -F text="testing text body" --form-string html="<strong>testing html body</strong>" \
 -F from=test@yourdomain.com -F api_user=your_sendgrid_username -F api_key=your_sendgrid_password \

--- a/source/API_Reference/Web_API/mail.md
+++ b/source/API_Reference/Web_API/mail.md
@@ -149,7 +149,7 @@ $ curl https://api.sendgrid.com/api/mail.send.json \
 -F to=recipient@domain.com -F toname=test -F subject="Example Subject" \
 -F text="testing text body" --form-string html="<strong>testing html body</strong>" \
 -F from=test@yourdomain.com -F api_user=your_sendgrid_username -F api_key=your_sendgrid_password \
--F files[attachment.gz]=@f.php.gz https://api.sendgrid.com/api/mail.send.json
+-F files\[attachment.gz\]=@f.php.gz
 {% endcodeblock %}
 
 <span class="label label-info">Note</span> To ensure that it uploads from a local file, use \<@filename\>.
@@ -163,7 +163,7 @@ $ curl https://api.sendgrid.com/api/mail.send.json \
 -F to=recipient@domain.com -F toname=test -F subject="Example Subject" \
 -F text="testing text body" --form-string html="<strong>testing html body</strong>" \
 -F from=test@yourdomain.com -F api_user=your_sendgrid_username -F api_key=your_sendgrid_password \
--F files[attachment.pdf]=@attachment.pdf;type=application/pdf
+-F files\[attachment.pdf\]=@attachment.pdf;type=application/pdf
 {% endcodeblock %}
 
 {% anchor h3 %}


### PR DESCRIPTION
Fix for issue: https://github.com/sendgrid/docs/issues/689

Also removed duplicate "https://api.sendgrid.com/api/mail.send.json" in curl call
And removed '$' to create easy copy-paste