### PR TITLE
Encode the password in livedoc to work with `&`.

### DIFF
--- a/source/_assets/javascripts/livedocs.js
+++ b/source/_assets/javascripts/livedocs.js
@@ -83,7 +83,7 @@ $(function() {
         e.preventDefault();
 
         username = $.cookie('username');
-        password = $.cookie('password');
+        password = window.encodeURIComponent($.cookie('password'));
 
         var valid = Livedocs.validateRequired(this);
         if (!valid) return;


### PR DESCRIPTION
In SendGrid's API documentation, passwords which contains `&` does not cope with the live demo.
I investigated why it does not works and found that the delimiter `&` does not encoded in the query string.
For example, `pass&word` is shortened as `pass` and the authentication never successes.

This PR encodes the password with `window.encodeURIComponent`,
which make sure the delimiter `&` does not included in the query string.

![blocks_-_sendgrid_documentation___sendgrid](https://cloud.githubusercontent.com/assets/1067855/6765081/d45ad1da-d013-11e4-81fe-2532b602f294.png)