### PR TITLE
Update libraries.md

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -143,7 +143,7 @@ Python
 -   [smtpapi-python](http://github.com/sendgrid/smtpapi-python) *by SendGrid*- Official Python library to create SMTP API headers
 -   [greplin-tornado-sendgrid](https://github.com/Cue/greplin-tornado-sendgrid) *by Daniel Gross* - SendGrid client for Tornado Web Server
 -   [django-sendgrid](https://github.com/RyanBalfanz/django-sendgrid) *by Ryan Balfanz* - SendGrid SMTP API interface for Django
--   [sendgrid-sendgrid](https://github.com/elbuo8/sendgrid-django) *by Yamil Asusta* - SendGrid Web API interface for Django
+-   [sendgrid-django](https://github.com/elbuo8/sendgrid-django) *by Yamil Asusta* - SendGrid Web API interface for Django
 
 {% anchor h3 %}
 Ruby 


### PR DESCRIPTION
changed sendgrid-sendgrid to sendgrid-django, which is the actual name of the library (the user who reported it was confused by it)