### PR TITLE
Remove discontinued links.

### DIFF
--- a/source/Integrate/Code_Examples/Webhook_Examples/php.md
+++ b/source/Integrate/Code_Examples/Webhook_Examples/php.md
@@ -63,7 +63,3 @@ foreach ($events as $event) {
 
 {% endcodeblock %}
 
-
-{% info %}
-get the event webhook up and running easily with our awesome open source app, eventkit <a href="http://sendgrid.github.io/eventkit/setup.html/" ?>Chick here to get setup</a>.
-{% endinfo %}


### PR DESCRIPTION
EventKit-PHP has been discontinued in favor of [EventKit-Rails](http://github.com/sendgrid/eventkit-rails) which offers a one click deploy to heroku.