### PR TITLE
Update a few bundled Ruby gems to avoid fatal error on OS X Yosemite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     kramdown (1.3.3)
     less (2.5.0)
       commonjs (~> 0.2.7)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.11)
     liquid (2.5.5)
     listen (2.7.4)
       celluloid (>= 0.15.2)
@@ -99,7 +99,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.1.7.1)
     redcarpet (3.1.1)
-    ref (1.0.5)
+    ref (2.0.0)
     rubypants (0.2.0)
     s3-static-site (0.3.0)
       aws-sdk
@@ -110,7 +110,7 @@ GEM
     sass (3.3.7)
     simple-cloudfront-invalidator (1.0.1)
       colored (= 1.2)
-    therubyracer (0.12.1)
+    therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
     tilt (2.0.1)


### PR DESCRIPTION
I was running into this error on my Mac (OS X 10.10 Yosemite) when running `bundle exec rake preview`:

```
dyld: lazy symbol binding failed: Symbol not found: __ZN2v82V821AddGCPrologueCallbackEPFvNS_6GCTypeENS_15GCCallbackFlagsEES1_
  Referenced from: /Users/larrygilbert/.chefdk/gem/ruby/2.1.0/extensions/x86_64-darwin-12/2.1.0/therubyracer-0.12.1/v8/init.bundle
  Expected in: flat namespace

dyld: Symbol not found: __ZN2v82V821AddGCPrologueCallbackEPFvNS_6GCTypeENS_15GCCallbackFlagsEES1_
  Referenced from: /Users/larrygilbert/.chefdk/gem/ruby/2.1.0/extensions/x86_64-darwin-12/2.1.0/therubyracer-0.12.1/v8/init.bundle
  Expected in: flat namespace
```

I updated the bundled gems using `bundle update therubyracer`, and I no longer run into this error.

These are the updated gems:

libv8 (3.16.14.7 -> 3.16.14.11)
ref (1.0.5 -> 2.0.0)
therubyracer (0.12.1 -> 0.12.2)
