### PR TITLE
Delete descriptions of domain whitelabel on ips.md

### DIFF
--- a/source/User_Guide/Settings/Whitelabel/ips.md
+++ b/source/User_Guide/Settings/Whitelabel/ips.md
@@ -50,14 +50,6 @@ We will then prepend a second level subdomain similar to ```o1``` incrementing t
 Domain
 {% endanchor %}
 
-{% warning %}
-If you add a new default domain whitelabel for a domain that is already whitelabeled on your account, you risk invalidating and removing the default status of the previously set up whitelabel.
-{% endwarning %}
-
-{% info %}
-Your domain whitelabel will not affect your email link whitelabel and vice versa.
-{% endinfo %}
-
 The root domain for your subdomain. This is the domain that will receive the email reputation from the whitelabel.  Your root domain should match your FROM email address. If you are sending from newsletter@example.com, then you should whitelabel example.com so the domains match.
 
 {% anchor h3 %}


### PR DESCRIPTION
These lines may have been only copied from domains.md.