### PR TITLE
Removes duplicated field pools in Get example

### DIFF
--- a/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
+++ b/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
@@ -50,7 +50,6 @@ HTTP/1.1 200 OK
 [
   {
     "ip":"000.00.00.0",
-    "pools":["new_test5"],
     "warmup":true,
     "start_date":1409616000,
     "subusers": ["username1", "username2"],


### PR DESCRIPTION
Removes duplicated `pools` field in Response example:
https://sendgrid.com/docs/API_Reference/Web_API_v3/IP_Management/ip_addresses.html#-GET