### PR TITLE
add URLs to Classroom index page

### DIFF
--- a/source/Classroom/index.html
+++ b/source/Classroom/index.html
@@ -10,32 +10,32 @@ navigation:
   show: true
 ---
 
-<h2><a href="">Basics</a></h2>
+<h2><a href="{{root_url}}/Classroom/Basics/index.html">Basics</a></h2>
 <p>
 This section contains how-to articles and resources for general SendGrid topics. You will be able to find help with account administration, introductory information about our APIs, answers to billing related questions, in addition to other common questions and concerns.
 </p>
 
-<h2><a href="">Build</a></h2>
+<h2><a href="{{root_url}}/Classroom/Build/index.html">Build</a></h2>
 <p>
 Here you will find resources that can help you choose what content you should include in your email campaigns, how you can add that content to your emails, and help with the different methods of formatting and designing your emails.
 </p>
 
-<h2><a href="">Deliver</a></h2>
+<h2><a href="{{root_url}}/Classroom/Deliver/index.html">Deliver</a></h2>
 <p>
 This section contains answers to the different questions our users have about email deliverability. You will be able to find articles discussing basic sending habits that help you to ensure the delivery of your emails. You will also find resources about topics such as email address collection and contact list hygiene, how to authenticate yourself as a sender, and what to do when you encounter deliverability problems such as dropped emails.
 </p>
 
-<h2><a href="">Send</a></h2>
+<h2><a href="{{root_url}}/Classroom/Send/index.html">Send</a></h2>
 <p>
 This section addresses the basic act of sending email. You will find articles covering topics such as scheduling your sends, how to cancel the delivery of an email, the different methods available for sending emails, what types of content you may send, and who you can, or should, send that content to.
 </p>
 
-<h2><a href="">Track</a></h2>
+<h2><a href="{{root_url}}/Classroom/Track/index.html">Track</a></h2>
 <p>
 Here you will be able to find information about what it means to track your emails, what metrics you are able to track, and how to collect and store data about the events you are tracking.
 </p>
 
-<h2><a href="">Troubleshooting</a></h2>
+<h2><a href="{{root_url}}/Classroom/Troubleshooting/index.html">Troubleshooting</a></h2>
 <p>
 Here we provide you with many troubleshooting guides for problems ranging from account administration to delivery problems such as email deferrals and sending delays. If you are unable to find the solution to your problem here, don’t forget to try Searching our Docs for other helpful resources.
 </p>


### PR DESCRIPTION
The headers for each subsection now link to each corresponding index page.