### PR TITLE
Correct Number of Unique Senders

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/senders.md
+++ b/source/User_Guide/Marketing_Campaigns/senders.md
@@ -37,7 +37,7 @@ so that you can input the right information and add this to your emails.
 When you click “Create New Sender,” you will be shown a form where you can set up a sender identity.
 
 {% info %}
-You can create up to 50 unique sender identities.
+You can create up to 10 unique sender identities.
 {% endinfo %}
 
 ![]({{root_url}}/images/sender_identity_1.png "Sender Identities")


### PR DESCRIPTION
Changed from 50 to 10, as customers are only able to create 10 unique senders in Marketing Campaigns.