### PR TITLE
Updated documentation links and typos

### DIFF
--- a/source/Integrate/Other/index.html
+++ b/source/Integrate/Other/index.html
@@ -13,5 +13,10 @@ navigation:
         Interspire 
       </a>
     </li>
+    <li>
+      <a href="sugarcrm.html">
+        SugarCRM 
+      </a>
+    </li>
   </ul>
 </div>

--- a/source/Integrate/Other/interspire.md
+++ b/source/Integrate/Other/interspire.md
@@ -6,7 +6,7 @@ navigation:
   show: true
 ---
 
-## *Why* to integrate Interspire with SendGrid
+## *Why* integrate Interspire with SendGrid
 
 Interspire's [Email Marketer](http://www.interspire.com/emailmarketer/) is a powerful email marketing tool used by some SendGrid customers to carry out more in-depth marketing campaigns. Email Marketer has all the bells and whistles of an email marketing suite, and it's really good at helping customers carry out marketing campaigns from start to finish. SendGrid is really good at giving mail senders all the necessary tools to ensure their mail gets delivered to the inbox. This is why some customers choose to create their email marketing campaigns with Interspire and send the mail through SendGrid, to ensure optimized deliverability of the mail to the inbox. Luckily, Interspire makes this integration with SendGrid simple.
 
@@ -21,7 +21,7 @@ In order to set Email Marketer's outbound mail server to point to SendGrid, clic
 -   **SMTP Hostname**: ssl://smtp.sendgrid.net or tls://smtp.sendgrid.net
 -   **SMTP Username**: [your SendGrid account's username]
 -   **SMTP Password**: [your SendGrid account's password]
--   **SMTP Port**: [the port of your choosing, the options for which can be found [here]({{%20root_url}}/Integrate/index.html)]
+-   **SMTP Port**: [the port of your choosing, the options for which can be found [here]({{root_url}}/Classroom/Basics/Email_Infrastructure/smtp_ports.html)]
 
 Once these settings changes have been made within the Email Settings page within your Email Marketer account, all mail from the application will be sent to SendGrid so we can send it to the end recipient. Simple as that.
 

--- a/source/Integrate/Other/sugarcrm.md
+++ b/source/Integrate/Other/sugarcrm.md
@@ -14,13 +14,13 @@ navigation:
 What is SugarCRM?
 {% endanchor %}
 
-One of the primary competitors to the Salesforce CRM, [SugarCRM](http://www.sugarcrm.com) is a widely used customer relationship management software and as they explain on their website, "[SugarCRM is] designed to help your business communicate with prospects, share sales information, close deals and keep customers happy. Thousands of successful companies use Sugar everyday to manage sales, marketing and support." Since SendGrid's become synonymous with optimized deliverability of transactional email to the inbox, some of our customers have asked us how they can send mail from their CRM software through our service so those emails can also be optimized for deliverability to the inbox. If you're a SendGrid as well as SugarCRM customer, let's get into how you'll go about doing this!
+One of the primary competitors to the Salesforce CRM, [SugarCRM](http://www.sugarcrm.com) is a widely used customer relationship management software and as they explain on their website, "SugarCRM is designed to help your business communicate with prospects, share sales information, close deals and keep customers happy. Thousands of successful companies use Sugar everyday to manage sales, marketing and support." Since SendGrid's become synonymous with optimized deliverability of transactional email to the inbox, some of our customers have asked us how they can send mail from their CRM software through our service so those emails can also be optimized for deliverability to the inbox. If you're a SendGrid as well as SugarCRM customer, let's get into how you'll go about doing this!
 
 {% anchor h2 %}
 How to integrate SugarCRM with SendGrid
 {% endanchor %}
 
-SendGrid customers utilizing our service for their transactional email and wanting to use SugarCRM for their email marketing campaigns can easily make a few settings changes within their SugarCRM account in order to point their outgoing mail to us, so we can deliver it to the end recipient. In order to send mail from SugarCRM to SendGrid, navigate the following on the SugarCRM site: Admin > Email Settings > Choose "SMTP" as the mail transfer agent > Enter required server info as follows:
+SendGrid customers utilizing our service for their transactional email and wanting to use SugarCRM for their email marketing campaigns can easily make a few settings changes within their SugarCRM account in order to point their outgoing mail to us, so we can deliver it to the end recipient. In order to send mail from SugarCRM to SendGrid, navigate the following on the SugarCRM site: Admin > Email Settings > Choose "Other" as the Email provider > Enter required server info as follows:
 
 -   **SMTP Hostname**: ssl://smtp.sendgrid.net or tls://smtp.sendgrid.net
 -   **SMTP Username**: [your SendGrid account's username]
@@ -29,4 +29,4 @@ SendGrid customers utilizing our service for their transactional email and wanti
 
 Once these changes have been made within the Email Settings page within your SugarCRM account, all outgoing mail from the application will be routed to SendGrid so we can send it to your end recipient.
 
-SugarCRM outlines this process in more detail in the [SugarCRM support documentation](http://support.sugarcrm.com/04_Find_Answers/02KB/02Administration/100Email/Configuring_Your_Outbound_Email_Server_(SMTP)_to_Work_With_Sugar).
+SugarCRM outlines this process in more detail in the [SugarCRM support documentation](<http://support.sugarcrm.com/04_Find_Answers/02KB/02Administration/100Email/Configuring_Your_Outbound_Email_Server_(SMTP)_to_Work_With_Sugar>).

--- a/source/Integrate/Partners/Google.md
+++ b/source/Integrate/Partners/Google.md
@@ -23,4 +23,4 @@ Compute Engine
 
 If you're using Google's Compute Engine, click [here](https://cloud.google.com/compute/docs/sending-mail#sendgrid)
 
-Check out our blog for more information on how to make Google and SendGrid work together [here]({{site.blog_url}}/?s=google&submit=).  
+Check out our blog for more information on how to make Google and SendGrid work together [here]({{site.blog_url}}/?s=google+app+engine&submit=).  

--- a/source/Integrate/Partners/index.html
+++ b/source/Integrate/Partners/index.html
@@ -27,22 +27,22 @@ Partners
       </a>
     </li>
     <li>
-      <a href="{{root_url}}/../../Classroom/Troubleshooting/how_to_change_the_password_for_your_sendgrid_account_via_softlayer.html">
+      <a href="/Classroom/Troubleshooting/Account_Administration/how_to_change_the_password_for_your_sendgrid_account_via_softlayer.html">
         How to change the password for your SendGrid account via Softlayer
       </a>
     </li>
     <li>
-      <a href="{{root_url}}/../../Classroom/Troubleshooting/how_to_change_the_password_for_your_sendgrid_add_on_via_azure.html">
-        How to change the password for your SendGrid add-on via Asure.
+      <a href="/Classroom/Troubleshooting/Account_Administration/how_to_change_the_password_for_your_sendgrid_add_on_via_azure.html">
+        How to change the password for your SendGrid add-on via Azure.
       </a>
     </li>
     <li>
-      <a href="{{root_url}}/../../Classroom/Troubleshooting/how_to_change_the_password_for_your_sendgrid_add_on_via_openshift.html">
+      <a href="/Classroom/Troubleshooting/Account_Administration/how_to_change_the_password_for_your_sendgrid_add_on_via_openshift.html">
         How to change the password for your SendGrid add-on via OpenShift.
       </a>
     </li>
     <li>
-      <a href="{{root_url}}/../../Classroom/Troubleshooting/how_to_change_the_password_for_your_sendgrid_add_on_via_the_ibm_cloud_marketplace.html">
+      <a href="/Classroom/Troubleshooting/Account_Administration/how_to_change_the_password_for_your_sendgrid_add_on_via_the_ibm_cloud_marketplace.html">
         How to change the password for your SendGrid add-on via the IBM Cloud Marketplace.
       </a>
     </li>


### PR DESCRIPTION
These pages had bad links and/or typos:
https://sendgrid.com/docs/Integrate/Partners/index.html
https://sendgrid.com/docs/Integrate/Other/index.html
https://sendgrid.com/docs/Integrate/Other/sugarcrm.html