### PR TITLE
Scheduled Sends Docs Update

### DIFF
--- a/source/API_Reference/SMTP_API/scheduling_parameters.md
+++ b/source/API_Reference/SMTP_API/scheduling_parameters.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 With scheduling you can send large volumes of email in queued batches or target individual recipients by specifying custom UNIX timestamp parameter.
-Using the parameters defined below, you can queue batches of emails targeting individual recipients.
+Using the parameters defined below, you can queue batches of emails targeting individual recipients. **Emails can be scheduled up to 72 hours in advance.**
 
 This parameter allows SendGrid to begin processing a customer’s email requests before sending. SendGrid will then queue those messages and release
 them when the timestamp is exceeded. This technique allows for a more efficient way to distribute large email requests and can **improve overall mail delivery time**

--- a/source/API_Reference/SMTP_API/scheduling_parameters.md
+++ b/source/API_Reference/SMTP_API/scheduling_parameters.md
@@ -6,8 +6,12 @@ navigation:
   show: true
 ---
 
-With scheduling you can send large volumes of email in queued batches or target individual recipients by specifying custom UNIX timestamp parameter.
-Using the parameters defined below, you can queue batches of emails targeting individual recipients. **Emails can be scheduled up to 72 hours in advance.**
+With scheduling you can send large volumes of email in queued batches or target individual recipients by specifying a custom UNIX timestamp parameter.
+Using the parameters defined below, you can queue batches of emails targeting individual recipients.
+
+{% info %}
+**Emails can be scheduled up to 72 hours in advance.** However, this scheduling constraint does not apply to campaigns sent via [Marketing Campaigns]({{root_url}}/User_Guide/Marketing_Campaigns/index.html).
+{% endinfo%}
 
 This parameter allows SendGrid to begin processing a customer’s email requests before sending. SendGrid will then queue those messages and release
 them when the timestamp is exceeded. This technique allows for a more efficient way to distribute large email requests and can **improve overall mail delivery time**

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -64,9 +64,7 @@ Validate whether or not a batch id is valid
 
 # Group Cancel Scheduled Sends
 
-The Cancel Scheduled Sends feature allows the customer to cancel a
-scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html)
-included in the SMTPAPI header. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
+The Cancel Scheduled Sends feature allows the customer to cancel a scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) included in the SMTPAPI header. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
 <br>
 <br>
 **You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation at one time.**

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -9,14 +9,14 @@ navigation:
 FORMAT: 1A
 
 # Cancellation of Scheduled Sends
-Cancelling scheduled send
+Canceling scheduled send
 
 # Group Batch IDs
 
-If you set the [SMTPAPI header batch_id]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html),
-it allows you to then cancel a scheduled send based on that batch_id by calling the [Cancel Scheduled Send endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends)
+If you set the [SMTPAPI header batch_id]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html), it allows you to then cancel a scheduled send based on that batch_id by calling the [Cancel Scheduled Send endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends).
 
 ## Batch ID Generation [/mail/batch]
+
 Generate a new Batch ID to associate with scheduled sends
 
 ### Generate Batch ID [POST]
@@ -37,7 +37,7 @@ Generate a new Batch ID to associate with scheduled sends
 
 + Parameters
     + batch_id (required, string, `HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi`) ... The batch ID you want to check
-    
+
 
 ### Validate Batch ID [GET]
 
@@ -50,28 +50,35 @@ Validate whether or not a batch id is valid
     + Body
 
              {
-                "batch_id": "YOUR_BATCH_ID"
+                "batch_id": "HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi"
              }
 
 + Response 400 (application/json)
 
     + Body
-          "" : "invalid batch id"
+
+             {
+                "errors":[{"field": null, "message": "invalid batch id"}]
+             }
+
 
 # Group Cancel Scheduled Sends
 
 The Cancel Scheduled Sends feature allows the customer to cancel a
 scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html)
-included in the SMTPAPI header.
-
-Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
+included in the SMTPAPI header. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
+<br>
+<br>
+**You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation at one time.**
+<br>
+<br>
+If you submit a cancel or pause request after the maximum number of cancellation/pause requests has already been reached, an HTTP 400 error will be returned.
 
 ## Cancel or pause a scheduled send [/user/scheduled_sends]
 
 ### Cancel or pause a scheduled send [POST]
 
-Cancel or pause a scheduled send. If the maximum number of cancellations/pauses are added, HTTP 400 will
-be returned.
+Cancel or pause a scheduled send.
 
 + Request
 
@@ -87,13 +94,14 @@ be returned.
 + Response 400
 
     + Body
-          "" : "max limit reached"
-          "" : "invalid batch id"
-          "batch_id" : "a status for this batch id exists, try PATCH to update the status"
+
+            "" : "max limit reached"
+            "batch_id" : "invalid batch id"
+            "batch_id" : "a status for this batch id exists, try PATCH to update the status"
 
 ### Retrieve all scheduled sends [GET]
 
-Get all cancel/paused scheduled send information. 
+Get all cancel/paused scheduled send information.
 
 + Request (application/json)
 
@@ -114,7 +122,7 @@ A CRUD for managing user scheduled send cancellations
 
 ### Retrieve a scheduled send [GET]
 
-Get a single cancel/paused scheduled send information. 
+Get a single cancel/paused scheduled send information.
 
 + Request (application/json)
 
@@ -144,7 +152,7 @@ Update the status of a scheduled send.
 
     + Body
 
-        "" : "batch id not found"
+            "" : "batch id not found"
 
 ### Delete a cancellation or pause of a scheduled send [DELETE]
 
@@ -158,4 +166,4 @@ Delete the cancellation/pause of a scheduled send.
 
     + Body
 
-        "" : "batch id not found"
+            "" : "batch id not found"

--- a/source/Glossary/scheduled_emails.md
+++ b/source/Glossary/scheduled_emails.md
@@ -14,4 +14,4 @@ Scheduling emails allows the ability to have the email send at a certain time.
 
 For example if I am a retailer who has a promotion starting at 10:00am you want the email to land as close to that time as possible. Scheduling can support this.
 
-Whether using [Marketing Campaigns]({{root_url}}/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.html) or [our transactional APIs]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) you can define parameters on when to send a single email or batches of emails.
+Whether using [Marketing Campaigns]({{root_url}}/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.html) or [our transactional APIs]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) you can define parameters on when to send a single email or batches of emails. **Emails can be scheduled up to 72 hours in advance.**

--- a/source/Glossary/scheduled_emails.md
+++ b/source/Glossary/scheduled_emails.md
@@ -14,4 +14,8 @@ Scheduling emails allows the ability to have the email send at a certain time.
 
 For example if I am a retailer who has a promotion starting at 10:00am you want the email to land as close to that time as possible. Scheduling can support this.
 
-Whether using [Marketing Campaigns]({{root_url}}/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.html) or [our transactional APIs]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) you can define parameters on when to send a single email or batches of emails. **Emails can be scheduled up to 72 hours in advance.**
+Whether using [Marketing Campaigns]({{root_url}}/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.html) or [our transactional APIs]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) you can define parameters on when to send a single email or batches of emails.
+
+{% info %}
+There is no constraint on how early you can schedule campaigns sent via [Marketing Campaigns]({{root_url}}/User_Guide/Marketing_Campaigns/index.html). However, all other email sent via SendGrid can only be scheduled up to 72 hours in advance.
+{% endinfo %}


### PR DESCRIPTION
* Updated the following files with limit that emails can only be scheduled up to 72 hours in advance (excluding Marketing Campaign sends)
 * /API_Reference/SMTP_API/scheduling_parameters.md
 * /Glossary/scheduled_emails.md
* Updated /API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint with constraint that only 10 batches of schedule sends can be canceled/paused at once