### PR TITLE
Add SMTP Integration warning

### DIFF
--- a/source/Integrate/index.html
+++ b/source/Integrate/index.html
@@ -70,6 +70,12 @@ more information.</p>
 Customers should utilize SMTPAPI if this is an option. As with SMTP, 100 messages can be sent with each connection, but there can be 1000 recipients for each message.
 {% endinfo %}
 
+{% warning %}
+We strongly discourage users from sending mail directly through a single specific IP address when integrating with SendGrid. Always point your traffic to <strong></strong>smtp.sendgrid.net</strong>.
+
+The IP addresses at smtp.sendgrid.net are changed often and without notice. If you point your traffic to one specific IP, you will experience interruptions in your service when these IPs are changed.
+{% endwarning %}
+
 {% anchor h2 %}
 Receive Email From Your Application 
 {% endanchor %}


### PR DESCRIPTION
* Updated /Integrate/index.html with a warning discouraging users from pointing email traffic to one specific IP address instead of smtp.sendgrid.net