### PR TITLE
Add crosslinks between API Permissions List and API Keys index page

### DIFF
--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -74,19 +74,19 @@ The following is a complete list of all possible permissions that you may assign
   <tbody>
       <tr>
         <td>api_keys.create</td>
-        <td>create new api keys</td>
+        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Generate-a-new-API-Key-for-the-authenticated-user-POST">create new api keys</a></td>
       </tr>
       <tr>
         <td>api_keys.delete</td>
-        <td>delete existing api keys</td>
+        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Revoke-an-existing-API-Key-DELETE">delete existing api keys</a></td>
       </tr>
       <tr>
         <td>api_keys.read</td>
-        <td>retrieve api keys</td>
+        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#List-all-API-Keys-belonging-to-the-authenticated-user-GET">retrieve api keys</a></td>
       </tr>
       <tr>
         <td>api_keys.update</td>
-        <td>update existing api keys</td>
+        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Update-the-name-amp-scopes-of-an-API-Key-PUT">update existing api keys</a></td>
       </tr>
   </tbody>
 </table>

--- a/source/API_Reference/Web_API_v3/API_Keys/index.apiblueprint
+++ b/source/API_Reference/Web_API_v3/API_Keys/index.apiblueprint
@@ -84,7 +84,7 @@ This will create a new random API Key for the user with permissions assigned. A 
 
 ## API Key [/api_keys/{api_key_id}]
 ### Get an existing API Key [GET]
-Retrieve a single api key. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+Retrieve a single api key. For a list of permissions that can be assigned to API Keys, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 <br />
 <br />
 If the API Key ID does not exist an HTTP 404 will be returned.
@@ -114,7 +114,7 @@ If the API Key ID does not exist an HTTP 404 will be returned.
 
 ### Revoke an existing API Key [DELETE]
 Authentications using this API Key will fail
-after this request is made, with some small propagation delay. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+after this request is made, with some small propagation delay. For a list of permissions that can be assigned to API Keys, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 <br />
 <br />
 If the API Key ID does not exist an HTTP 404 will be returned.
@@ -135,7 +135,7 @@ If the API Key ID does not exist an HTTP 404 will be returned.
             }
 
 ### Update the name of an existing API Key [PATCH]
-A JSON request body with a "name" property is required. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+A JSON request body with a "name" property is required. For a list of permissions that can be assigned to API Keys, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 
 + Request
 
@@ -156,7 +156,7 @@ A JSON request body with a "name" property is required. For the permissions that
 
 ### Update the name & scopes of an API Key [PUT]
 A JSON request body with a "name" property is required.
-Most provide the list of all the scopes an api key should have. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+Most provide the list of all the scopes an api key should have. For a list of permissions that can be assigned to API Keys, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 
 + Request
 

--- a/source/API_Reference/Web_API_v3/API_Keys/index.apiblueprint
+++ b/source/API_Reference/Web_API_v3/API_Keys/index.apiblueprint
@@ -33,7 +33,7 @@ SendGrid v3 Web API or the [Mail API Endpoint]({{root_url}}/API_Reference/Web_AP
 
 ### Generate a new API Key for the authenticated user [POST]
 
-This will create a new random API Key for the user with permissions assigned. A JSON request body containing a "name" property is required. If number of maximum keys is reached, HTTP 403 will be returned. Optionally, you can specify "scopes" to limit what permissions an API Key is given. If no API Key is provided, it will assign all of the parent account's assignable scopes to the API Key. For a list scopes, please look at the [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html)
+This will create a new random API Key for the user with permissions assigned. A JSON request body containing a "name" property is required. If number of maximum keys is reached, HTTP 403 will be returned. Optionally, you can specify "scopes" to limit what permissions an API Key is given. If no API Key is provided, it will assign all of the parent account's assignable scopes to the API Key. For a list of all scopes, please look at the [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html)
 
 
 + Request
@@ -84,8 +84,9 @@ This will create a new random API Key for the user with permissions assigned. A 
 
 ## API Key [/api_keys/{api_key_id}]
 ### Get an existing API Key [GET]
-Retrieve a single api key.
-
+Retrieve a single api key. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+<br />
+<br />
 If the API Key ID does not exist an HTTP 404 will be returned.
 
 + Response 200 (application/json)
@@ -113,8 +114,9 @@ If the API Key ID does not exist an HTTP 404 will be returned.
 
 ### Revoke an existing API Key [DELETE]
 Authentications using this API Key will fail
-after this request is made, with some small propogation delay.
-
+after this request is made, with some small propagation delay. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
+<br />
+<br />
 If the API Key ID does not exist an HTTP 404 will be returned.
 
 + Response 204 (application/json)
@@ -133,7 +135,7 @@ If the API Key ID does not exist an HTTP 404 will be returned.
             }
 
 ### Update the name of an existing API Key [PATCH]
-A JSON request body with a "name" property is required.
+A JSON request body with a "name" property is required. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 
 + Request
 
@@ -154,7 +156,7 @@ A JSON request body with a "name" property is required.
 
 ### Update the name & scopes of an API Key [PUT]
 A JSON request body with a "name" property is required.
-Most provide the list of all the scopes an api key should have.
+Most provide the list of all the scopes an api key should have. For the permissions that can be set for this endpoint, please see our [API Keys Permissions List]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html#API-Keys).
 
 + Request
 

--- a/source/API_Reference/Web_API_v3/index.md
+++ b/source/API_Reference/Web_API_v3/index.md
@@ -37,7 +37,7 @@ curl -H "Content-Type: application/json" -u sendgrid_username -X POST -d '{"name
 
 You then enter your password at the prompt.
 
-V3 API also supports the use of API Keys. API Keys allow you to use another method of authentication separate from your username and password to your account. Keys add an additional layer of security for your account. API Keys can be generated in your account - visit <a href="https://app.sendgrid.com/settings/api_keys">https://app.sendgrid.com/settings/api_keys</a>. To use keys, you must set a plain text header named "Authorization" with the contents of the header being "Bearer XXX" where XXX is your API Secret Key.
+V3 API also supports the use of API Keys. API Keys allow you to use another method of authentication separate from your account username and password. API Keys add an additional layer of security for your account and can be assigned [specific permissions]({{root_url}}/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html) to limit which areas of your account they may be used to access. API Keys can be generated in your account - visit <a href="https://app.sendgrid.com/settings/api_keys">https://app.sendgrid.com/settings/api_keys</a>. To use keys, you must set a plain text header named "Authorization" with the contents of the header being "Bearer XXX" where XXX is your API Secret Key.
 
 Example header:
 


### PR DESCRIPTION
Updated
* /API_Reference/Web_API_v3/API_Keys/index.html
  * Each endpoint description on this page now links to the respective scope on the API Keys Permissions List
* /API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
  * Each scope in the "API Keys" scopes table on the API Keys Permissions List now links to each respective API endpoint on /API_Reference/Web_API_v3/API_Keys/index.html.
* /API_Reference/Web_API_v3/index.html now links to API Keys Permissions List in paragraph referencing API Keys




