### PR TITLE
Updated SendGrid for Mobile Pages

### DIFF
--- a/source/User_Guide/SendGrid_for_Mobile/dashboard.md
+++ b/source/User_Guide/SendGrid_for_Mobile/dashboard.md
@@ -16,9 +16,11 @@ navigation:
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
 	</a>
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
+    <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
+  </a>
 </p>
 
 The dashboard page will display your account’s statistics for the past day, week, or month. SendGrid offers a number of [statistics]({{root_url}}/User_Guide/Statistics/index.html) to report what is happening with your messages.
 
 You can also export the statistics for each individual day to a CSV file by tapping the “share” button.
-

--- a/source/User_Guide/SendGrid_for_Mobile/email_activity.md
+++ b/source/User_Guide/SendGrid_for_Mobile/email_activity.md
@@ -16,9 +16,12 @@ navigation:
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
 	</a>
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
+    <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
+  </a>
 </p>
 
-Here you can view the real-time logs of all emails sent from your account in the last 7 days. You can also narrow your search by pulling down on the screen and searching for an email address, and/or selecting the “More” button in the top right corner, selecting “Search Options,” and selecting only certain events to show.
+Here you can view the real-time logs of all [email activity]({{root_url}}/User_Guide/email_activity.html) from your account in the last 7 days. You can also narrow your search by pulling down on the screen and searching for an email address, and/or selecting the “More” button in the top right corner, selecting “Search Options,” and selecting only certain events to show.
 
 Tapping on any event will reveal more information, such as server responses or user agents.
 

--- a/source/User_Guide/SendGrid_for_Mobile/index.html
+++ b/source/User_Guide/SendGrid_for_Mobile/index.html
@@ -44,9 +44,9 @@ System Requirements
   </a><sup>2</sup>
 </p>
 
-<p>
+<p class="small">
   <sup>1</sup>Apple and the Apple logo are trademarks of Apple Inc., registered in the U.S. and other countries. App Store is a service mark of Apple Inc.
 </p>
-<p>
+<p class="small">
   <sup>2</sup>Android, Google Play, and the Google Play logo are trademarks of Google Inc.
 </p>

--- a/source/User_Guide/SendGrid_for_Mobile/index.html
+++ b/source/User_Guide/SendGrid_for_Mobile/index.html
@@ -38,8 +38,15 @@ System Requirements
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a>
+	</a><sup>1</sup>
   <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
     <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
-  </a>
+  </a><sup>2</sup>
+</p>
+
+<p>
+  <sup>1</sup>Apple and the Apple logo are trademarks of Apple Inc., registered in the U.S. and other countries. App Store is a service mark of Apple Inc.
+</p>
+<p>
+  <sup>2</sup>Android, Google Play, and the Google Play logo are trademarks of Google Inc.
 </p>

--- a/source/User_Guide/SendGrid_for_Mobile/index.html
+++ b/source/User_Guide/SendGrid_for_Mobile/index.html
@@ -13,14 +13,25 @@ navigation:
 What is SendGrid for Mobile?
 {% endanchor %}
 
-<p>SendGrid for mobile keeps you connected with your SendGrid account on the go. Keep track of your statistics, manage your suppression lists, view your real-time logs and more.</p>
+<p>
+  SendGrid’s mobile app enables you to monitor your email activity, manage suppression lists, and troubleshoot mission critical email delivery while on-the-go. With SendGrid’s mobile app, you can:
+</p>
+
+<ul>
+  <li>View and search real-time delivery metrics (clicks, opens, bounces, etc.)</li>
+  <li>Manage unsubscribe/suppression lists</li>
+  <li>Search and troubleshoot by email address</li>
+  <li>Drill down to view subuser accounts</li>
+  <li>Export CSV files and share reports via email</li>
+  <li>Enable multi-user credentials for secure sign-in</li>
+</ul>
 
 {% anchor h2 %}
 System Requirements
 {% endanchor %}
 
 <ul>
-	<li>An iPhone, iPod Touch, or iPad with iOS 8 or later</li>
+	<li>An Android device, iPhone, iPod Touch, or iPad with iOS 8 or later</li>
 	<li>A SendGrid account is required. You can sign up on our <a href="{{site.site_url}}/user/signup" target="_blank">website</a> or contact our friendly sales team at 888-985-7363.</li>
 </ul>
 
@@ -28,4 +39,7 @@ System Requirements
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
 	</a>
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
+    <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
+  </a>
 </p>

--- a/source/User_Guide/SendGrid_for_Mobile/subusers.md
+++ b/source/User_Guide/SendGrid_for_Mobile/subusers.md
@@ -16,6 +16,9 @@ navigation:
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
 	</a>
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
+    <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
+  </a>
 </p>
 
 {% warning %}

--- a/source/User_Guide/SendGrid_for_Mobile/suppression.md
+++ b/source/User_Guide/SendGrid_for_Mobile/suppression.md
@@ -16,9 +16,12 @@ navigation:
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
 	</a>
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&hl=en&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1">
+    <img alt="Get it on Google Play" src="http://developer.android.com/images/brand/en_generic_rgb_wo_45.png" style="display:inline" />
+  </a>
 </p>
 
-The Suppression List section allows you to view and modify your account’s [suppression lists]({{root_url}}/User_Guide/Delivery_Metrics/email_reports.html).
+The Suppression List section allows you to view and modify your account’s [suppression lists]({{root_url}}/User_Guide/Suppressions/index.html).
 
 Depending on the list you’re viewing, you can tap on an address to get more information (for instance, the bounce reason for addresses listed on the bounce list). You can also swipe left on an address to delete it off a list.
 


### PR DESCRIPTION
Updated the following pages with information regarding SendGrid for Mobile Android App
* /User_Guide/SendGrid_for_Mobile/index.html
 * now includes a legal attribution for both Apple App Store and Google Play badges
* /User_Guide/SendGrid_for_Mobile/dashboard.html
* /User_Guide/SendGrid_for_Mobile/email_activity.html
* /User_Guide/SendGrid_for_Mobile/subusers.html
* /User_Guide/SendGrid_for_Mobile/suppression.html