### PR TITLE
add recommended rate limits for mail.send endpoint

### DIFF
--- a/source/API_Reference/Web_API/mail.md
+++ b/source/API_Reference/Web_API/mail.md
@@ -32,7 +32,9 @@ send
 
 SendGrid's [API Keys]({{root_url}}/User_Guide/Account/api_keys.html) should be used when sending email over the API.
 
-You can have up to 10,000 recipients per API request.
+{% info %}
+You can have up to 10,000 recipients per API request. While we do not enforce rate limits on sending mail via the mail.send endpoint, we do recommend that users avoid making more than 3,000 API requests per second.
+{% endinfo %}
 
 {% parameters mail %}
  {% parameter 'to' 'Yes' 'Must be a valid email address' 'This can also be passed in as an array, to send to multiple locations. Example: to[]=a@mail.com&to[]=b@mail.com. Note that recipients passed in this parameter will be visible as part of the message. If you wish to hide the recipients, use the TO parameter in the [x-smtpapi]({{root_url}}/API_Reference/SMTP_API/index.html) header.' %}


### PR DESCRIPTION
Added guidelines for limiting the number of API requests to the mail.send endpoint to 3,000 requests/second.