### PR TITLE
Updated Transactional Templates Docs

### DIFF
--- a/source/User_Guide/Transactional_Templates/create_edit.md
+++ b/source/User_Guide/Transactional_Templates/create_edit.md
@@ -102,6 +102,16 @@ Unsubscribe Substitution Tags
 
 You can use [substitution tags]({{root_url}}/API_Reference/SMTP_API/substitution_tags.html) to add links to your email to allow recipients to unsubscribe from only these emails, from all of your emails, and to manage their unsubscribe settings for your emails.
 
+{% warning %}
+When using the group unsubscribe substitution tag, you must specify which unsubscribe group you would like to use. If you are sending your email via our SMTP API, please add the group ID into the X-SMTPAPI header. If you are sending via our Web API, please enter the group ID into the x-smtpapi parameter of the mail.send API call.
+
+You must also specify which unsubscribe groups to include on the Manage Preference page if you are using the Manage Email Preferences substitution tag. For more detailed information, please visit our [API Reference]({{root_url}}/API_Reference/SMTP_API/suppressions.html).
+{% endwarning %}
+
+{% info %}
+You can find your group IDs by looking at the Group ID column in the [Unsubscribe Groups UI]({{site.app_url}}/suppressions/advanced_suppression_manager), or by calling the [GET method]({{root_url}}/API_Reference/Web_API_v3/Suppression_Management/groups.html#-GET) of the groups resource.
+{% endinfo %}
+
 {% anchor h3 %}
 Unsubscribe From This List
 {% endanchor %}


### PR DESCRIPTION
Updated /User_Guide/Transactional_Templates/create_edit.html
 * Now notifies users that they are required to specify unsubscribe group IDs when using unsubscribe group substitution tag and manage email preferences substitution tag
 * ID's must be added to the X-SMTPAPI header or x-smtpapi parameter
 * Links to Suppressions Management UI so users can easily find their Unsubscribe Group IDs