### PR TITLE
changed link to KB to point to Classroom

### DIFF
--- a/source/User_Guide/Settings/Whitelabel/domains.md
+++ b/source/User_Guide/Settings/Whitelabel/domains.md
@@ -139,7 +139,7 @@ Examples Of Why You Might Change Or Replace A Domain Whitelabel
 
 1. If you were a Sendgrid customer before May 27th, 2015 and you want to update to the new whitelabel system
 2. You want to change your domain whitelabel
-3. [You add IP addresses to your SendGrid account](https://support.sendgrid.com/hc/en-us/articles/200181948-Adding-an-additional-dedicated-IP-to-your-account)
+3. [You add IP addresses to your SendGrid account]({{root_url}}/Classroom/Basics/Account/adding_an_additional_dedicated_ip_to_your_account.html)
 
 The steps for changing or replacing a whitelabel are easy!
 


### PR DESCRIPTION
Updated a link that pointed to:
https://support.sendgrid.com/hc/en-us/articles/200181948-Adding-an-additional-dedicated-IP-to-your-account
to point to:
https://sendgrid.com/docs/Classroom/Basics/Account/adding_an_additional_dedicated_ip_to_your_account.html