### PR TITLE
Fix liquid error and improve example for template endpoint

### DIFF
--- a/source/API_Reference/Web_API_v3/Settings/mail.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Settings/mail.apiblueprint
@@ -221,6 +221,7 @@ FORMAT: 1A
 
 ### Update Spam Check Settings [PATCH]
 ```max_score``` should be between 1 and 10 inclusively
+```url``` can be url or email
 
 + Request (application/json)
 
@@ -228,18 +229,19 @@ FORMAT: 1A
 
             {
               "enabled": true,
-              "url": "url", // can be url or email
+              "url": "url",
               "max_score": 5
             }
 
 + Response 200 (application/json)
 ```max_score``` should be between 1 and 10 inclusively
+```url``` can be url or email
 
     + Body
 
             {
               "enabled": true,
-              "url": "url", // can be url or email
+              "url": "url",
               "max_score": 5
             }
 
@@ -253,7 +255,7 @@ FORMAT: 1A
 
             {
               "enabled": true,
-              "html_content": "..."
+              "html_content": "<% body %>"
             }
 
 ### Update Template Settings [PATCH]
@@ -264,7 +266,7 @@ FORMAT: 1A
 
             {
               "enabled": true,
-              "html_content": "..."
+              "html_content": "<% body %>"
             }
 
 + Response 200 (application/json)
@@ -273,7 +275,7 @@ FORMAT: 1A
 
             {
               "enabled": true,
-              "html_content": "..."
+              "html_content": "<% body %>"
             }
 
 ## Bounce Purge Settings Resource [/mail_settings/bounce_purge]


### PR DESCRIPTION
I think the // comment was causing this liquid error: http://www.screencast.com/t/vaCRMPpl
Removed the ... with <% body %> because you always need to have the <% body %> tag or you will get an error