### PR TITLE
Added sgsend - sending email from the command line

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -77,6 +77,7 @@ Command Line
 {% endanchor %}
 
 -   [cmdgrid](http://github.com/martyndavies/cmdgrid) *by Martyn Davies* - CLI for working with SendGrid's Parse API
+-   [sgsend](http://github.com/vvaidy/sgsend) *by Vijay Vaidyanathan* - Sending email from the shell command line (for Macs and Unix)
 
 {% anchor h3 %}
 Go 


### PR DESCRIPTION
This is a simple Python 2.x utility I wrote to be able to send mail using the SendGrid API from the unix command line, thought others might possibly find it of some use.