### PR TITLE
added request body to Update an IP Pool name

### DIFF
--- a/source/API_Reference/Web_API_v3/IP_Management/ip_pools.md
+++ b/source/API_Reference/Web_API_v3/IP_Management/ip_pools.md
@@ -109,6 +109,8 @@ Update an IP pool's name.
   {% parameter name Yes 'String. max 64 characters' 'New name of the pool' %}
 {% endparameters %}
 
+{% apiv3requestbody %} {"name":"marketing"} {% endapiv3requestbody %}
+
 {% apiv3example put PUT https://api.sendgrid.com/v3/ips/pools/:pool_name name=new_pool_name %}
 {% v3response %}
 HTTP/1.1 200 OK	


### PR DESCRIPTION
We were missing the request body for the PUT /ip/pools/{pool_name} endpoint