### PR TITLE
Update for New Marketing Campaigns Preheader Setting

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
+++ b/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
@@ -60,6 +60,10 @@ Your <a href="{{root_url}}/User_Guide/Marketing_Campaigns/senders.html">sender i
 </p>
 
 <p>
+<strong>Email Preheader:</strong> You can write a brief description of the content of your campaign. This preheader text will appear direcly after the subject line when a recipient previews your email. The preheader is one of the very first items that a user will see when viewing your campaign. This setting allows you to easily create a unique preheader without having to make any changes to your template.
+</p>
+
+<p>
 <strong>Lists/Segments to Send To:</strong> You can choose which contacts will receive your email. You can choose more than one list or segment. A contact in multiple selected lists will only receive the email once.
 </p>
 

--- a/source/User_Guide/Marketing_Campaigns/drag_drop.md
+++ b/source/User_Guide/Marketing_Campaigns/drag_drop.md
@@ -40,14 +40,14 @@ Available Modules
 {% endanchor %}
 
 {% info %}
-We populate every campaign with both pre-header and footer modules.
+We populate every campaign with footer modules.
 {% endinfo %}
 
 {% warning %}
-<strong>Pre-header</strong> and <strong>footer</strong> modules are locked modules and cannot be removed.
+<strong>Footer</strong> modules are locked modules and cannot be removed.
 {% endwarning %}
 
-Pre-header and footer are important pieces of any email campaign, where information like sender details and unsubscribe links are included. Individual settings for these include background color and padding or margin spacing.
+Footers are important pieces of any email campaign, where information like sender details and unsubscribe links are included. Individual settings for these include background color and padding or margin spacing.
 
 <table id="dragdrop-modules" class="table table-bordered table-striped">
   <thead>
@@ -105,7 +105,7 @@ Pre-header and footer are important pieces of any email campaign, where informat
       <td>A visual divider, or horizontal rule, between modules</td>
       <td>background color, line color, height, padding</td>
     </tr>
-    
+
     <tr>
       <td>Social</td>
       <td>Icons that allow for social media integration within your campaigns.</td>
@@ -346,7 +346,7 @@ The WYSIWYG module follows the generic template. You can leave the section marke
 Social
 {% endanchor %}
 
-The social icons module allows for simple social media integration when creating or editing templates or campaigns. The module offers five different social media icon options (Facebook, Twitter, Instagram, Google+, and Pinterest) all of which can be toggled on or off as well as fully customized to match individual branding and design standards. The module displays when an icon link has been updated to point to a social media destination, providing a visual indicator that links have been properly configured. 
+The social icons module allows for simple social media integration when creating or editing templates or campaigns. The module offers five different social media icon options (Facebook, Twitter, Instagram, Google+, and Pinterest) all of which can be toggled on or off as well as fully customized to match individual branding and design standards. The module displays when an icon link has been updated to point to a social media destination, providing a visual indicator that links have been properly configured.
 
 To turn a social media option on or off, simply check or uncheck its corresponding checkbox. Once you have selected your desired icons, you can adjust the size, color, and border radius of the icons to match a template or campaign theme.
 


### PR DESCRIPTION
* Updated /User_Guide/Marketing_Campaigns/Campaigns/index.html
 * Includes information on new setting allowing users to add an optional preheader to their campaigns
* Updated /User_Guide/Marketing_Campaigns/drag_drop.html
 * Removed verbiage about preheader modules that are automatically added to campaign templates. Preheaders are not optional via Campaign Settings.