### PR TITLE
Updated links to resources.sendgrid.com

### DIFF
--- a/source/Glossary/bulk_mail_folder.md
+++ b/source/Glossary/bulk_mail_folder.md
@@ -10,8 +10,8 @@ navigation:
   show: false
 ---
 
-The Bulk Mail Folder is also called the “spam” or “junk” folder, the folder where questionable email is routed. 
+The Bulk Mail Folder is also called the “spam” or “junk” folder, the folder where questionable email is routed.
 
-There are many factors which determine whether or not a message lands in the Bulk Mail Folder. Each receiving mail server will use its own criteria to determine the quality of each message it receives. 
+There are many factors which determine whether or not a message lands in the Bulk Mail Folder. Each receiving mail server will use its own criteria to determine the quality of each message it receives.
 
-SendGrid offers many [best practices]({{root_url}}/Classroom/Deliver/index.html) to help ensure your message lands appropriately in the inbox. Keep your emails out of the Junk folder by learning more about [Email Deliverability](http://resources.sendgrid.com/deliverability-guide-v2/?mc=SendGrid%20Documentation).
+SendGrid offers many [best practices]({{root_url}}/Classroom/Deliver/index.html) to help ensure your message lands appropriately in the inbox. Keep your emails out of the Junk folder by learning more about [Email Deliverability](https://go.sendgrid.com/Deliverability-Guide-V2.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).

--- a/source/Glossary/complaint.md
+++ b/source/Glossary/complaint.md
@@ -10,10 +10,10 @@ navigation:
   show: false
 ---
 
-A complaint is when an email recipient identifies an email message as spam or junk by clicking the “report spam” or “mark as junk” button within their email reader. 
+A complaint is when an email recipient identifies an email message as spam or junk by clicking the “report spam” or “mark as junk” button within their email reader.
 
 A sender’s complaint rate is calculated by dividing the total number of emails received by the ISP by the number of complaints reported by that ISP’s customers.
 
 Higher numbers of complaints can negatively impact your [email deliverability]({{root_url}}/Glossary/email_deliverability.html).
 
-To get more information please check out our [Email Infrastructure Guide.](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+To get more information please check out our [Email Infrastructure Guide.](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/dns.md
+++ b/source/Glossary/dns.md
@@ -27,4 +27,4 @@ server for www.sendgrid.com to get a Web page.
 For more information:
 
 * [CNAMES]({{root_url}}/Glossary/cname.html)
-* The SendGrid [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+* The SendGrid [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/email_authentication.md
+++ b/source/Glossary/email_authentication.md
@@ -12,4 +12,4 @@ navigation:
 
 Email authentication refers to technical standards that help ISPs and other receivers validate the identity of an email sender. There are three authentication standards in use: [SPF]({{root_url}}/Glossary/spf.html) developed by AOL, [Sender ID]({{root_url}}/Glossary/sender_id.html) developed by Microsoft and [DKIM]({{root_url}}/Glossary/dkim.html) developed by Yahoo!.
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation).
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).

--- a/source/Glossary/feedback_loop.md
+++ b/source/Glossary/feedback_loop.md
@@ -12,4 +12,4 @@ navigation:
 
 A feedback loop is the process by which an ISP forwards emails reported as spam (see [complaint]({{root_url}}/Glossary/complaint.html)) for immediate removal by the sender.
 
-[To get more information please check out our Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+[To get more information please check out our Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/ip_address.md
+++ b/source/Glossary/ip_address.md
@@ -22,5 +22,5 @@ If you are on a Pro 100k or above plan you can see your IP reputation and IP add
 
 For more information:
 
-* [SendGrid Email Infrastructure Guide.](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+* [SendGrid Email Infrastructure Guide.](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)
 * [Whitelabeling your IP]({{root_url}}/User_Guide/Setting_Up_Your_Server/Whitelabeling/index.html)

--- a/source/Glossary/mta.md
+++ b/source/Glossary/mta.md
@@ -13,4 +13,4 @@ Mail Transfer Agent or Message Transfer Agent (MTA) is software that transfers e
 
 An MTA implements both the client (sending) and server (receiving) portions of the [Simple Mail Transfer Protocol]({{root_url}}/Glossary/smtp.html).
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation).
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).

--- a/source/Glossary/mx_record.md
+++ b/source/Glossary/mx_record.md
@@ -12,5 +12,4 @@ seo:
 
 A Mail Exchanger (MX) record in the DNS system specifies a mail server responsible for accepting email addresses on behalf of a domain. The MX records associated with a domain assure that the email is properly routed via [Simple Mail Transfer Protocol]({{root_url}}/Glossary/smtp.html) (SMTP).
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
- 
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/openrelay.md
+++ b/source/Glossary/openrelay.md
@@ -10,5 +10,5 @@ seo:
 ---
 
 An SMTP server configured in such a way that it allows anyone on the Internet to send email through it, not just mail destined for or originating from known users. This is not a recommended configuration because it can be exploited by spammers. Servers with open relays are routinely blocked and/or blacklisted.
- 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/phishing.md
+++ b/source/Glossary/phishing.md
@@ -14,4 +14,4 @@ Phishing is a technique for acquiring information such as user names, passwords,
 
 SendGrid employs both technology and staff to prevent the sending of phishing emails. We have a solid track record of working with the global email community to detect and stop the sending of phishing and spam emails.
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation).
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).

--- a/source/Glossary/reverse_dns.md
+++ b/source/Glossary/reverse_dns.md
@@ -12,4 +12,4 @@ navigation:
 
 Reverse DNS (rDNS) is a method of resolving an IP address into a [domain name]({{root_url}}/Glossary/domain.html), just as the domain name system (DNS) resolves domain names into associated IP addresses. One of the applications of reverse DNS is as a spam filter.
 
-For more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+For more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/sender_id.md
+++ b/source/Glossary/sender_id.md
@@ -12,4 +12,4 @@ navigation:
 
 Sender ID is an email authentication standard developed by Microsoft that compares the email sender’s “From” address to the IP address to verify that it is authorized to send email from that domain.
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation).
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).

--- a/source/Glossary/spam_filter.md
+++ b/source/Glossary/spam_filter.md
@@ -14,4 +14,4 @@ Spam Filters are software based email filters that block email on a range of att
 
 Spam filters typically will move the messages they find to the [spam folder]({{root_url}}/Glossary/bulk_mail_folder.html) within the user's respective email application, keeping that email out of the user's inbox entirely.
 
-To get more information please check out our [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation)
+To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)

--- a/source/Glossary/spf.md
+++ b/source/Glossary/spf.md
@@ -87,6 +87,6 @@ SPF Wizard
 
 Related Links:
 
-* <a href="https://sendgrid.zendesk.com/hc/en-us/articles/202517236">SPF Records Explained</a>
-* <a href="https://sendgrid.zendesk.com/hc/en-us/articles/200185168">SPF: Don't Exceed Ten DNS Lookups!</a>
-* <a href="https://sendgrid.zendesk.com/hc/en-us/articles/200181678">Internet Standards (SPF and DKIM) and Deliverability</a>
+* <a href="{{root_url}}/Classroom/Deliver/Sender_Authentication/spf_records_explained.html">SPF Records Explained</a>
+* <a href="{{root_url}}/Classroom/Deliver/Sender_Authentication/spf_dont_exceed_ten_dns_lookups.html">SPF: Don't Exceed Ten DNS Lookups!</a>
+* <a href="{{root_url}}/Classroom/Deliver/Sender_Authentication/internet_standards_spf_and_dkim_and_deliverability.html">Internet Standards (SPF and DKIM) and Deliverability</a>

--- a/source/Glossary/spoofing.md
+++ b/source/Glossary/spoofing.md
@@ -16,4 +16,4 @@ If you might have been tricked by a phishing email sent via SendGrid, please con
 
 If we find out that a customer of ours is sending spoofing or phishing emails we will ban their account immediately.
 
-To get more information please check out our [Email Infrastructure Guide.](http://resources.sendgrid.com/email-infrastructure-guide/?mc=SendGrid%20Documentation).
+To get more information please check out our [Email Infrastructure Guide.](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).


### PR DESCRIPTION
There are several Docs pages that link to SendGrid whitepapers on the old location: resources.sendgrid.com
* These links have been replaced with the current/correct URLs