### PR TITLE
fixed layout for Google Play and Apple Store badges

### DIFF
--- a/source/User_Guide/SendGrid_for_Mobile/dashboard.md
+++ b/source/User_Guide/SendGrid_for_Mobile/dashboard.md
@@ -15,11 +15,15 @@ navigation:
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a><sup>1</sup>
+	</a>
+  <sup>1</sup>
+</p>
+
+<p style="text-align:center">
   <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-  	<img style="height:45px" style="width:185px" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" style="display:inline;border:none;width:135px;height:45px" />
   </a>
-<sup>2</sup>
+  <sup>2</sup>
 </p>
 
 The dashboard page will display your account’s statistics for the past day, week, or month. SendGrid offers a number of [statistics]({{root_url}}/User_Guide/Statistics/index.html) to report what is happening with your messages.

--- a/source/User_Guide/SendGrid_for_Mobile/email_activity.md
+++ b/source/User_Guide/SendGrid_for_Mobile/email_activity.md
@@ -15,11 +15,15 @@ navigation:
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a><sup>1</sup>
-<a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-	<img style="height:45px" style="width:185px" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
-</a>
-<sup>2</sup>
+	</a>
+  <sup>1</sup>
+</p>
+
+<p style="text-align:center">
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" style="display:inline;border:none;width:135px;height:45px" />
+  </a>
+  <sup>2</sup>
 </p>
 
 Here you can view the real-time logs of all [email activity]({{root_url}}/User_Guide/email_activity.html) from your account in the last 7 days. You can also narrow your search by pulling down on the screen and searching for an email address, and/or selecting the “More” button in the top right corner, selecting “Search Options,” and selecting only certain events to show.

--- a/source/User_Guide/SendGrid_for_Mobile/index.html
+++ b/source/User_Guide/SendGrid_for_Mobile/index.html
@@ -38,11 +38,15 @@ System Requirements
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a><sup>1</sup>
-<a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-	<img style="height:45px" style="width:185px" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
-</a>
-<sup>2</sup>
+	</a>
+  <sup>1</sup>
+</p>
+
+<p style="text-align:center">
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" style="display:inline;border:none;width:135px;height:45px" />
+  </a>
+  <sup>2</sup>
 </p>
 
 <p class="small">

--- a/source/User_Guide/SendGrid_for_Mobile/subusers.md
+++ b/source/User_Guide/SendGrid_for_Mobile/subusers.md
@@ -15,11 +15,15 @@ navigation:
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a><sup>1</sup>
-<a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-	<img style="height:45px" style="width:185px" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
-</a>
-<sup>2</sup>
+	</a>
+  <sup>1</sup>
+</p>
+
+<p style="text-align:center">
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" style="display:inline;border:none;width:135px;height:45px" />
+  </a>
+  <sup>2</sup>
 </p>
 
 {% warning %}

--- a/source/User_Guide/SendGrid_for_Mobile/suppression.md
+++ b/source/User_Guide/SendGrid_for_Mobile/suppression.md
@@ -15,11 +15,15 @@ navigation:
 <p style="text-align:center">
 	<a href="https://itunes.apple.com/us/app/sendgrid/id916808878?mt=8" target="_blank">
 		<img src="{{root_url}}/images/download_app_store.svg" alt="Download On The App Store" style="display:inline;border:none;" />
-	</a><sup>1</sup>
-<a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-	<img style="height:45px" style="width:185px" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
-</a>
-<sup>2</sup>
+	</a>
+  <sup>1</sup>
+</p>
+
+<p style="text-align:center">
+  <a href="https://play.google.com/store/apps/details?id=com.sendgrid.android.sendgrid.app&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" style="display:inline;border:none;width:135px;height:45px" />
+  </a>
+  <sup>2</sup>
 </p>
 
 The Suppression List section allows you to view and modify your account’s [suppression lists]({{root_url}}/User_Guide/Suppressions/index.html).


### PR DESCRIPTION
* Fixed the HTML for the layout of the Apple Store and Google Play badges on
  * /User_Guide/SendGrid_for_Mobile/dashboard.html
  * /User_Guide/SendGrid_for_Mobile/email_activity.html
  * /User_Guide/SendGrid_for_Mobile/index.html
  * /User_Guide/SendGrid_for_Mobile/subusers.html
  * /User_Guide/SendGrid_for_Mobile/suppression.html