### PR TITLE
Swiftype updates

### DIFF
--- a/source/_includes/asides/page_navigation.html
+++ b/source/_includes/asides/page_navigation.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="col-md-3 col-sm-3 hidden-sm">
+<div id="sidebar" class="col-md-3 col-sm-3 hidden-sm" data-swiftype-index='false'>
     <div id="sidebar-wrapper">
       <form class="navbar-search">
         <div class="input-group">

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   {% if page.seo.title and page.seo.override %}
     <title>{{ page.seo.title }}</title>
+    <meta class='swiftype' name='title' data-type='string' content='{{ page.seo.title }}' />
   {% else %}
     {% capture title %}{% if page.seo.title %}{{ page.seo.title }}{% else %}{{ page.title }}{% endif %}{% endcapture %}
     <title>{% if title %}{{ title }} - {% endif %}{{ site.title }}</title>
@@ -30,6 +31,19 @@
   {% if page.seo.robots %}
     <meta name="robots" content="{{ page.seo.robots }}">
   {% endif %}
+
+  {% if page.st.type %}
+    <meta class='swiftype' name='type' data-type='enum' content='{{ page.st.type }}' />
+  {% endif %}
+
+  {% if page.st.info %}
+    <meta class='swiftype' name='info' data-type='string' content='{{ page.st.info }}' />
+  {% endif %}
+
+  {% if page.st.publish_date %}
+    <meta class='swiftype' name='published_at' data-type='date' content='{{ page.st.publish_date }}' />
+  {% endif %}
+
 
   <!-- http://t.co/dKP3o1e -->
   <meta name="HandheldFriendly" content="True">

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -17,8 +17,13 @@
 
   {% if page.seo.description %}
     <meta name="description" content="{{ page.seo.description }}">
+    <meta class='swiftype' name='info' data-type='string' content='{{ page.seo.description }}' />
   {% else %}
-    {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
+    {% if page.description %}
+      <meta name="description" content="{{ page.description }}">
+      <meta class='swiftype' name='info' data-type='string' content='{{ page.description }}' />
+
+    {% endif %}
   {% endif %}
 
   {% capture canonical %}{% if page.seo.canonical %}{{ page.seo.canonical }}{% else %}{{site.url}}{{page.url}}{% endif %}{% endcapture %}
@@ -37,7 +42,6 @@
   {% endif %}
 
   {% if page.st.info %}
-    <meta class='swiftype' name='info' data-type='string' content='{{ page.st.info }}' />
   {% endif %}
 
   {% if page.st.publish_date %}

--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -1,4 +1,4 @@
-<div class="navbar navbar-default" id="nav">
+<div class="navbar navbar-default" id="nav" data-swiftype-index='false'>
   <div class="container-fluid">
     <div class="row">
       <div class="navbar-header">

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -19,12 +19,12 @@
     <link href='http://www.freebase.com/m/0wr97kd' itemprop='sameAs'>
   </div>
   <div class="container-fluid">
-    <div class="row" id="content">
+    <div class="row" id="content" data-swiftype-name="body">
       {{ content | expand_urls: root_url }}
     </div>
   </div>
   {% if page.footer != false %}
-	{% include footer.html %}
+	 {% include footer.html %}
   {% endif %}
 
   {% include swiftype.html %}


### PR DESCRIPTION
added new st  meta tags:
published_at
info
type

these can be used in the doc through front matter like so:
```
---
st:
  published_at: 2016-03-31
  type: [single word to describe the type of page, eg. user_guide]
seo:
  title: the seo friendly title is also the swiftype title now
  description: this description is pushed into the swiftype:info tag
---
```

I formally unincluded menus from swiftype using their "do not crawl" tag
Lastly, I formally marked the body of the page for swiftype.

All of these should allow us more functionality with swiftype.