### PR TITLE
added click tracking limit

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
+++ b/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
@@ -190,7 +190,7 @@ Link Tracking
 You can also view detailed statistics about the links you include in your campaigns. From your Campaign Statistics page you will see a table ranking your links according to the number of times they were clicked by your recipients. You will see the number of total clicks for each link in addition to the total number of unique clicks for each link. All of these stats can be displayed as raw numbers or percentages by clicking the Toggle switch.
 
 {% info %}
-Click tracking stats will be displayed for the first 20 links in your campaign. 
+Click tracking stats will be displayed for the top 20 most frequently clicked links within your campaign.
 {% endinfo %}
 
 {% info %}

--- a/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
+++ b/source/User_Guide/Marketing_Campaigns/Campaigns/index.html
@@ -190,6 +190,10 @@ Link Tracking
 You can also view detailed statistics about the links you include in your campaigns. From your Campaign Statistics page you will see a table ranking your links according to the number of times they were clicked by your recipients. You will see the number of total clicks for each link in addition to the total number of unique clicks for each link. All of these stats can be displayed as raw numbers or percentages by clicking the Toggle switch.
 
 {% info %}
+Click tracking stats will be displayed for the first 20 links in your campaign. 
+{% endinfo %}
+
+{% info %}
 Clicks can not be tracked in A/B test campaigns. 
 {% endinfo %}
 


### PR DESCRIPTION
We only display click tracking stats for up to 20 (the first 20) links in a campaign.