### PR TITLE
API Key Scopes Docs Usability Update

### DIFF
--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -48,7 +48,7 @@ The following is a complete list of all possible permissions that you may assign
 </div>
 
 {% anchor h2 %}Alerts{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "alerts.create",
   "alerts.delete",
@@ -58,7 +58,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}API Keys{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "api_keys.create",
   "api_keys.delete",
@@ -68,7 +68,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}ASM Groups{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "asm.groups.create",
   "asm.groups.delete",
@@ -78,7 +78,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Billing{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "billing.delete",
   "billing.read",
@@ -87,7 +87,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Categories{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "categories.create",
   "categories.delete",
@@ -99,7 +99,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Clients{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "clients.desktop.stats.read",
   "clients.phone.stats.read",
@@ -110,7 +110,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Credentials{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "credentials.create",
   "credentials.delete",
@@ -120,7 +120,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Stats{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "email_activity.read",
   "stats.read",
@@ -133,7 +133,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}IPs{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "ips.assigned.read",
   "ips.read",
@@ -150,7 +150,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Mail Settings{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail_settings.address_whitelist.read",
   "mail_settings.address_whitelist.update",
@@ -175,7 +175,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Mail{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail.batch.create",
   "mail.batch.delete",
@@ -186,7 +186,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Marketing Campaigns{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "marketing_campaigns.create",
   "marketing_campaigns.delete",
@@ -197,7 +197,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Partner Settings{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "partner_settings.new_relic.update",
   "partner_settings.read",
@@ -207,7 +207,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Scheduled Sends{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "user.scheduled_sends.create",
   "user.scheduled_sends.delete",
@@ -217,7 +217,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Subusers{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "subusers.create",
   "subusers.delete",
@@ -239,7 +239,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Suppressions{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "suppressions.create",
   "suppressions.delete",
@@ -249,7 +249,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Templates{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "templates.create",
   "templates.delete",
@@ -267,7 +267,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Tracking{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "tracking_settings.click.read",
   "tracking_settings.click.update",
@@ -282,7 +282,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}User Settings{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "user.account.create",
   "user.account.delete",
@@ -324,7 +324,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Webhook{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "user.webhooks.event.settings.read",
   "user.webhooks.event.settings.update",
@@ -337,7 +337,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Whitelabel{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "whitelabel.create",
   "whitelabel.delete",
@@ -347,7 +347,7 @@ The following is a complete list of all possible permissions that you may assign
 {% endcodeblock %}
 
 {% anchor h2 %}Whitelist{% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "access_settings.whitelist.delete",
   "access_settings.whitelist.read",

--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -48,498 +48,164 @@ The following is a complete list of all possible permissions that you may assign
 </div>
 
 {% anchor h2 %}Alerts{% endanchor %}
-<table class="table table-bordered table-striped">
-    <tbody>
-      <tr>
-        <td>alerts.create</td>
-        <td>create new alerts</td>
-      </tr>
-      <tr>
-        <td>alerts.delete</td>
-        <td>delete existing alerts</td>
-      </tr>
-      <tr>
-        <td>alerts.read</td>
-        <td>retrieve alerts</td>
-      </tr>
-      <tr>
-        <td>alerts.update</td>
-        <td>update existing alerts</td>
-      </tr>
-    </tbody>
-<table>
+{% codeblock %}
+"alerts.create"
+"alerts.delete"
+"alerts.read"
+"alerts.update"
+{% endcodeblock %}
 
 {% anchor h2 %}API Keys{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>api_keys.create</td>
-        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Generate-a-new-API-Key-for-the-authenticated-user-POST">create new api keys</a></td>
-      </tr>
-      <tr>
-        <td>api_keys.delete</td>
-        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Revoke-an-existing-API-Key-DELETE">delete existing api keys</a></td>
-      </tr>
-      <tr>
-        <td>api_keys.read</td>
-        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#List-all-API-Keys-belonging-to-the-authenticated-user-GET">retrieve api keys</a></td>
-      </tr>
-      <tr>
-        <td>api_keys.update</td>
-        <td><a href="{{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html#Update-the-name-amp-scopes-of-an-API-Key-PUT">update existing api keys</a></td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"api_keys.create"
+"api_keys.delete"
+"api_keys.read"
+"api_keys.update"
+{% endcodeblock %}
 
 {% anchor h2 %}ASM Groups{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>asm.groups.create</td>
-        <td>create new unsubscribe groups</td>
-      </tr>
-      <tr>
-        <td>asm.groups.delete</td>
-        <td>delete existing unsubscribe groups</td>
-      </tr>
-      <tr>
-        <td>asm.groups.read</td>
-        <td>retrieve unsubscribe groups</td>
-      </tr>
-      <tr>
-        <td>asm.groups.update</td>
-        <td>update existing unsubscribe groups</td>
-      </tr>
-    </tbody>
-</table>
+{% codeblock %}
+"asm.groups.create"
+"asm.groups.delete"
+"asm.groups.read"
+"asm.groups.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Billing{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>billing.delete</td>
-        <td>perform a cancellation of the account</td>
-      </tr>
-      <tr>
-        <td>billing.read</td>
-        <td>retrieve billing information and invoices</td>
-      </tr>
-      <tr>
-        <td>billing.update</td>
-        <td>modify billing information, including the ability to perform package changes</td>
-      </tr>
-    </tbody>
-</table>
+{% codeblock %}
+"billing.delete"
+"billing.read"
+"billing.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Categories{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>categories.create</td>
-        <td>create a new category</td>
-      </tr>
-      <tr>
-        <td>categroeis.delete</td>
-        <td>delete an existing category</td>
-      </tr>
-      <tr>
-        <td>categories.read</td>
-        <td>retrieve categories</td>
-      </tr>
-      <tr>
-        <td>categories.update</td>
-        <td>update an existing category</td>
-      </tr>
-      <tr>
-        <td>categories.stats.read</td>
-        <td>retrieve category stats</td>
-      </tr>
-      <tr>
-        <td>categories.stats.sums.read</td>
-        <td>retrieve summed category stats</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"categories.create"
+"categories.delete"
+"categories.read"
+"categories.update"
+"categories.stats.read"
+"categories.stats.sums.read"
+{% endcodeblock %}
 
 {% anchor h2 %}Clients{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>clients.desktop.stats.read</td>
-        <td>retrieve desktop client stats</td>
-      </tr>
-      <tr>
-        <td>clients.phone.stats.read</td>
-        <td>retrieve phone client stats</td>
-      </tr>
-      <tr>
-        <td>clients.stats.read</td>
-        <td>retrieve client stats</td>
-      </tr>
-      <tr>
-        <td>clients.tablet.stats.read</td>
-        <td>retrieve tablet client stats</td>
-      </tr>
-      <tr>
-        <td>clients.webmail.stats.read</td>
-        <td>retrieve webmail client stats</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"clients.desktop.stats.read"
+"clients.phone.stats.read"
+"clients.stats.read"
+"clients.tablet.stats.read"
+"clients.webmail.stats.read"
+{% endcodeblock %}
 
 {% anchor h2 %}Credentials{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>credentials.create</td>
-        <td>create new credentials</td>
-      </tr>
-      <tr>
-        <td>credentials.delete</td>
-        <td>delete existing credentials</td>
-      </tr>
-      <tr>
-        <td>credentials.read</td>
-        <td>retrieve credentials</td>
-      </tr>
-      <tr>
-        <td>credentials.update</td>
-        <td>update existing credentials</td>
-      </tr>
-  </tbody>
-<table>
+{% codeblock %}
+"credentials.create"
+"credentials.delete"
+"credentials.read"
+"credentials.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Stats{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>email_activity.read</td>
-        <td>retrieve email activity</td>
-      </tr>
-      <tr>
-        <td>stats.read</td>
-        <td>retrieve stats</td>
-      </tr>
-      <tr>
-        <td>stats.global.read</td>
-        <td>retrieve global stats</td>
-      </tr>
-      <tr>
-        <td>browsers.stats.read</td>
-        <td>retrieve browser stats</td>
-      </tr>
-      <tr>
-        <td>devices.stats.read</td>
-        <td>retrieve device stats</td>
-      </tr>
-      <tr>
-        <td>geo.stats.read</td>
-        <td>retrieve geographical stats</td>
-      </tr>
-      <tr>
-        <td>mailbox_providers.stats.read</td>
-        <td>retrieve stats for mailbox providers</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"email_activity.read"
+"stats.read"
+"stats.global.read"
+"browsers.stats.read"
+"devices.stats.read"
+"geo.stats.read"
+"mailbox_providers.stats.read"
+{% endcodeblock %}
 
 {% anchor h2 %}IPs{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>ips.assigned.read</td>
-        <td>retrieve assigned IPs</td>
-      </tr>
-      <tr>
-        <td>ips.read</td>
-        <td>retrieve all IPs</td>
-      </tr>
-      <tr>
-        <td>ips.pools.create</td>
-        <td>create new IP pools</td>
-      </tr>
-      <tr>
-        <td>ips.pools.delete</td>
-        <td>delete an existing IP pool</td>
-      </tr>
-      <tr>
-        <td>ips.pools.read</td>
-        <td>retrieve IP pools</td>
-      </tr>
-      <tr>
-        <td>ips.pools.update</td>
-        <td>update existing IP pools</td>
-      </tr>
-      <tr>
-        <td>ips.pools.ips.create</td>
-        <td>add an IP to an IP pool</td>
-      </tr>
-      <tr>
-        <td>ips.pools.ips.delete</td>
-        <td>remove an IP from an IP pool</td>
-      </tr>
-      <tr>
-        <td>ips.warmup.create</td>
-        <td>add IPs to the warmup group</td>
-      </tr>
-      <tr>
-        <td>ips.warmup.delete</td>
-        <td>remove an IP from the warmup group</td>
-      </tr>
-      <tr>
-        <td>ips.warmup.read</td>
-        <td>retrieve IPs in the warmup pool</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"ips.assigned.read"
+"ips.read"
+"ips.pools.create"
+"ips.pools.delete"
+"ips.pools.read"
+"ips.pools.update"
+"ips.pools.ips.create"
+"ips.pools.ips.delete"
+"ips.warmup.create"
+"ips.warmup.delete"
+"ips.warmup.read"
+{% endcodeblock %}
 
 {% anchor h2 %}Mail Settings{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>mail_settings.address_whitelist.read</td>
-        <td>retrieve settings for address whitelisting</td>
-      </tr>
-      <tr>
-        <td>mail_settings.address_whitelist.update</td>
-        <td>modify settings for address whitelisting</td>
-      </tr>
-      <tr>
-        <td>mail_settings.bcc.read</td>
-        <td>retrieve settings for bcc</td>
-      </tr>
-      <tr>
-        <td>mail_settings.bcc.update</td>
-        <td>modify settings for bcc</td>
-      </tr>
-      <tr>
-        <td>mail_settings.bounce_purge.read</td>
-        <td>retrieve settings for bounce purges</td>
-      </tr>
-      <tr>
-        <td>mail_settings.bounce_purge.update</td>
-        <td>modify settings for bounce purges</td>
-      </tr>
-      <tr>
-        <td>mail_settings.footer.read</td>
-        <td>retrieve settings for email footers</td>
-      </tr>
-      <tr>
-        <td>mail_settings.footer.update</td>
-        <td>modify settings for email footers</td>
-      </tr>
-      <tr>
-        <td>mail_settings.forward_bounce.read</td>
-        <td>retrieve settings for bounce forwarding</td>
-      </tr>
-      <tr>
-        <td>mail_settings.forward_bounce.update</td>
-        <td>modify settings for bounce forwarding</td>
-      </tr>
-      <tr>
-        <td>mail_settings.forward_spam.read</td>
-        <td>retrieve settings for spam forwarding</td>
-      </tr>
-      <tr>
-        <td>mail_settings.forward_spam.update</td>
-        <td>modify settings for spam forwarding</td>
-      </tr>
-      <tr>
-        <td>mail_settings.plain_content.read</td>
-        <td>retrieve settings for plain text conversion</td>
-      </tr>
-      <tr>
-        <td>mail_settings.plain_content.update</td>
-        <td>modify settings for plain text conversion</td>
-      </tr>
-      <tr>
-        <td>mail_settings.read</td>
-        <td>retrieve a list of the available mail settings</td>
-      </tr>
-      <tr>
-        <td>mail_settings.spam_check.read</td>
-        <td>retrieve settings for spam checking</td>
-      </tr>
-      <tr>
-        <td>mail_settings.spam_check.update</td>
-        <td>modify settings for spam checking</td>
-      </tr>
-      <tr>
-        <td>mail_settings.template.read</td>
-        <td>retrieve settings for templating</td>
-      </tr>
-      <tr>
-        <td>mail_settings.template.update</td>
-        <td>modify settings for templating</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"mail_settings.address_whitelist.read"
+"mail_settings.address_whitelist.update"
+"mail_settings.bcc.read"
+"mail_settings.bcc.update"
+"mail_settings.bounce_purge.read"
+"mail_settings.bounce_purge.update"
+"mail_settings.footer.read"
+"mail_settings.footer.update"
+"mail_settings.forward_bounce.read"
+"mail_settings.forward_bounce.update"
+"mail_settings.forward_spam.read"
+"mail_settings.forward_spam.update"
+"mail_settings.plain_content.read"
+"mail_settings.plain_content.update"
+"mail_settings.read"
+"mail_settings.spam_check.read"
+"mail_settings.spam_check.update"
+"mail_settings.template.read"
+"mail_settings.template.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Mail{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>mail.batch.create</td>
-        <td>create batch id for schedule and cancel scheduled sends</td>
-      </tr>
-      <tr>
-        <td>mail.batch.delete</td>
-        <td>delete batch id for schedule and cancel scheduled sends</td>
-      </tr>
-      <tr>
-        <td>mail.batch.read</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>mail.batch.update</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>mail.send</td>
-        <td>send mail</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"mail.batch.create"
+"mail.batch.delete"
+"mail.batch.read"
+"mail.batch.update"
+"mail.send"
+{% endcodeblock %}
 
 {% anchor h2 %}Marketing Campaigns{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>marketing_campaigns.create</td>
-        <td>perform POST operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-        <td>marketing_campaigns.delete</td>
-        <td>perform DELETE operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-        <td>marketing_campaigns.read</td>
-        <td>perform GET operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-        <td>marketing_campaigns.update</td>
-        <td>perform PUT/PATCH operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-        <td>partner_settings.new_relic.read</td>
-        <td>retrieve settings for the New Relic integration</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"marketing_campaigns.create"
+"marketing_campaigns.delete"
+"marketing_campaigns.read"
+"marketing_campaigns.update"
+"partner_settings.new_relic.read"
+{% endcodeblock %}
 
 {% anchor h2 %}Partner Settings{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>partner_settings.new_relic.update</td>
-        <td>modify settings for the New Relic integration</td>
-      </tr>
-      <tr>
-        <td>partner_settings.read</td>
-        <td>retrieve a list of the available partner settings</td>
-      </tr>
-      <tr>
-        <td>partner_settings.sendwithus.read</td>
-        <td>retrieve settings for the SendWithUs integration</td>
-      </tr>
-      <tr>
-        <td>partner_settings.sendwithus.update</td>
-        <td>modify settings for the SendWithUs integration</td>
-      </tr>
-  </tbody>
-</table>
+"partner_settings.new_relic.update"
+"partner_settings.read"
+"partner_settings.sendwithus.read"
+"partner_settings.sendwithus.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Scheduled Sends{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>user.scheduled_sends.create</td>
-        <td>create new scheduled send</td>
-      </tr>
-      <tr>
-        <td>user.scheduled_sends.delete</td>
-        <td>delete existing scheduled send</td>
-      </tr>
-      <tr>
-        <td>user.scheduled_sends.read</td>
-        <td>retrieve scheduled send</td>
-      </tr>
-      <tr>
-        <td>user.scheduled_sends.update</td>
-        <td>update existing scheduled send</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"user.scheduled_sends.create"
+"user.scheduled_sends.delete"
+"user.scheduled_sends.read"
+"user.scheduled_sends.update"
+{% endcodeblock %}
 
 {% anchor h2 %}Subusers{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>subusers.create</td>
-        <td>create new subusers</td>
-      </tr>
-      <tr>
-        <td>subusers.delete</td>
-        <td>delete existing subusers</td>
-      </tr>
-      <tr>
-        <td>subusers.read</td>
-        <td>retrieve subusers</td>
-      </tr>
-      <tr>
-        <td>subusers.update</td>
-        <td>update existing subusers</td>
-      </tr>
-      <tr>
-        <td>subusers.credits.read</td>
-        <td>retrieve a subuser's credit allocations</td>
-      </tr>
-      <tr>
-        <td>subusers.credits.update</td>
-        <td>update a subuser's credit allocations</td>
-      </tr>
-      <tr>
-        <td>subusers.credits.remaining.update</td>
-        <td>update a subuser's remaining credits</td>
-      </tr>
-      <tr>
-        <td>subusers.monitor.create</td>
-        <td>create a monitor on the subuser</td>
-      </tr>
-      <tr>
-        <td>subusers.monitor.delete</td>
-        <td>delete an existing monitor from the subuser</td>
-      </tr>
-      <tr>
-        <td>subusers.monitor.read</td>
-        <td>retrieve a monitor on a subuser</td>
-      </tr>
-      <tr>
-        <td>subusers.monitor.update</td>
-        <td>update an existing monitor on the subuser</td>
-      </tr>
-      <tr>
-        <td>subusers.reputations.read</td>
-        <td>retrieve subuser reputations</td>
-      </tr>
-      <tr>
-        <td>subusers.stats.read</td>
-        <td>retrieve subuser stats</td>
-      </tr>
-      <tr>
-        <td>subusers.stats.monthly.read</td>
-        <td>retrieve subuser monthly stats</td>
-      </tr>
-      <tr>
-        <td>subusers.stats.sums.read</td>
-        <td>retrieve summed subser stats</td>
-      </tr>
-      <tr>
-        <td>subusers.summary.read</td>
-        <td>retrieve a summary of subsers</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock %}
+"subusers.create"
+"subusers.delete"
+"subusers.read"
+"subusers.update"
+"subusers.credits.read"
+"subusers.credits.update"
+"subusers.credits.remaining.update"
+"subusers.monitor.create"
+"subusers.monitor.delete"
+"subusers.monitor.read"
+"subusers.monitor.update"
+"subusers.reputations.read"
+"subusers.stats.read"
+"subusers.stats.monthly.read"
+"subusers.stats.sums.read"
+"subusers.stats.summary.read"
+{% endcodeblock %}
 
 {% anchor h2 %}Suppressions{% endanchor %}
 <table class="table table-bordered table-striped">

--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -48,507 +48,309 @@ The following is a complete list of all possible permissions that you may assign
 </div>
 
 {% anchor h2 %}Alerts{% endanchor %}
-{% codeblock %}
-"alerts.create"
-"alerts.delete"
-"alerts.read"
-"alerts.update"
+{% codeblock lang:json %}
+"scopes": [
+  "alerts.create",
+  "alerts.delete",
+  "alerts.read",
+  "alerts.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}API Keys{% endanchor %}
-{% codeblock %}
-"api_keys.create"
-"api_keys.delete"
-"api_keys.read"
-"api_keys.update"
+{% codeblock lang:json %}
+"scopes": [
+  "api_keys.create",
+  "api_keys.delete",
+  "api_keys.read",
+  "api_keys.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}ASM Groups{% endanchor %}
-{% codeblock %}
-"asm.groups.create"
-"asm.groups.delete"
-"asm.groups.read"
-"asm.groups.update"
+{% codeblock lang:json %}
+"scopes": [
+  "asm.groups.create",
+  "asm.groups.delete",
+  "asm.groups.read",
+  "asm.groups.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Billing{% endanchor %}
-{% codeblock %}
-"billing.delete"
-"billing.read"
-"billing.update"
+{% codeblock lang:json %}
+"scopes": [
+  "billing.delete",
+  "billing.read",
+  "billing.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Categories{% endanchor %}
-{% codeblock %}
-"categories.create"
-"categories.delete"
-"categories.read"
-"categories.update"
-"categories.stats.read"
-"categories.stats.sums.read"
+{% codeblock lang:json %}
+"scopes": [
+  "categories.create",
+  "categories.delete",
+  "categories.read",
+  "categories.update",
+  "categories.stats.read",
+  "categories.stats.sums.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Clients{% endanchor %}
-{% codeblock %}
-"clients.desktop.stats.read"
-"clients.phone.stats.read"
-"clients.stats.read"
-"clients.tablet.stats.read"
-"clients.webmail.stats.read"
+{% codeblock lang:json %}
+"scopes": [
+  "clients.desktop.stats.read",
+  "clients.phone.stats.read",
+  "clients.stats.read",
+  "clients.tablet.stats.read",
+  "clients.webmail.stats.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Credentials{% endanchor %}
-{% codeblock %}
-"credentials.create"
-"credentials.delete"
-"credentials.read"
-"credentials.update"
+{% codeblock lang:json %}
+"scopes": [
+  "credentials.create",
+  "credentials.delete",
+  "credentials.read",
+  "credentials.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Stats{% endanchor %}
-{% codeblock %}
-"email_activity.read"
-"stats.read"
-"stats.global.read"
-"browsers.stats.read"
-"devices.stats.read"
-"geo.stats.read"
-"mailbox_providers.stats.read"
+{% codeblock lang:json %}
+"scopes": [
+  "email_activity.read",
+  "stats.read",
+  "stats.global.read",
+  "browsers.stats.read",
+  "devices.stats.read",
+  "geo.stats.read",
+  "mailbox_providers.stats.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}IPs{% endanchor %}
-{% codeblock %}
-"ips.assigned.read"
-"ips.read"
-"ips.pools.create"
-"ips.pools.delete"
-"ips.pools.read"
-"ips.pools.update"
-"ips.pools.ips.create"
-"ips.pools.ips.delete"
-"ips.warmup.create"
-"ips.warmup.delete"
-"ips.warmup.read"
+{% codeblock lang:json %}
+"scopes": [
+  "ips.assigned.read",
+  "ips.read",
+  "ips.pools.create",
+  "ips.pools.delete",
+  "ips.pools.read",
+  "ips.pools.update",
+  "ips.pools.ips.create",
+  "ips.pools.ips.delete",
+  "ips.warmup.create",
+  "ips.warmup.delete",
+  "ips.warmup.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Mail Settings{% endanchor %}
-{% codeblock %}
-"mail_settings.address_whitelist.read"
-"mail_settings.address_whitelist.update"
-"mail_settings.bcc.read"
-"mail_settings.bcc.update"
-"mail_settings.bounce_purge.read"
-"mail_settings.bounce_purge.update"
-"mail_settings.footer.read"
-"mail_settings.footer.update"
-"mail_settings.forward_bounce.read"
-"mail_settings.forward_bounce.update"
-"mail_settings.forward_spam.read"
-"mail_settings.forward_spam.update"
-"mail_settings.plain_content.read"
-"mail_settings.plain_content.update"
-"mail_settings.read"
-"mail_settings.spam_check.read"
-"mail_settings.spam_check.update"
-"mail_settings.template.read"
-"mail_settings.template.update"
+{% codeblock lang:json %}
+"scopes": [
+  "mail_settings.address_whitelist.read",
+  "mail_settings.address_whitelist.update",
+  "mail_settings.bcc.read",
+  "mail_settings.bcc.update",
+  "mail_settings.bounce_purge.read",
+  "mail_settings.bounce_purge.update",
+  "mail_settings.footer.read",
+  "mail_settings.footer.update",
+  "mail_settings.forward_bounce.read",
+  "mail_settings.forward_bounce.update",
+  "mail_settings.forward_spam.read",
+  "mail_settings.forward_spam.update",
+  "mail_settings.plain_content.read",
+  "mail_settings.plain_content.update",
+  "mail_settings.read",
+  "mail_settings.spam_check.read",
+  "mail_settings.spam_check.update",
+  "mail_settings.template.read",
+  "mail_settings.template.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Mail{% endanchor %}
-{% codeblock %}
-"mail.batch.create"
-"mail.batch.delete"
-"mail.batch.read"
-"mail.batch.update"
-"mail.send"
+{% codeblock lang:json %}
+"scopes": [
+  "mail.batch.create",
+  "mail.batch.delete",
+  "mail.batch.read",
+  "mail.batch.update",
+  "mail.send"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Marketing Campaigns{% endanchor %}
-{% codeblock %}
-"marketing_campaigns.create"
-"marketing_campaigns.delete"
-"marketing_campaigns.read"
-"marketing_campaigns.update"
-"partner_settings.new_relic.read"
+{% codeblock lang:json %}
+"scopes": [
+  "marketing_campaigns.create",
+  "marketing_campaigns.delete",
+  "marketing_campaigns.read",
+  "marketing_campaigns.update",
+  "partner_settings.new_relic.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Partner Settings{% endanchor %}
-"partner_settings.new_relic.update"
-"partner_settings.read"
-"partner_settings.sendwithus.read"
-"partner_settings.sendwithus.update"
+{% codeblock lang:json %}
+"scopes": [
+  "partner_settings.new_relic.update",
+  "partner_settings.read",
+  "partner_settings.sendwithus.read",
+  "partner_settings.sendwithus.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Scheduled Sends{% endanchor %}
-{% codeblock %}
-"user.scheduled_sends.create"
-"user.scheduled_sends.delete"
-"user.scheduled_sends.read"
-"user.scheduled_sends.update"
+{% codeblock lang:json %}
+"scopes": [
+  "user.scheduled_sends.create",
+  "user.scheduled_sends.delete",
+  "user.scheduled_sends.read",
+  "user.scheduled_sends.update"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Subusers{% endanchor %}
-{% codeblock %}
-"subusers.create"
-"subusers.delete"
-"subusers.read"
-"subusers.update"
-"subusers.credits.read"
-"subusers.credits.update"
-"subusers.credits.remaining.update"
-"subusers.monitor.create"
-"subusers.monitor.delete"
-"subusers.monitor.read"
-"subusers.monitor.update"
-"subusers.reputations.read"
-"subusers.stats.read"
-"subusers.stats.monthly.read"
-"subusers.stats.sums.read"
-"subusers.stats.summary.read"
+{% codeblock lang:json %}
+"scopes": [
+  "subusers.create",
+  "subusers.delete",
+  "subusers.read",
+  "subusers.update",
+  "subusers.credits.read",
+  "subusers.credits.update",
+  "subusers.credits.remaining.update",
+  "subusers.monitor.create",
+  "subusers.monitor.delete",
+  "subusers.monitor.read",
+  "subusers.monitor.update",
+  "subusers.reputations.read",
+  "subusers.stats.read",
+  "subusers.stats.monthly.read",
+  "subusers.stats.sums.read",
+  "subusers.stats.summary.read"
+]
 {% endcodeblock %}
 
 {% anchor h2 %}Suppressions{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>suppression.create</td>
-        <td>create a new suppression</td>
-      </tr>
-      <tr>
-        <td>suppression.delete</td>
-        <td>delete an existing suppression</td>
-      </tr>
-      <tr>
-        <td>suppression.read</td>
-        <td>retrieve suppressions</td>
-      </tr>
-      <tr>
-        <td>suppression.update</td>
-        <td>update an existing suppression</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "suppressions.create",
+  "suppressions.delete",
+  "suppressions.read",
+  "suppressions.update"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}Templates{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>templates.create</td>
-        <td>create a template</td>
-      </tr>
-      <tr>
-        <td>templates.delete</td>
-        <td>delete a template</td>
-      </tr>
-      <tr>
-        <td>templates.read</td>
-        <td>retreive a template</td>
-      </tr>
-      <tr>
-        <td>templates.update</td>
-        <td>update a template</td>
-      </tr>
-      <tr>
-        <td>templates.versions.activate.create</td>
-        <td>sets the "active" field to 1 for specified version template</td>
-      </tr>
-      <tr>
-        <td>templates.versions.activate.delete</td>
-        <td>sets the "active" field to 0 for specified version template</td>
-      </tr>
-      <tr>
-        <td>templates.versions.activate.read</td>
-        <td>retrieve the active version for specified template</td>
-      </tr>
-      <tr>
-        <td>templates.versions.activate.update</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>templates.versions.create</td>
-        <td>create a template version</td>
-      </tr>
-      <tr>
-        <td>templates.versions.delete</td>
-        <td>delete a template version</td>
-      </tr>
-      <tr>
-        <td>templates.versions.read</td>
-        <td>retrieve a specific version of a template</td>
-      </tr>
-      <tr>
-        <td>templates.versions.update</td>
-        <td>update a template version</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "templates.create",
+  "templates.delete",
+  "templates.read",
+  "templates.update",
+  "templates.versions.activate.create",
+  "templates.versions.activate.delete",
+  "templates.versions.activate.read",
+  "templates.versions.activate.update",
+  "templates.versions.create",
+  "templates.versions.delete",
+  "templates.versions.read",
+  "templates.versions.update"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}Tracking{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>tracking_settings.click.read</td>
-        <td>retrieve settings for click tracking</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.click.update</td>
-        <td>modify settings for click tracking</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.google_analytics.read</td>
-        <td>retrieve settings for google analytics</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.google_analytics.update</td>
-        <td>modify settings for google analytics</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.open.read</td>
-        <td>retrive settings for open tracking</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.open.update</td>
-        <td>modify settings for open tracking</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.read</td>
-        <td>retrive a list of the available tracking settings</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.subscription.read</td>
-        <td>retrieve settings for subscription tracking</td>
-      </tr>
-      <tr>
-        <td>tracking_settings.subscription.update</td>
-        <td>modify settings for subscription tracking</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "tracking_settings.click.read",
+  "tracking_settings.click.update",
+  "tracking_settings.google_analytics.read",
+  "tracking_settings.google_analytics.update",
+  "tracking_settings.open.read",
+  "tracking_settings.open.update",
+  "tracking_settings.read",
+  "tracking_settings.subscription.read",
+  "tracking_settings.subscription.update"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}User Settings{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>user.account.create</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.account.delete</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.account.read</td>
-        <td>retrieve user account information</td>
-      </tr>
-      <tr>
-        <td>user.account.update</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.credits.create</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.credits.delete</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.credits.read</td>
-        <td>retrieve user credit information</td>
-      </tr>
-      <tr>
-        <td>user.credits.update</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.email.create</td>
-        <td>create new email</td>
-      </tr>
-      <tr>
-        <td>user.email.delete</td>
-        <td>delete existing email</td>
-      </tr>
-      <tr>
-        <td>user.email.read</td>
-        <td>retrieve email</td>
-      </tr>
-      <tr>
-        <td>user.email.update</td>
-        <td>update existing email</td>
-      </tr>
-      <tr>
-        <td>user.multifactor_authentication.create</td>
-        <td>add multifactor authentication to your account</td>
-      </tr>
-      <tr>
-        <td>user.multifactor_authentication.delete</td>
-        <td>delete multifactor authentication from your account</td>
-      </tr>
-      <tr>
-        <td>user.multifactor_authentication.read</td>
-        <td>retrieve multifactor authentication</td>
-      </tr>
-      <tr>
-        <td>user.multifactor_authentication.update</td>
-        <td>update existing multifactor authentication</td>
-      </tr>
-      <tr>
-        <td>user.password.create</td>
-        <td>create new password</td>
-      </tr>
-      <tr>
-        <td>user.password.delete</td>
-        <td>delete existing password</td>
-      </tr>
-      <tr>
-        <td>user.password.read</td>
-        <td>retrieve password</td>
-      </tr>
-      <tr>
-        <td>user.password.update</td>
-        <td>update existing password</td>
-      </tr>
-      <tr>
-        <td>user.profile.create</td>
-        <td>create new profile</td>
-      </tr>
-      <tr>
-        <td>user.profile.delete</td>
-        <td>delete existing profile</td>
-      </tr>
-      <tr>
-        <td>user.profile.read</td>
-        <td>retrieve profile</td>
-      </tr>
-      <tr>
-        <td>user.profile.update</td>
-        <td>update existing profile</td>
-      </tr>
-      <tr>
-        <td>user.settings.enforced_tls.create</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.settings.enforced_tls.delete</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>user.settings.enforced_tls.read</td>
-        <td>retrieve enforced TLS settings</td>
-      </tr>
-      <tr>
-        <td>user.settings.enforced_tls.update</td>
-        <td>update enforced TLS settings</td>
-      </tr>
-      <tr>
-        <td>user.timezone.create</td>
-        <td>create new timezone</td>
-      </tr>
-      <tr>
-        <td>user.timezone.delete</td>
-        <td>delete existing timezone</td>
-      </tr>
-      <tr>
-        <td>user.timezone.read</td>
-        <td>retrieve timezone</td>
-      </tr>
-      <tr>
-        <td>user.timezone.update</td>
-        <td>update existing timezone</td>
-      </tr>
-      <tr>
-        <td>user.username.create</td>
-        <td>create new username</td>
-      </tr>
-      <tr>
-        <td>user.username.delete</td>
-        <td>delete existing username</td>
-      </tr>
-      <tr>
-        <td>user.username.read</td>
-        <td>retrieve username</td>
-      </tr>
-      <tr>
-        <td>user.username.update</td>
-        <td>update existing username</td>
-      </tr>
-    </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "user.account.create",
+  "user.account.delete",
+  "user.account.read",
+  "user.account.update",
+  "user.credits.create",
+  "user.credits.delete",
+  "user.credits.read",
+  "user.credits.update",
+  "user.email.create",
+  "user.email.delete",
+  "user.email.read",
+  "user.email.update",
+  "user.multifactor_authentication.create",
+  "user.multifactor_authentication.delete",
+  "user.multifactor_authentication.read",
+  "user.multifactor_authentication.update",
+  "user.password.create",
+  "user.password.delete",
+  "user.password.read",
+  "user.password.update",
+  "user.profile.create",
+  "user.profile.delete",
+  "user.profile.read",
+  "user.profile.update",
+  "user.settings.enforced_tls.create",
+  "user.settings.enforced_tls.delete",
+  "user.settings.enforced_tls.read",
+  "user.settings.enforced_tls.update",
+  "user.timezone.create",
+  "user.timezone.delete",
+  "user.timezone.read",
+  "user.timezone.update",
+  "user.username.create",
+  "user.username.delete",
+  "user.username.read",
+  "user.username.update"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}Webhook{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>user.webhooks.event.settings.read</td>
-        <td>retrieve event webhook settings</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.event.settings.update</td>
-        <td>modify event webhook settings</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.parse.settings.create</td>
-        <td>create a hostname and url for parsing incoming mail</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.parse.settings.delete</td>
-        <td>delete existing settings for parsing incoming mail</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.parse.settings.read</td>
-        <td>retrieve settings for parsing incoming mail</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.parse.settings.update</td>
-        <td>update settings for parse incoming mail</td>
-      </tr>
-      <tr>
-        <td>user.webhooks.parse.stats.read</td>
-        <td>retrieve parse webhook stats</td>
-      </tr>
-  </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "user.webhooks.event.settings.read",
+  "user.webhooks.event.settings.update",
+  "user.webhooks.parse.settings.create",
+  "user.webhooks.parse.settings.delete",
+  "user.webhooks.parse.settings.read",
+  "user.webhooks.parse.settings.update",
+  "user.webhooks.parse.stats.read"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}Whitelabel{% endanchor %}
-<table class="table table-bordered table-striped">
-  <tbody>
-      <tr>
-        <td>whitelabel.create</td>
-        <td>create whitelabels</td>
-      </tr>
-      <tr>
-        <td>whitelabel.delete</td>
-        <td>delete existing whitelabels</td>
-      </tr>
-      <tr>
-        <td>whitelabel.read</td>
-        <td>retrieve whitelabels</td>
-      </tr>
-      <tr>
-        <td>whitelabel.update</td>
-        <td>update existing whitelabels</td>
-      </tr>
-    </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "whitelabel.create",
+  "whitelabel.delete",
+  "whitelabel.read",
+  "whitelabel.update"
+]
+{% endcodeblock %}
 
 {% anchor h2 %}Whitelist{% endanchor %}
-<table class="table table-bordered table-striped">
-    <tbody>
-      <tr>
-        <th>access_settings.whitelist.create</th>
-        <th>create new whitelist entries for account access</th>
-      </tr>
-      <tr>
-        <td>access_settings.whitelist.delete</td>
-        <td>delete existing whitelist entries for account access</td>
-      </tr>
-      <tr>
-        <td>access_settings.whitelist.read</td>
-        <td>retrieve whitelist entries for account access</td>
-      </tr>
-      <tr>
-        <td>access_settings.whitelist.update</td>
-        <td>update existing whitelist entries for account access</td>
-      </tr>
-    </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "access_settings.whitelist.delete",
+  "access_settings.whitelist.read",
+  "access_settings.whitelist.update"
+]
+{% endcodeblock %}

--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -85,26 +85,41 @@ Several specific use cases for an API Key and the permissions that you might wan
 Example Permissions for Common API Key Use Cases
 {% endanchor h2 %}
 
+<ul>
+  <li><a href="#-Read-Only-Access-for-Mail-Send">Mail Send: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Mail-Send">Mail Send: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Alerts">Alerts: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Alerts">Alerts: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Stats">Stats: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Stats">Stats: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Suppressions">Suppressions: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Suppressions">Suppressions: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Whitelabels">Whitelabels: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Whitelables">Whitelabels: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-IP-Management">IP Management: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-IP-Manaagement">IP Management: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Templates">Templates: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Templates">Templates: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Inbound-Parse">Inbound Parse: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Inbound-Parse">Inbound Parse: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Mail-Settings">Mail Settings: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Mail-Settings">Mail Settings: Full Access</a></li>
+  <li><a href="#-Read-Only-Access-for-Marketing-Campaigns">Marketing Campaigns: Read Only Access</a></li>
+  <li><a href="#-Full-Access-for-Marketing-Campaigns">Marketing Campaigns: Full Access</a></li>
+</ul>
+
 {% anchor h3 %}
-Billing
-{% endanchor h3 %}
-
-An API Key for authenticating billing related API calls should be given the following permissions.
-
+Read Only Access for Mail Send
+{% endanchor %}
 {% codeblock lang:json %}
 "scopes": [
-  "billing.delete",
-  "billing.read",
-  "billing.update"
+  "mail.batch.read"
 ]
 {% endcodeblock %}
 
 {% anchor h3 %}
-Mail
-{% endanchor h3 %}
-
-If you were to create an API Key for authenticating API calls that result in creating, sending, reading, and deleting emails, you would want to assign that key the following permissions.
-
+Full Access for Mail Send
+{% endanchor %}
 {% codeblock lang:json %}
 "scopes": [
   "mail.batch.create",
@@ -116,44 +131,231 @@ If you were to create an API Key for authenticating API calls that result in cre
 {% endcodeblock %}
 
 {% anchor h3 %}
-Marketing Campaigns
-{% endanchor h3 %}
-
-An API Key used only to authenticate API calls that relate specifically to Marketing Campaigns should include the following permissions.
-
+Read Only Access for Alerts
+{% endanchor %}
 {% codeblock lang:json %}
 "scopes": [
-  "marketing_campaigns.create",
-  "marketing_campaigns.delete",
-  "marketing_campaigns.read",
-  "marketing_campaigns.update"
+  "alerts.read"
 ]
 {% endcodeblock %}
 
 {% anchor h3 %}
-Stats
-{% endanchor h3 %}
-
-To limit who can access your statistics, create an API Key with the following permissions. Stats do not have "full access" because it would be impossible for you to change your stats via an API call.
-
+Full Access for Alerts
+{% endanchor %}
 {% codeblock lang:json %}
-"stats": [
-  "stats.read",
-  "stats.global.read"
+"scopes": [
+  "alerts.create",
+  "alerts.delete",
+  "alerts.read",
+  "alerts.update"
 ]
 {% endcodeblock %}
 
 {% anchor h3 %}
-Whitelabel
-{% endanchor h3 %}
+Read Only Access for Stats
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "email_activity.read",
+  "stats.read",
+  "stats.global.read",
+  "browsers.stats.read",
+  "devices.stats.read",
+  "geo.stats.read",
+  "mailbox_providers.stats.read"
+]
+{% endcodeblock %}
 
-An API Key for authenticating API calls that can create, change, and remove whitelabel information would require the the following permissions.
+{% anchor h3 %}
+Read Only Access for Suppressions
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "suppressions.read"
+]
+{% endcodeblock %}
 
+{% anchor h3 %}
+Full Access for Suppressions
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "suppressions.create",
+  "suppressions.delete",
+  "suppressions.read",
+  "suppressions.update"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for Whitelabels
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "whitelabel.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for Whitelabels
+{% endanchor %}
 {% codeblock lang:json %}
 "scopes": [
   "whitelabel.create",
   "whitelabel.delete",
   "whitelabel.read",
   "whitelabel.update"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for IP Management
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "ips.assigned.read",
+  "ips.read",
+  "ips.pools.read",
+  "ips.warmup.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for IP Management
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "ips.assigned.read",
+  "ips.read",
+  "ips.pools.create",
+  "ips.pools.delete",
+  "ips.pools.read",
+  "ips.pools.update",
+  "ips.pools.ips.create",
+  "ips.pools.ips.delete",
+  "ips.warmup.create",
+  "ips.warmup.delete",
+  "ips.warmup.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for Templates
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "templates.read",
+  "templates.versions.activate.read",
+  "templates.versions.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for Templates
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "templates.create",
+  "templates.delete",
+  "templates.read",
+  "templates.update",
+  "templates.versions.activate.create",
+  "templates.versions.activate.delete",
+  "templates.versions.activate.read",
+  "templates.versions.activate.update",
+  "templates.versions.create",
+  "templates.versions.delete",
+  "templates.versions.read",
+  "templates.versions.update"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for Inbound Parse
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "user.webhooks.parse.settings.read",
+  "user.webhooks.parse.stats.read"
+  ]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for Inbound Parse
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "user.webhooks.parse.settings.create",
+  "user.webhooks.parse.settings.delete",
+  "user.webhooks.parse.settings.read",
+  "user.webhooks.parse.settings.update",
+  "user.webhooks.parse.stats.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for Mail Settings
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "mail_settings.address_whitelist.read",
+  "mail_settings.bcc.read",
+  "mail_settings.bounce_purge.read",
+  "mail_settings.footer.read",
+  "mail_settings.forward_bounce.read",
+  "mail_settings.forward_spam.read",
+  "mail_settings.plain_content.read",
+  "mail_settings.read",
+  "mail_settings.spam_check.read",
+  "mail_settings.template.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for Mail Settings
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "mail_settings.address_whitelist.read",
+  "mail_settings.address_whitelist.update",
+  "mail_settings.bcc.read",
+  "mail_settings.bcc.update",
+  "mail_settings.bounce_purge.read",
+  "mail_settings.bounce_purge.update",
+  "mail_settings.footer.read",
+  "mail_settings.footer.update",
+  "mail_settings.forward_bounce.read",
+  "mail_settings.forward_bounce.update",
+  "mail_settings.forward_spam.read",
+  "mail_settings.forward_spam.update",
+  "mail_settings.plain_content.read",
+  "mail_settings.plain_content.update",
+  "mail_settings.read",
+  "mail_settings.spam_check.read",
+  "mail_settings.spam_check.update",
+  "mail_settings.template.read",
+  "mail_settings.template.update"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Read Only Access for Marketing Campaigns
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "marketing_campaigns.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Full Access for Marketing Campaigns
+{% endanchor %}
+{% codeblock lang:json %}
+"scopes": [
+  "marketing_campaigns.create",
+  "marketing_campaigns.delete",
+  "marketing_campaigns.read",
+  "marketing_campaigns.update",
+  "partner_settings.new_relic.read"
 ]
 {% endcodeblock %}

--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -91,22 +91,13 @@ Billing
 
 An API Key for authenticating billing related API calls should be given the following permissions.
 
-<table class="table table-bordered table-striped">
-   <tbody>
-      <tr>
-         <td>billing.delete</td>
-         <td>Perform a cancellation of the account</td>
-      </tr>
-      <tr>
-         <td>billing.read</td>
-         <td>Retrieve billing information and invoices</td>
-      </tr>
-      <tr>
-         <td>billing.update</td>
-         <td>Modify billing information, including the ability to perform package changes</td>
-      </tr>
-   </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "billing.delete",
+  "billing.read",
+  "billing.update"
+]
+{% endcodeblock %}
 
 {% anchor h3 %}
 Mail
@@ -114,30 +105,15 @@ Mail
 
 If you were to create an API Key for authenticating API calls that result in creating, sending, reading, and deleting emails, you would want to assign that key the following permissions.
 
-<table class="table table-bordered table-striped">
-   <tbody>
-      <tr>
-         <td>mail.batch.create</td>
-         <td>Create batch id for schedule and cancel scheduled sends</td>
-      </tr>
-      <tr>
-         <td>mail.batch.delete</td>
-         <td>Delete batch id for schedule and cancel scheduled sends</td>
-      </tr>
-      <tr>
-         <td>mail.batch.read</td>
-         <td></td>
-      </tr>
-      <tr>
-         <td>mail.batch.update</td>
-         <td></td>
-      </tr>
-      <tr>
-         <td>mail.send</td>
-         <td>Send mail</td>
-      </tr>
-   </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "mail.batch.create",
+  "mail.batch.delete",
+  "mail.batch.read",
+  "mail.batch.update",
+  "mail.send"
+]
+{% endcodeblock %}
 
 {% anchor h3 %}
 Marketing Campaigns
@@ -145,26 +121,14 @@ Marketing Campaigns
 
 An API Key used only to authenticate API calls that relate specifically to Marketing Campaigns should include the following permissions.
 
-<table class="table table-bordered table-striped">
-   <tbody>
-      <tr>
-         <td>marketing_campaigns.create</td>
-         <td>Perform POST operations on marketing campaigns</td>
-      </tr>
-      <tr>
-         <td>marketing_campaigns.delete</td>
-         <td>perform DELETE operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-         <td>marketing_campaigns.read</td>
-         <td>perform GET operations on marketing campaign APIs</td>
-      </tr>
-      <tr>
-         <td>marketing_campaigns.update</td>
-         <td>perform PUT/PATCH operations on marketing campaign APIs</td>
-      </tr>
-   </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "marketing_campaigns.create",
+  "marketing_campaigns.delete",
+  "marketing_campaigns.read",
+  "marketing_campaigns.update"
+]
+{% endcodeblock %}
 
 {% anchor h3 %}
 Stats
@@ -172,18 +136,12 @@ Stats
 
 To limit who can access your statistics, create an API Key with the following permissions. Stats do not have "full access" because it would be impossible for you to change your stats via an API call.
 
-<table class="table table-bordered table-striped">
-   <tbody>
-      <tr>
-         <td>stats.read</td>
-         <td>Retreive stats</td>
-      </tr>
-      <tr>
-         <td>stats.global.read</td>
-         <td>Retrieve global stats</td>
-      </tr>
-   </tbody>
-</table>
+{% codeblock lang:json %}
+"stats": [
+  "stats.read",
+  "stats.global.read"
+]
+{% endcodeblock %}
 
 {% anchor h3 %}
 Whitelabel
@@ -191,23 +149,11 @@ Whitelabel
 
 An API Key for authenticating API calls that can create, change, and remove whitelabel information would require the the following permissions.
 
-<table class="table table-bordered table-striped">
-   <tbody>
-      <tr>
-         <td>whitelabel.create</td>
-         <td>Create whitelabels</td>
-      </tr>
-      <tr>
-         <td>whitelabel.delete</td>
-         <td>Delete existing whitelabels</td>
-      </tr>
-      <tr>
-         <td>whitelabel.read</td>
-         <td>Retrieve whitelabels</td>
-      </tr>
-      <tr>
-         <td>whitelabel.update</td>
-         <td>Update existing whitelabels</td>
-      </tr>
-   </tbody>
-</table>
+{% codeblock lang:json %}
+"scopes": [
+  "whitelabel.create",
+  "whitelabel.delete",
+  "whitelabel.read",
+  "whitelabel.update"
+]
+{% endcodeblock %}

--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -111,7 +111,7 @@ Example Permissions for Common API Key Use Cases
 {% anchor h3 %}
 Read Only Access for Mail Send
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail.batch.read"
 ]
@@ -120,7 +120,7 @@ Read Only Access for Mail Send
 {% anchor h3 %}
 Full Access for Mail Send
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail.batch.create",
   "mail.batch.delete",
@@ -133,7 +133,7 @@ Full Access for Mail Send
 {% anchor h3 %}
 Read Only Access for Alerts
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "alerts.read"
 ]
@@ -142,7 +142,7 @@ Read Only Access for Alerts
 {% anchor h3 %}
 Full Access for Alerts
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "alerts.create",
   "alerts.delete",
@@ -154,7 +154,7 @@ Full Access for Alerts
 {% anchor h3 %}
 Read Only Access for Stats
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "email_activity.read",
   "stats.read",
@@ -169,7 +169,7 @@ Read Only Access for Stats
 {% anchor h3 %}
 Read Only Access for Suppressions
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "suppressions.read"
 ]
@@ -178,7 +178,7 @@ Read Only Access for Suppressions
 {% anchor h3 %}
 Full Access for Suppressions
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "suppressions.create",
   "suppressions.delete",
@@ -190,7 +190,7 @@ Full Access for Suppressions
 {% anchor h3 %}
 Read Only Access for Whitelabels
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "whitelabel.read"
 ]
@@ -199,7 +199,7 @@ Read Only Access for Whitelabels
 {% anchor h3 %}
 Full Access for Whitelabels
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "whitelabel.create",
   "whitelabel.delete",
@@ -211,7 +211,7 @@ Full Access for Whitelabels
 {% anchor h3 %}
 Read Only Access for IP Management
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "ips.assigned.read",
   "ips.read",
@@ -223,7 +223,7 @@ Read Only Access for IP Management
 {% anchor h3 %}
 Full Access for IP Management
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "ips.assigned.read",
   "ips.read",
@@ -242,7 +242,7 @@ Full Access for IP Management
 {% anchor h3 %}
 Read Only Access for Templates
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "templates.read",
   "templates.versions.activate.read",
@@ -253,7 +253,7 @@ Read Only Access for Templates
 {% anchor h3 %}
 Full Access for Templates
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "templates.create",
   "templates.delete",
@@ -273,7 +273,7 @@ Full Access for Templates
 {% anchor h3 %}
 Read Only Access for Inbound Parse
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "user.webhooks.parse.settings.read",
   "user.webhooks.parse.stats.read"
@@ -283,7 +283,7 @@ Read Only Access for Inbound Parse
 {% anchor h3 %}
 Full Access for Inbound Parse
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "user.webhooks.parse.settings.create",
   "user.webhooks.parse.settings.delete",
@@ -296,7 +296,7 @@ Full Access for Inbound Parse
 {% anchor h3 %}
 Read Only Access for Mail Settings
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail_settings.address_whitelist.read",
   "mail_settings.bcc.read",
@@ -314,7 +314,7 @@ Read Only Access for Mail Settings
 {% anchor h3 %}
 Full Access for Mail Settings
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "mail_settings.address_whitelist.read",
   "mail_settings.address_whitelist.update",
@@ -341,7 +341,7 @@ Full Access for Mail Settings
 {% anchor h3 %}
 Read Only Access for Marketing Campaigns
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "marketing_campaigns.read"
 ]
@@ -350,7 +350,7 @@ Read Only Access for Marketing Campaigns
 {% anchor h3 %}
 Full Access for Marketing Campaigns
 {% endanchor %}
-{% codeblock lang:json %}
+{% codeblock %}
 "scopes": [
   "marketing_campaigns.create",
   "marketing_campaigns.delete",


### PR DESCRIPTION
* The lists of API Key Permissions in the API Reference and the Classroom have been reformated into codeblocks rather than HTML tables to make it easier for users to copy/paste scopes into an API call. We have also expanded the list of common scopes use cases in the classroom, and have provided a list of both "full access" and "read only access" scopes.
 * /API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
 * /Classroom/Basics/API/api_key_permissions.html