### PR TITLE
Remove reference for heroku-sendgrid-stats plugin

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -167,7 +167,6 @@ Ruby
 {% endanchor %}
 
 -   [sendgrid](http://github.com/stephenb/sendgrid) *by Stephen Blankenship* - SendGrid rubygem (ActionMailer)
--   [heroku-sendgrid-stats](https://github.com/hone/heroku-sendgrid-stats) *by Terence Lee* - Heroku CLI plugin to pull SendGrid stats
 -   [sendgrid_toolkit](http://github.com/freerobby/sendgrid_toolkit) *by Robby Grossman* - Ruby wrapper for the SendGrid Web API
 -   [sendgrid-rails](http://github.com/PavelTyk/sendgrid-rails) *by Pavel Tsiukhtsiayeu* - Extends ActionMailer with SendGrid methods
 -   [gatling_gun](http://github.com/okrb/gatling_gun) *by James Edward Gray II* - Simple wrapper over SendGrid's Marketing Email API.


### PR DESCRIPTION
The Heroku plugin `heroku-sendgrid-stats` is deprecated and no longer maintained. I installed it and was unable to use it. See error message below:

    ➜  working_directory git:(Working_Branch) ✗ heroku plugins:install git://github.com/hone/heroku-sendgrid-stats.git
    Installing git://github.com/hone/heroku-sendgrid-stats.git... done
    ➜  working_directory git:(Working_Branch) ✗ heroku sendgrid
     !    DEPRECATED: Heroku::Client#deprecate is deprecated, please use the heroku-api gem.
     !    DEPRECATED: More information available at https://github.com/heroku/heroku.rb
     !    DEPRECATED: Deprecated method called from /Users/ACIDSTEALTH/.heroku/client/lib/heroku/client.rb:127.
     !    The requested API endpoint was not found. Are you using the right HTTP verb (i.e. `GET` vs. `POST`), and did you specify your intended version with the `Accept` header?