### PR TITLE
fixed link to Transactional Templates Editor

### DIFF
--- a/source/User_Guide/Transactional_Templates/index.html
+++ b/source/User_Guide/Transactional_Templates/index.html
@@ -80,5 +80,5 @@ Start Now!
 {% endanchor %}
 
 Start using our Transactional Templates now by creating your first Template!
-<a href="{{site.app_url}}/templates/new"><img src="{{root_url}}/images/template_engine_6.png" class="img-responsive center-block"/></a>
+<a href="https://sendgrid.com/templates"><img src="{{root_url}}/images/template_engine_6.png" class="img-responsive center-block"/></a>
 </div>


### PR DESCRIPTION
The link to create a new transactional template was broken. I've added the correct URL: https://sendgrid.com/templates