### PR TITLE
fixed tables.less

### DIFF
--- a/source/_assets/stylesheets/tables.less
+++ b/source/_assets/stylesheets/tables.less
@@ -1,4 +1,4 @@
-table {
+table.apitable {
   color: @slate-60;
   text-align: left;
   font-size: @scaledown-1;


### PR DESCRIPTION
The new API Tables style sheet was being applied to ALL tables. We've made this specific to tables that only specify class="apitable"