### PR TITLE
5/10/16 Docs Updates to Fix API Examples and API Tables

### DIFF
--- a/plugins/api_error_table.rb
+++ b/plugins/api_error_table.rb
@@ -13,9 +13,9 @@ module Jekyll
     def render(context)
       output = super
       output = <<HTML
-<h2>#{@name}</h2>
+{% anchor h3 #{@tag}%}#{@name}{% endanchor %}
 #{@description}
-<table name="#{@identifier}">
+<table class="apitable" name="#{@identifier}">
   <tbody>
     <tr>
       <th colspan="1">Error Code</th>

--- a/source/_assets/stylesheets/tables.less
+++ b/source/_assets/stylesheets/tables.less
@@ -1,4 +1,4 @@
-table {
+table.apitable {
   color: @slate-60;
   text-align: left;
   font-size: @scaledown-1;


### PR DESCRIPTION
* Updated /_assets/stylesheets/tables.less stylesheet to only be applied to tables with class="apitable"