### PR TITLE
Remove list_id from Segment PATCH

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
@@ -751,7 +751,7 @@ Segments may contain multiple condtions, joined by an "and" or "or" in the "and_
 
      + Body
 
-            {"name":"The Millers","list_id":5,"conditions":[{"field":"last_name", "value":"Miller", "operator":"eq", "and_or":""}]}
+            {"name":"The Millers","conditions":[{"field":"last_name", "value":"Miller", "operator":"eq", "and_or":""}]}
 
 + Response 200
 


### PR DESCRIPTION
adding the list_id throws an error. as long as oyu define the segment_id properly in the URI, the call works, even for a list-specific segment