### PR TITLE
note that click tracking will not work with spaces around = sign in href attribute

### DIFF
--- a/source/Classroom/Track/Clicks/click_tracking_html_best_practices.md
+++ b/source/Classroom/Track/Clicks/click_tracking_html_best_practices.md
@@ -11,7 +11,7 @@ navigation:
   show: true
 ---
 
-If you are experiencing issues with the click tracking setting not replacing your original links, please take a look at your link formatting. Links must be in the proper format in order for our click tracking setting to find and replace them. Links must be within an HTML `<a>` tag, must be quoted, and must be proceeded by **`"http://`** or **`"https://`**  
+If you are experiencing issues with the click tracking setting not replacing your original links, please take a look at your link formatting. Links must be in the proper format in order for our click tracking setting to find and replace them. Links must be within an HTML `<a>` tag, must be quoted, must not contain spaces around the `=` in the `href` attribute, and must be proceeded by **`"http://`** or **`"https://`**
 Here are some example links that will be properly replaced by our click tracking app:
 
 `<a href="http://www.sendgrid.com">SendGrid</a>`
@@ -26,6 +26,7 @@ The following links, even though they may still resolve, will not be captured or
 
 `<a href=http://www.sendgrid.com>SendGrid</a>`
 
+`<a href= http://www.sendgrid.com>SendGrid</a>`
 
 
 {% info %}


### PR DESCRIPTION
My group ran into this and have support ticket #670074 filed.

I think its worth noting that spaces around the `=` in an `href` attribute will prevent click tracking from working, even though it is valid markup.

e.g.
`<a href="http://google.com">` will rewrite and track but `<a href= "http://google.com">` will not.