### PR TITLE
organized v3/mail/send errors docs alphabetically

### DIFF
--- a/source/API_Reference/Web_API_v3/Mail/errors.md
+++ b/source/API_Reference/Web_API_v3/Mail/errors.md
@@ -45,10 +45,19 @@ Table of Contents
 {% endanchor %}
 
 * [Personalizations Errors](#-Personalizations-Errors)
-* [Message Level Errors](#-Message-Level-Errors)
-* [Content Errors](#-Content-Errors)
-* [Attachment Errors](#-Attachment-Errors)
 * [ASM Errors](#-ASM-Errors)
+* [Attachment Errors](#-Attachment-Errors)
+* [Batch ID Errors](#-Batch-ID-Errors)
+* [Categories Errors](#-Categories-Errors)
+* [Content Errors](#-Content-Errors)
+* [From Address Errors](#-From-Address-Errors)
+* [Headers Errors](#-Headers-Errors)
+* [IP Pool Errors](#-IP-Pool-Errors)
+* [Reply To Errors](#-Reply-To-Errors)
+* [Sections Errors](#-Sections-Errors)
+* [Send At Errors](#-Send-At-Errors)
+* [Subject Line Errors](#-Subject-Line-Errors)
+* [Template Errors](#-Template-Errors)
 * [Mail Settings Errors](#-Mail-Settings-Errors)
 * [Tracking Settings Errors](#-Tracking-Settings-Errors)
 
@@ -62,16 +71,6 @@ Personalizations Errors
   {% api_error_table_message "The personalization block is limited to 100 personalizations per API request. You have provided X personalizations. Please consider splitting this into multiple requests and resending your request." "The v3 Mail Send endpoint is only capable of processing 100 individual <code>personalizations</code> objects per request. If you need to send your email to more than 100 different recipients, we recommend that you simply make more than once call. For more information about the <code>personalizations</code> array, and how you can use it to define who you would like you send your email to, and how you would like your email to be processed, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 
   {% api_error_table_message "You must have at least one personalization." "Every email you send must have at least one recipient email address included. Recipients are defined in the <code>personalizations</code> array. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
-{% endapi_error_table %}
-
-{% api_error_table personalizations.to "" message.personalizations.to %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The to array must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "Every email you send must have at least one, valid recipient email address included. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
-{% endapi_error_table %}
-
-{% api_error_table "Recipient Errors" "The following error messages relate to general email recipient problems." message.recipient-errors %}
-  {% api_error_table_row 400 %}
 
   {% api_error_table_message "There is a limit of 100 total recipients (to + cc + bcc) per request." "The combined, total number of email recipients may never exceed 100. This includes recipients defined within the <code>to</code>, <code>cc</code>, and <code>bcc</code> parameters. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 
@@ -80,16 +79,6 @@ Personalizations Errors
   {% api_error_table_message "Each unique email address in the <code>personalizations</code> array should only be included once. You have included [email address] more than once." "To prevent the same email from being delivered to one recipient multiple times, SendGrid will confirm that you do not duplicate an email address in your request. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 
   {% api_error_table_message "The to parameter is required for all personalization objects." "For every single object that you include within the <code>personalizations</code> array, you must include at least one <code>to</code> email object with a valid email address. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
-{% endapi_error_table %}
-
-{% api_error_table personalizations.cc "" message.personalizations.cc %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The cc array, when used, must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "For every carbon copy of your email, you must include one, valid recipient email address. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
-
-  {% api_error_table_message "Each recipient object must at least have an email address and may also contain a name. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "Every recipient that you define within the <code>personalizations.cc</code> array must be in the form of an email object including one, valid email address. You are not required to include a name." %}
-
-  {% api_error_table_message "Each unique email address in the personalization block should only be included once. You have included [email address] more than once." "To prevent the same email from being delivered to one recipient multiple times, SendGrid will confirm that you do not duplicate an email address in your request. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 {% endapi_error_table %}
 
 {% api_error_table personalizations.bcc "" message.personalizations.bcc %}
@@ -102,27 +91,14 @@ Personalizations Errors
   {% api_error_table_message "Each unique email address in the personalization block should only be included once. You have included [email address] more than once." "To prevent the same email from being delivered to one recipient multiple times, SendGrid will confirm that you do not duplicate an email address in your request. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 {% endapi_error_table %}
 
-{% api_error_table personalizations.subject "" message.personalizations.subject %}
+{% api_error_table personalizations.cc "" message.personalizations.cc %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The subject of your email must be a string at least one character in length." "You are required to include a subject for every email you send, and you may not include an empty subject. The minimum length of your subject is one character." %}
+  {% api_error_table_message "The cc array, when used, must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "For every carbon copy of your email, you must include one, valid recipient email address. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 
-  {% api_error_table_message "The subject is required. You can get around this requirement if you use a template with a subject defined." "Every email must have a subject. This can be accomplished 3 ways: you include a template that has a subject, you define a global subject, or every single personalizations object has a subject." %}
+  {% api_error_table_message "Each recipient object must at least have an email address and may also contain a name. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "Every recipient that you define within the <code>personalizations.cc</code> array must be in the form of an email object including one, valid email address. You are not required to include a name." %}
 
-{% endapi_error_table %}
-
-{% api_error_table personalizations.categories "" message.personalizations.categories %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "You are limited to 10 categories per personalization. You provided X categories." "For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Categories must be an array of strings." "Every object that you include within the categories array must be a string. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Each category must not be longer than 255 characters. [YOUR CATEGORY] exceeds this limit" "The maximum length of a category is 255 characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "The categories must be a unique list, and you have included [YOUR CATEGORY] more than once." "You cannot include the same category more than once within the categories array. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Categories can not contain non-ASCII characters" "Each category name must only be comprised of ASCII characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
+  {% api_error_table_message "Each unique email address in the personalization block should only be included once. You have included [email address] more than once." "To prevent the same email from being delivered to one recipient multiple times, SendGrid will confirm that you do not duplicate an email address in your request. For more information on how you may specify your recipients, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 {% endapi_error_table %}
 
 {% api_error_table personalizations.custom_args "" message.personalizations.custom_args %}
@@ -147,6 +123,22 @@ Personalizations Errors
   {% api_error_table_message "Header cannot be one of the reserved keys." "Some header keys are reserved. You may not include any of the following reserved keys: <code>x-sg-id</code>, <code>x-sg-eid</code>, <code>received</code>, <code>dkim-signature</code>, <code>Content-Type</code>, <code>Content-Transfer-Encoding</code>, <code>To</code>, <code>From</code>, <code>Subject</code>, <code>Reply-To</code>, <code>CC</code>, <code>BCC</code>." %}
 {% endapi_error_table %}
 
+{% api_error_table personalizations.send_at "" message.personalizations.send_at %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The <code>send_at</code> parameter is expecting a Unix timestamp as an integer. We will send immediately if you include a <code>send_at</code> timestamp that is in the past." "<code>send_at</code> accepts a unix timestamp representing when you want your email to be sent from SendGrid. If you want the email to be sent at the time of your API request, simply omit the <code>send_at</code> parameter." %}
+
+  {% api_error_table_message "Scheduling more than 72 hours in advance is forbidden." "The <code>send_at</code> parameter allows you to schedule your email to be sent up to 72 hours in advance, but due to our constraints, we cannot schedule emails more than 72 hours in the future. For more information on scheduling parameters, please see our <a href=\"{{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html\">API Reference</a>." %}
+{% endapi_error_table %}
+
+{% api_error_table personalizations.subject "" message.personalizations.subject %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The subject of your email must be a string at least one character in length." "You are required to include a subject for every email you send, and you may not include an empty subject. The minimum length of your subject is one character." %}
+
+  {% api_error_table_message "The subject is required. You can get around this requirement if you use a template with a subject defined." "Every email must have a subject. This can be accomplished 3 ways: you include a template that has a subject, you define a global subject, or every single personalizations object has a subject." %}
+{% endapi_error_table %}
+
 {% api_error_table personalizations.substitutions "" message.personalizations.substitutions %}
   {% api_error_table_row 400 %}
 
@@ -155,38 +147,104 @@ Personalizations Errors
   {% api_error_table_message "You are limited to 10,000 substitutions." "You may not make more than 10,000 substitutions per request. Substitutions will apply to the content of your email, in addition to the <code>subject</code> and <code>reply_to</code> parameters" %}
 {% endapi_error_table %}
 
-{% api_error_table personalizations.send_at "" message.personalizations.send_at %}
-{% api_error_table_row 400 %}
+{% api_error_table personalizations.to "" message.personalizations.to %}
+  {% api_error_table_row 400 %}
 
-{% api_error_table_message "The <code>send_at</code> parameter is expecting a Unix timestamp as an integer. We will send immediately if you include a <code>send_at</code> timestamp that is in the past." "<code>send_at</code> accepts a unix timestamp representing when you want your email to be sent from SendGrid. If you want the email to be sent at the time of your API request, simply omit the <code>send_at</code> parameter." %}
-
-{% api_error_table_message "Scheduling more than 72 hours in advance is forbidden." "The <code>send_at</code> parameter allows you to schedule your email to be sent up to 72 hours in advance, but due to our constraints, we cannot schedule emails more than 72 hours in the future. For more information on scheduling parameters, please see our <a href=\"{{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html\">API Reference</a>." %}
+  {% api_error_table_message "The to array must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "Every email you send must have at least one, valid recipient email address included. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." %}
 {% endapi_error_table %}
 
 {% anchor h2 %}
-Message Level Errors
+ASM Errors
 {% endanchor %}
 
-{% api_error_table from "" message.from %}
+{% api_error_table asm.group_id "" message.asm.group_id %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The from object must at least have an <code>email</code> parameter with a valid email address and may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}" "While every <code>from</code> parameter must include a valid email address, you are not required to include a name." %}
+  {% api_error_table_message "The ASM group ID must be an integer." "Suppression Groups, or unsubscribe groups, are a great way to record which emails your recipients want to receive. Including the <code>asm.group_id</code> in your request allows you to group your email with other, similar sends. However, these group IDs are always generated as integers, and so you must ensure that <code>asm.group_id</code> is defined as an integer. For more information please read our <a href=\"{{root_url}}/API_Reference/Web_API_v3/Suppression_Management/groups.html\">Unsubscribe Groups</a> documentation." %}
 
-  {% api_error_table_message "The <code>from</code> object must be provided for every email send. It is an object that requires the <code>email</code> parameter, but may also contain a <code>name</code> parameter.  e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}" "You are required to provide a from address whenever you send an email through SendGrid. This is used for authentication purposes and helps to build a positive sending reputation with your recipients' ISPs. You are not required to include a name within the <code>from</code> parameter." %}
+  {% api_error_table_message "The ASM group ID must be a valid Group ID on your account. You provided [YOUR ASM GROUP ID]." "" %}
 {% endapi_error_table %}
 
-{% api_error_table reply_to "" message.reply_to %}
+{% api_error_table asm.groups_to_display "" message.asm.groups_to_display %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The <code>reply_to</code> object, when used, must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "For every carbon copy of your email, you must include one, valid recipient email address. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." "" %}
+  {% api_error_table_message "The ASM Group IDs to display must be an array of integers." "" %}
+
+  {% api_error_table_message "All ASM groups to display must be valid ASM groups IDs on your account. You provided {invalid IDs}." "" %}
+
+  {% api_error_table_message "There is a limit of 25 unsubscribe groups that can be displayed to a user at a time." "" %}
 {% endapi_error_table %}
 
-{% api_error_table subject "" message.subject %}
+{% anchor h2 %}
+Attachment Errors
+{% endanchor %}
+
+{% api_error_table attachments.content "" message.attachments.content %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The subject of your email must be a string at least one character in length." "You are required to include a subject for every email you send, and you may not include an empty subject. The minimum length of your subject is one character." %}
+  {% api_error_table_message "The attachment content must be base64 encoded." "" %}
 
-  {% api_error_table_message "The subject is required. You can get around this requirement if you use a template with a subject defined or if every personalization has a subject defined." "Every email must have a subject. This can be accomplished 3 ways: you include a template that has a subject, you define a global subject, or every single personalizations object has a subject." %}
+  {% api_error_table_message "The attachment content must be a string at least one character in length." "" %}
+{% endapi_error_table %}
+
+{% api_error_table attachments.content_id "" message.attachments.content_id %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The content ID of your attachment must be a string. You provided [YOUR CONTENT ID]." "The <code>content_id</code> is a unique id that you specify for the attachment. This is used when the disposition is set to &#34;inline&#34; and the attachment is an image, allowing the file to be displayed within the body of your email. For example, <code>&lt;img src=&#34;cid:ii_139db99fdb5c3704&#34;&gt;&lt;/img&gt;</code>" %}
+
+  {% api_error_table_message "The content ID of your attachment cannot contain CRLF characters." "When defining your <code>content_id</code>, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
+{% endapi_error_table %}
+
+{% api_error_table attachments.disposition "" message.attachments.disposition %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The disposition of your attachment can be either &#34;inline&#34; or &#34;attachment&#34;. You provided [YOUR DISPOSITION]." "The content-disposition of your attachment defines how you would like the attachment to be displayed. For example, &#34;inline&#34; results in the attached file being displayed automatically within the message while &#34;attachment&#34; results in the attached file requiring some action to be taken before it is displayed (e.g. opening or downloading the file). <code>attachments.disposition</code> always defaults to &#34;attachment&#34;. Can be either &#34;attachment&#34; or &#34;inline&#34;." %}
+{% endapi_error_table %}
+
+{% api_error_table attachments.filename "" message.attachments.filename %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The filename of your attachment must be a string." "" %}
+
+  {% api_error_table_message "The filename of your attachment cannot contain CRLF characters." "When defining the filename of your attachment, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
+
+  {% api_error_table_message "filename is required." "You must always include a filename for your attachment." %}
+{% endapi_error_table %}
+
+{% api_error_table attachments.type "" message.attachments.type %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The attachment type must be a string and at least one character in length." "" %}
+
+  {% api_error_table_message "The type cannot contain ';', or CRLF characters." "When defining the type of your attachment content, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Batch ID Errors
+{% endanchor %}
+
+{% api_error_table batch_id "" message.batch_id %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The batch_id must be a string." "Batch IDs are always generated as strings, so when you choose to include a batch ID in your send, you must make sure that <code>batch_id</code> is defined as a string. For more information about batch IDs, and how you can use them to group sends together, please visit our <a href=\"{{root_url}}/API_Reference/Web_API_v3/cancel_schedule_send.html\">API Reference</a>." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Categories Errors
+{% endanchor %}
+
+{% api_error_table categories "" message.categories %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "There is a limit of 10 categories for each email that is sent. You provided X categories." "For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
+
+  {% api_error_table_message "Categories must be an array of strings." "Every object that you include within the categories array must be a string. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
+
+  {% api_error_table_message "Each category must not be longer than 255 characters. [YOUR CATEGORY] exceeds this limit" "he maximum length of a category is 255 characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
+
+  {% api_error_table_message "The categories must be a unique list, and you have included [YOUR CATEGORY] more than once. " "You cannot include the same category more than once within the categories array. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
+
+  {% api_error_table_message "Categories can not contain non-ASCII characters." "Each category name must only be comprised of ASCII characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
 {% endapi_error_table %}
 
 {% anchor h2 %}
@@ -224,64 +282,20 @@ Content Errors
 {% endapi_error_table %}
 
 {% anchor h2 %}
-Attachment Errors
+From Address Errors
 {% endanchor %}
 
-{% api_error_table attachments.content "" message.attachments.content %}
+{% api_error_table from "" message.from %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The attachment content must be base64 encoded." "" %}
+  {% api_error_table_message "The from object must at least have an <code>email</code> parameter with a valid email address and may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}" "While every <code>from</code> parameter must include a valid email address, you are not required to include a name." %}
 
-  {% api_error_table_message "The attachment content must be a string at least one character in length." "" %}
+  {% api_error_table_message "The <code>from</code> object must be provided for every email send. It is an object that requires the <code>email</code> parameter, but may also contain a <code>name</code> parameter.  e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}" "You are required to provide a from address whenever you send an email through SendGrid. This is used for authentication purposes and helps to build a positive sending reputation with your recipients' ISPs. You are not required to include a name within the <code>from</code> parameter." %}
 {% endapi_error_table %}
 
-{% api_error_table attachments.type "" message.attachments.type %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The attachment type must be a string and at least one character in length." "" %}
-
-  {% api_error_table_message "The type cannot contain ';', or CRLF characters." "When defining the type of your attachment content, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
-{% endapi_error_table %}
-
-{% api_error_table attachments.filename "" message.attachments.filename %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The filename of your attachment must be a string." "" %}
-
-  {% api_error_table_message "The filename of your attachment cannot contain CRLF characters." "When defining the filename of your attachment, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
-
-  {% api_error_table_message "filename is required." "You must always include a filename for your attachment." %}
-{% endapi_error_table %}
-
-{% api_error_table attachments.disposition "" message.attachments.disposition %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The disposition of your attachment can be either &#34;inline&#34; or &#34;attachment&#34;. You provided [YOUR DISPOSITION]." "The content-disposition of your attachment defines how you would like the attachment to be displayed. For example, &#34;inline&#34; results in the attached file being displayed automatically within the message while &#34;attachment&#34; results in the attached file requiring some action to be taken before it is displayed (e.g. opening or downloading the file). <code>attachments.disposition</code> always defaults to &#34;attachment&#34;. Can be either &#34;attachment&#34; or &#34;inline&#34;." %}
-{% endapi_error_table %}
-
-{% api_error_table attachments.content_id "" message.attachments.content_id %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The content ID of your attachment must be a string. You provided [YOUR CONTENT ID]." "The <code>content_id</code> is a unique id that you specify for the attachment. This is used when the disposition is set to &#34;inline&#34; and the attachment is an image, allowing the file to be displayed within the body of your email. For example, <code>&lt;img src=&#34;cid:ii_139db99fdb5c3704&#34;&gt;&lt;/img&gt;</code>" %}
-
-  {% api_error_table_message "The content ID of your attachment cannot contain CRLF characters." "When defining your <code>content_id</code>, you may not include the characters <code>;</code>, <code>,</code>, <code>\n</code>, or <code>\r</code>." %}
-{% endapi_error_table %}
-
-{% api_error_table template_id "" message.template_id %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The template ID must be a string, you provided [YOUR TEMPLATE ID]." "Template IDs are always strings." %}
-
-  {% api_error_table_message "The Template ID must be a valid template id for your account. You provided [YOUR TEMPLATE ID]." "We do not allow you to send an empty email, so in the event that the only content of your email is contained within your template, we want to make sure that the included template exists, and is valid." %}
-
-  {% api_error_table_message "Must be a valid template." "We do not allow you to send an empty email, so in the event that the only content of your email is contained within your template, we want to make sure that the included template exists, and is valid." %}
-{% endapi_error_table %}
-
-{% api_error_table sections "" message.sections %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The section values must be strings." "The values of your <code>sections</code> parameter will be substituted into the content of your email. We will only perform substitutions using strings, so please make sure that your section values are always defined as strings." %}
-{% endapi_error_table %}
+{% anchor h2 %}
+Headers Errors
+{% endanchor %}
 
 {% api_error_table headers "" message.headers %}
   {% api_error_table_row 400 %}
@@ -295,55 +309,9 @@ Attachment Errors
   {% api_error_table_message "Header can not be one of the reserved keys." "Some header keys are reserved. You may not include any of the following reserved headers: <code>x-sg-id</code>, <code>x-sg-eid</code>, <code>received</code>, <code>dkim-signature</code>, <code>Content-Type</code>, <code>Content-Transfer-Encoding</code>, <code>To</code>, <code>From</code>, <code>Subject</code>, <code>Reply-To</code>, <code>CC</code>, <code>BCC</code>." %}
 {% endapi_error_table %}
 
-{% api_error_table categories "" message.categories %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "There is a limit of 10 categories for each email that is sent. You provided X categories." "For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Categories must be an array of strings." "Every object that you include within the categories array must be a string. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Each category must not be longer than 255 characters. [YOUR CATEGORY] exceeds this limit" "he maximum length of a category is 255 characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "The categories must be a unique list, and you have included [YOUR CATEGORY] more than once. " "You cannot include the same category more than once within the categories array. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-
-  {% api_error_table_message "Categories can not contain non-ASCII characters." "Each category name must only be comprised of ASCII characters. For more information on how you can use categories to organize your email analytics, please visit our <a href=\"{{root_url}}/User_Guide/Statistics/categories.html\">User Guide</a>." %}
-{% endapi_error_table %}
-
-{% api_error_table send_at "" message.send_at %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The <code>send_at</code> parameter is expecting a Unix timestamp as an integer. We will send immediately if you include a <code>send_at</code> timestamp that is in the past." "<code>send_at</code> accepts a unix timestamp representing when you want your email to be sent from SendGrid. If you want the email to be sent at the time of your API request, simply omit the <code>send_at</code> parameter." %}
-
-  {% api_error_table_message "Scheduling more than 72 hours in advance is forbidden." "The <code>send_at</code> parameter allows you to schedule your email to be sent up to 72 hours in advance, but due to our constraints, we cannot schedule emails more than 72 hours in the future. For more information on scheduling parameters, please see our <a href=\"{{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html\">API Reference</a>." %}
-{% endapi_error_table %}
-
-{% api_error_table batch_id "" message.batch_id %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The batch_id must be a string." "Batch IDs are always generated as strings, so when you choose to include a batch ID in your send, you must make sure that <code>batch_id</code> is defined as a string. For more information about batch IDs, and how you can use them to group sends together, please visit our <a href=\"{{root_url}}/API_Reference/Web_API_v3/cancel_schedule_send.html\">API Reference</a>." %}
-{% endapi_error_table %}
-
 {% anchor h2 %}
-ASM Errors
+IP Pool Errors
 {% endanchor %}
-
-{% api_error_table asm.group_id "" message.asm.group_id %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The ASM group ID must be an integer." "Suppression Groups, or unsubscribe groups, are a great way to record which emails your recipients want to receive. Including the <code>asm.group_id</code> in your request allows you to group your email with other, similar sends. However, these group IDs are always generated as integers, and so you must ensure that <code>asm.group_id</code> is defined as an integer. For more information please read our <a href=\"{{root_url}}/API_Reference/Web_API_v3/Suppression_Management/groups.html\">Unsubscribe Groups</a> documentation." %}
-
-  {% api_error_table_message "The ASM group ID must be a valid Group ID on your account. You provided [YOUR ASM GROUP ID]." "" %}
-{% endapi_error_table %}
-
-{% api_error_table asm.groups_to_display "" message.asm.groups_to_display %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The ASM Group IDs to display must be an array of integers." "" %}
-
-  {% api_error_table_message "All ASM groups to display must be valid ASM groups IDs on your account. You provided {invalid IDs}." "" %}
-
-  {% api_error_table_message "There is a limit of 25 unsubscribe groups that can be displayed to a user at a time." "" %}
-{% endapi_error_table %}
 
 {% api_error_table ip_pool_name "" message.ip_pool_name %}
   {% api_error_table_row 400 %}
@@ -354,14 +322,66 @@ ASM Errors
 {% endapi_error_table %}
 
 {% anchor h2 %}
-Mail Settings Errors
+Reply To Errors
 {% endanchor %}
 
-{% api_error_table mail_settings.bcc.enable "" message.mail_settings.bcc.enable %}
+{% api_error_table reply_to "" message.reply_to %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The bcc enable param should be a boolean value." "" %}
+  {% api_error_table_message "The <code>reply_to</code> object, when used, must at least have an <code>email</code> parameter with a valid email address and it may also contain a <code>name</code> parameter. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "For every carbon copy of your email, you must include one, valid recipient email address. However, you are not required to include a corresponding name with the recipient email address. For more information on how to use <code>personalizations</code> to define who you want to send your email to, please visit our <a href=\"{{root_url}}/Classroom/Send/v3_Mail_Send/personalizations.html\">Classroom</a>." "" %}
 {% endapi_error_table %}
+
+{% anchor h2 %}
+Sections Errors
+{% endanchor %}
+
+{% api_error_table sections "" message.sections %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The section values must be strings." "The values of your <code>sections</code> parameter will be substituted into the content of your email. We will only perform substitutions using strings, so please make sure that your section values are always defined as strings." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Send At Errors
+{% endanchor %}
+
+{% api_error_table send_at "" message.send_at %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The <code>send_at</code> parameter is expecting a Unix timestamp as an integer. We will send immediately if you include a <code>send_at</code> timestamp that is in the past." "<code>send_at</code> accepts a unix timestamp representing when you want your email to be sent from SendGrid. If you want the email to be sent at the time of your API request, simply omit the <code>send_at</code> parameter." %}
+
+  {% api_error_table_message "Scheduling more than 72 hours in advance is forbidden." "The <code>send_at</code> parameter allows you to schedule your email to be sent up to 72 hours in advance, but due to our constraints, we cannot schedule emails more than 72 hours in the future. For more information on scheduling parameters, please see our <a href=\"{{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html\">API Reference</a>." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Subject Line Errors
+{% endanchor %}
+
+{% api_error_table subject "" message.subject %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The subject of your email must be a string at least one character in length." "You are required to include a subject for every email you send, and you may not include an empty subject. The minimum length of your subject is one character." %}
+
+  {% api_error_table_message "The subject is required. You can get around this requirement if you use a template with a subject defined or if every personalization has a subject defined." "Every email must have a subject. This can be accomplished 3 ways: you include a template that has a subject, you define a global subject, or every single personalizations object has a subject." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Template Errors
+{% endanchor %}
+
+{% api_error_table template_id "" message.template_id %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The template ID must be a string, you provided [YOUR TEMPLATE ID]." "Template IDs are always strings." %}
+
+  {% api_error_table_message "The Template ID must be a valid template id for your account. You provided [YOUR TEMPLATE ID]." "We do not allow you to send an empty email, so in the event that the only content of your email is contained within your template, we want to make sure that the included template exists, and is valid." %}
+
+  {% api_error_table_message "Must be a valid template." "We do not allow you to send an empty email, so in the event that the only content of your email is contained within your template, we want to make sure that the included template exists, and is valid." %}
+{% endapi_error_table %}
+
+{% anchor h2 %}
+Mail Settings Errors
+{% endanchor %}
 
 {% api_error_table mail_settings.bcc.email "" message.mail_settings.bcc.email %}
   {% api_error_table_row 400 %}
@@ -369,6 +389,12 @@ Mail Settings Errors
   {% api_error_table_message "The bcc email recipient object must at least have an email address and may also contain a name. e.g. <code>{&#34;email&#34;: &#34;example@example.com&#34;}</code> or <code>{&#34;email&#34;: &#34;example@example.com&#34;, &#34;name&#34;: &#34;Example Recipient&#34;}</code>" "" %}
 
   {% api_error_table_message "You must include a recipient object when using the bcc mail setting." "" %}
+{% endapi_error_table %}
+
+{% api_error_table mail_settings.bcc.enable "" message.mail_settings.bcc.enable %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The bcc enable param should be a boolean value." "" %}
 {% endapi_error_table %}
 
 {% api_error_table mail_settings.bypass_list_management.enable "" message.mail_settings.bypass_list_management.enable %}
@@ -383,16 +409,16 @@ Mail Settings Errors
   {% api_error_table_message "The footer enable param should be a boolean value." "" %}
 {% endapi_error_table %}
 
-{% api_error_table mail_settings.footer.text "" message.mail_settings.footer.text %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The text/plain version of your footer should be a string." "" %}
-{% endapi_error_table %}
-
 {% api_error_table mail_settings.footer.html "" message.mail_settings.footer.html %}
   {% api_error_table_row 400 %}
 
   {% api_error_table_message "The text/html version of your footer should be a string." "" %}
+{% endapi_error_table %}
+
+{% api_error_table mail_settings.footer.text "" message.mail_settings.footer.text %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The text/plain version of your footer should be a string." "" %}
 {% endapi_error_table %}
 
 {% api_error_table mail_settings.sandbox_mode.enable "" message.mail_settings.sandbox_mode.enable %}
@@ -407,20 +433,20 @@ Mail Settings Errors
   {% api_error_table_message "The spam check enable param should be a boolean value." "" %}
 {% endapi_error_table %}
 
-{% api_error_table mail_settings.spam_check.threshold "" message.mail_settings.spam_check.threshold %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The spam check threshold is between 1 and 10, with the lower numbers being the most strict filtering. " "" %}
-
-  {% api_error_table_message "You must include the spam check threshold  when using the spam check mail setting." "" %}
-{% endapi_error_table %}
-
 {% api_error_table mail_settings.spam_check.post_to_url "" message.mail_settings.spam_check.post_to_url %}
   {% api_error_table_row 400 %}
 
   {% api_error_table_message "The spam check url must be a string." "" %}
 
   {% api_error_table_message "You must include the url to post to when using the spam check mail setting." "" %}
+{% endapi_error_table %}
+
+{% api_error_table mail_settings.spam_check.threshold "" message.mail_settings.spam_check.threshold %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The spam check threshold is between 1 and 10, with the lower numbers being the most strict filtering. " "" %}
+
+  {% api_error_table_message "You must include the spam check threshold  when using the spam check mail setting." "" %}
 {% endapi_error_table %}
 
 {% anchor h2 %}
@@ -437,6 +463,42 @@ Tracking Settings Errors
   {% api_error_table_row 400 %}
 
   {% api_error_table_message "The click tracking enable text must be a boolean value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.enable "" message.tracking_settings.ganalytics.enable %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics enable param must be a boolean value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.utm_campaign "" message.tracking_settings.ganalytics.utm_campaign %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics utm_campaign must be a string value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.utm_content "" message.tracking_settings.ganalytics.utm_content %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics utm_content must be a string value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.utm_medium "" message.tracking_settings.ganalytics.utm_medium %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics utm_medium must be a string value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.utm_source "" message.tracking_settings.ganalytics.utm_source %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics utm_source must be a string value." "" %}
+{% endapi_error_table %}
+
+{% api_error_table tracking_settings.ganalytics.utm_term "" message.tracking_settings.ganalytics.utm_term %}
+  {% api_error_table_row 400 %}
+
+  {% api_error_table_message "The Google Analytics utm_term must be a string value." "" %}
 {% endapi_error_table %}
 
 {% api_error_table tracking_settings.open_tracking.enable "" message.tracking_settings.open_tracking.enable %}
@@ -457,12 +519,6 @@ Tracking Settings Errors
   {% api_error_table_message "The subscription tracking enable param should be a boolean value." "" %}
 {% endapi_error_table %}
 
-{% api_error_table tracking_settings.subscription_tracking.text "" message.tracking_settings.subscription_tracking.text %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The subscription tracking unsubscribe content for text/plain messages must be a string. " "" %}
-{% endapi_error_table %}
-
 {% api_error_table tracking_settings.subscription_tracking.html "" message.tracking_settings.subscription_tracking.html %}
   {% api_error_table_row 400 %}
 
@@ -475,38 +531,8 @@ Tracking Settings Errors
   {% api_error_table_message "The subscription tracking substitution tag must be a string value." "" %}
 {% endapi_error_table %}
 
-{% api_error_table tracking_settings.ganalytics.enable "" message.tracking_settings.ganalytics.enable %}
+{% api_error_table tracking_settings.subscription_tracking.text "" message.tracking_settings.subscription_tracking.text %}
   {% api_error_table_row 400 %}
 
-  {% api_error_table_message "The Google Analytics enable param must be a boolean value." "" %}
-{% endapi_error_table %}
-
-{% api_error_table tracking_settings.ganalytics.utm_source "" message.tracking_settings.ganalytics.utm_source %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The Google Analytics utm_source must be a string value." "" %}
-{% endapi_error_table %}
-
-{% api_error_table tracking_settings.ganalytics.utm_medium "" message.tracking_settings.ganalytics.utm_medium %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The Google Analytics utm_medium must be a string value." "" %}
-{% endapi_error_table %}
-
-{% api_error_table tracking_settings.ganalytics.utm_term "" message.tracking_settings.ganalytics.utm_term %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The Google Analytics utm_term must be a string value." "" %}
-{% endapi_error_table %}
-
-{% api_error_table tracking_settings.ganalytics.utm_content "" message.tracking_settings.ganalytics.utm_content %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The Google Analytics utm_content must be a string value." "" %}
-{% endapi_error_table %}
-
-{% api_error_table tracking_settings.ganalytics.utm_campaign "" message.tracking_settings.ganalytics.utm_campaign %}
-  {% api_error_table_row 400 %}
-
-  {% api_error_table_message "The Google Analytics utm_campaign must be a string value." "" %}
+  {% api_error_table_message "The subscription tracking unsubscribe content for text/plain messages must be a string. " "" %}
 {% endapi_error_table %}


### PR DESCRIPTION
* We have reorganized the errors docs for V3 Mail Send so that each parameter block is organized alphabetically. We have also added several headers to the table of contents for additional granularity.
 * /API_Reference/Web_API_v3/Mail/errors.html