### PR TITLE
Removed outdated Classroom page from Index

### DIFF
--- a/source/Classroom/Deliver/index.html
+++ b/source/Classroom/Deliver/index.html
@@ -100,7 +100,6 @@ navigation:
             <li><a href="{{root_url}}Undeliverable_Email/help_my_emails_arent_being_delivered.html">Help, My emails aren't being delivered!</a></li>
             <li><a href="{{root_url}}Undeliverable_Email/how_can_i_guarantee_my_emails_arrive_in_my_recipients_inbox.html">How can I guarantee my emails arrive in my recipients inbox?</a></li>
             <li><a href="{{root_url}}Undeliverable_Email/how_do_i_keep_emails_from_dropping.html">How do I keep emails from dropping?</a></li>
-            <li><a href="{{root_url}}Undeliverable_Email/how_sendgrid_handles_550_requested_action_not_taken_mailbox_unavailable_bounces.html">How SendGrid handles "550 Requested action not taken&#58; mailbox unavailable" bounces</a></li>
             <li><a href="{{root_url}}Undeliverable_Email/my_emails_are_being_blocked.html">My Emails Are Being Blocked</a></li>
             <li><a href="{{root_url}}Undeliverable_Email/my_emails_are_being_dropped.html">My Emails Are Being Dropped</a></li>
             <li><a href="{{root_url}}Undeliverable_Email/my_emails_are_going_to_spam.html">My Emails Are Going to Spam</a></li>


### PR DESCRIPTION
This article is out of date and too situational. Removing from index before the file is deleted.