### PR TITLE
Formatting plugins

### DIFF
--- a/plugins/boostrap_column_nop.rb
+++ b/plugins/boostrap_column_nop.rb
@@ -1,0 +1,48 @@
+#
+# Author: Matt Bernier
+# Make a bootstrap column
+#
+# Outputs the HTML for a bootstrap column of size 4 with id "best_column"
+#
+  # {% html_column md-4 best_column %}
+  # Some content
+  # {% endhtml_column %}
+#   ...
+# <div id="best_column" class="col-md-4">
+#   <p>Some content</p>
+# </div>
+#
+module Jekyll
+
+  class Bootstrap_Column_Nop < Liquid::Block
+
+    def initialize(tag_name, markup, tokens)
+      parameters = markup.shellsplit
+
+      @size = "col-#{parameters[0]}"
+
+      @class = defined?(parameters[1]) ? " #{parameters[1]}" : ""
+
+      @id = parameters[2];
+
+      if defined?(parameters[2].to_str)
+        if !empty?(parameters[2].to_str)
+          @id = "id=\"#{parameters[2]}\""
+        end
+      end
+
+
+      super
+    end
+    def render(context)
+        output = super
+output = <<HTML
+<div #{@id} class="#{@size}#{@class}">#{output}</div>
+HTML
+
+        #html = Kramdown::Document.new(output).to_html
+        return Liquid::Template.parse(output).render context
+    end
+  end
+end
+  Liquid::Template.register_tag('html_column_nop', Jekyll::Bootstrap_Column_Nop)

--- a/plugins/bootstrap_column.rb
+++ b/plugins/bootstrap_column.rb
@@ -1,0 +1,43 @@
+#
+# Author: Matt Bernier
+# Make a bootstrap column
+#
+# Outputs the HTML for a bootstrap column of size 4 with id "best_column"
+#
+  # {% html_column md-4 best_column %}
+  # Some content
+  # {% endhtml_column %}
+#   ...
+  # <div id="best_column" class="col-md-4">
+  #   <p>Some content</p>
+  # </div>
+#
+module Jekyll
+
+  class Bootstrap_Column < Liquid::Block
+
+    def initialize(tag_name, markup, tokens)
+      parameters = markup.shellsplit
+
+      @size = "col-#{parameters[0]}"
+
+      @class = defined?(parameters[1]) ? " #{parameters[1]}" : ""
+
+      @id = defined?(parameters[2]) ? "id=\"#{parameters[0]}\"" : ""
+
+      super
+    end
+    def render(context)
+        output = super
+output = <<HTML
+  <div #{@id} class="#{@class}">
+  #{output}
+  </div>
+HTML
+
+        #html = Kramdown::Document.new(output).to_html
+        return Liquid::Template.parse(output).render context
+    end
+  end
+end
+  Liquid::Template.register_tag('html_row', Jekyll::Bootstrap_Column)

--- a/plugins/bootstrap_column.rb
+++ b/plugins/bootstrap_column.rb
@@ -8,9 +8,9 @@
   # Some content
   # {% endhtml_column %}
 #   ...
-  # <div id="best_column" class="col-md-4">
-  #   <p>Some content</p>
-  # </div>
+# <div id="best_column" class="col-md-4">
+#   <p>Some content</p>
+# </div>
 #
 module Jekyll
 
@@ -23,16 +23,21 @@ module Jekyll
 
       @class = defined?(parameters[1]) ? " #{parameters[1]}" : ""
 
-      @id = defined?(parameters[2]) ? "id=\"#{parameters[0]}\"" : ""
+      @id = parameters[2];
+
+      if defined?(parameters[2].to_str)
+        if !empty?(parameters[2].to_str)
+          @id = "id=\"#{parameters[2]}\""
+        end
+      end
+
 
       super
     end
     def render(context)
         output = super
 output = <<HTML
-  <div #{@id} class="#{@class}">
-  #{output}
-  </div>
+<div #{@id} class="#{@size}#{@class}"><p>#{output}</p></div>
 HTML
 
         #html = Kramdown::Document.new(output).to_html
@@ -40,4 +45,4 @@ HTML
     end
   end
 end
-  Liquid::Template.register_tag('html_row', Jekyll::Bootstrap_Column)
+  Liquid::Template.register_tag('html_column', Jekyll::Bootstrap_Column)

--- a/plugins/bootstrap_row.rb
+++ b/plugins/bootstrap_row.rb
@@ -54,9 +54,7 @@ module Jekyll
     def render(context)
         output = super
 output = <<HTML
-  <div #{@id} class="row#{@class}">
-  #{output}
-  </div>
+<div #{@id} class="row#{@class}">#{output}</div>
 HTML
 
         #html = Kramdown::Document.new(output).to_html

--- a/plugins/bootstrap_row.rb
+++ b/plugins/bootstrap_row.rb
@@ -1,0 +1,67 @@
+#
+# Author: Matt Bernier
+# Make a bootstrap row
+#
+# Outputs the HTML for a bootstrap row with id "best_row"
+#
+#   {% html_row md-4 best_row %}
+#   Wheeee!
+#   {% endhtml_row %}
+#   ...
+#   <div id="best_row" class="row">
+#     Wheeee!
+#   </div>
+#
+# Use with html_column to output a proper bootstrap row and column pairing
+#
+#   {% html_row md-4 best_row %}
+#       {% html_column md-4 best_column %}
+#         Some content
+#       {% endhtml_column %}
+#       {% html_column md-4 best_column2 %}
+#         Some content
+#       {% endhtml_column %}
+#       {% html_column md-4 best_column3 %}
+#         Some content
+#       {% endhtml_column %}
+#   {% endhtml_row %}
+#   ...
+#   <div id="best_row" class="row">
+#     <div id="best_column" class="col-md-4">
+#         <p>Some content</p>
+#     </div>
+#     <div id="best_column2" class="col-md-4">
+#         <p>Some content</p>
+#     </div>
+#     <div id="best_column3" class="col-md-4">
+#         <p>Some content</p>
+#     </div>
+#   </div>
+#
+module Jekyll
+
+  class Bootstrap_Row < Liquid::Block
+
+    def initialize(tag_name, markup, tokens)
+      parameters = markup.shellsplit
+
+      @class = defined?(parameters[0]) ? " #{parameters[1]}" : ""
+
+      @id = defined?(parameters[1]) ? "id=\"#{parameters[0]}\"" : ""
+
+      super
+    end
+    def render(context)
+        output = super
+output = <<HTML
+  <div #{@id} class="row#{@class}">
+  #{output}
+  </div>
+HTML
+
+        #html = Kramdown::Document.new(output).to_html
+        return Liquid::Template.parse(output).render context
+    end
+  end
+end
+  Liquid::Template.register_tag('html_row', Jekyll::Bootstrap_Row)


### PR DESCRIPTION
Quickly built plugins that make doing text-based boostrap columns and rows easy. 

Also added a version that doesn't put the paragraph tag in.