### PR TITLE
Add Alerts API Docs

### DIFF
--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -10,7 +10,7 @@ Alerts allow you to specify an email address to receive notifications regarding 
 <br>
 <ul>
   <li>Usage alerts allow you to set the threshold at which an alert will be sent. For example, if you want to be notified when you've used 90% of your current package's allotted emails, you would set the "percentage" parameter to 90.</li>
-  <li>Stats notifications allow you to set the frequency at which you would like to receive. For example, if you want to receive your stats notifications every day, simply set the "frequency" parameter to "daily".</li>
+  <li>Stats notifications allow you to set how frequently the alerts will be sent. For example, if you want to receive your stats notifications every day, simply set the "frequency" parameter to "daily".</li>
 </ul>
 <br>
 For more information about alerts, please visit our <a href="{{root_url}}/User_Guide/Settings/alerts.html">User Guide</a>.
@@ -20,7 +20,7 @@ FORMAT: 1A
 
 ## Alerts Collection [/alerts]
 
-### Get All User Alerts [GET]
+### Get All Alerts [GET]
 
 Retrieve all alerts.
 
@@ -53,7 +53,7 @@ Retrieve all alerts.
             }
         ]
 
-### Create a New User Alert [POST]
+### Create a New Alert [POST]
 
 Create a new alert.
 <br>
@@ -89,9 +89,9 @@ Create a new alert.
                 "updated_at": 1451520930
             }
 
-## User Alerts Collection [/users/alerts/{user_alert_id}]
+## Alerts Collection [/alerts/{alert_id}]
 
-### Get a User Alert [GET]
+### Get an Alert [GET]
 
 Retrieve a specific alert.
 
@@ -108,15 +108,15 @@ Retrieve a specific alert.
                 "updated_at": 1451520930
             }
 
-### Delete a User Alert [DELETE]
+### Delete an Alert [DELETE]
 
-Delete a user alert.
+Delete an alert.
 
 + Response 204
 
-### Update a User Alert [PATCH]
+### Update an Alert [PATCH]
 
-Update a user alert.
+Update an alert.
 <br>
 <br>
 

--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -10,7 +10,7 @@ Alerts allow you to specify an email address to receive notifications regarding 
 <br>
 <ul>
   <li>Usage alerts allow you to set the threshold at which an alert will be sent. For example, if you want to be notified when you've used 90% of your current package's allotted emails, you would set the "percentage" parameter to 90.</li>
-  <li>Stats notifications allow you to set how frequently the alerts will be sent. For example, if you want to receive your stats notifications every day, simply set the "frequency" parameter to "daily".</li>
+  <li>Stats notifications allow you to set how frequently you would like to receive email statistics reports. For example, if you want to receive your stats notifications every day, simply set the "frequency" parameter to "daily". Stats notifications include data such as how many emails you sent each day, in addition to other email events such as bounces, drops, unsubscribes, etc.</li>
 </ul>
 <br>
 For more information about alerts, please visit our <a href="{{root_url}}/User_Guide/Settings/alerts.html">User Guide</a>.
@@ -55,7 +55,7 @@ Retrieve all alerts.
 
 ### Create a New Alert [POST]
 
-Create a new alert.
+Create a new alert. You can create the same alert multiple times, but with different email addresses specified in the "email_to" parameter. This is useful if you have multiple users on the same account who would like to receive the same alerts.
 <br>
 <br>
 

--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -25,33 +25,34 @@ FORMAT: 1A
 Retrieve all alerts.
 
 + Response 200 (application/json)
+    + Body
 
-        [
-            {
-                "created_at": 1451498784,
-                "email_to": "test@example.com",
-                "id": 46,
-                "percentage": 90,
-                "type": "usage_limit",
-                "updated_at": 1451498784
-            },
-            {
-                "created_at": 1451498812,
-                "email_to": "test@example.com",
-                "frequency": "monthly",
-                "id": 47,
-                "type": "stats_notification",
-                "updated_at": 1451498812
-            },
-            {
-                "created_at": 1451520930,
-                "email_to": "test@example.com",
-                "frequency": "daily",
-                "id": 48,
-                "type": "stats_notification",
-                "updated_at": 1451520930
-            }
-        ]
+            [
+                {
+                    "created_at": 1451498784,
+                    "email_to": "test@example.com",
+                    "id": 46,
+                    "percentage": 90,
+                    "type": "usage_limit",
+                    "updated_at": 1451498784
+                },
+                {
+                    "created_at": 1451498812,
+                    "email_to": "test@example.com",
+                    "frequency": "monthly",
+                    "id": 47,
+                    "type": "stats_notification",
+                    "updated_at": 1451498812
+                },
+                {
+                    "created_at": 1451520930,
+                    "email_to": "test@example.com",
+                    "frequency": "daily",
+                    "id": 48,
+                    "type": "stats_notification",
+                    "updated_at": 1451520930
+                }
+            ]
 
 ### Create a New Alert [POST]
 

--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -1,0 +1,134 @@
+---
+layout: page
+title: Alerts API
+weight: 0
+navigation:
+  show: true
+---
+
+FORMAT: 1A
+
+## Alerts Collection [/alerts]
+
+### Get All User Alerts [GET]
+
+Retrieve all alerts.
+
++ Response 200 (application/json)
+
+        [
+            {
+                "created_at": 1451498784,
+                "email_to": "test@example.com",
+                "id": 46,
+                "percentage": 90,
+                "type": "usage_limit",
+                "updated_at": 1451498784
+            },
+            {
+                "created_at": 1451498812,
+                "email_to": "test@example.com",
+                "frequency": "monthly",
+                "id": 47,
+                "type": "stats_notification",
+                "updated_at": 1451498812
+            },
+            {
+                "created_at": 1451520930,
+                "email_to": "test@example.com",
+                "frequency": "daily",
+                "id": 48,
+                "type": "stats_notification",
+                "updated_at": 1451520930
+            }
+        ]
+
+### Create a New User Alert [POST]
+
+Create a new alert.
+<br>
+
++ Attributes (object)
+    + type usage_alert (required, string) - Type of alert to create.
+    + email_to test@example.com (required, string) - Email to send the alert to.
+    + percentage 90 (optional, number) - Required for usage_alert. Threshold to send the email at.
+    + frequency daily (optional, string) - Required for stats_notification. How often to send the notification.
+
+
++ Request (application/json)
+
+    + Body
+
+            {
+                "type": "stats_notification",
+                "email_to": "test@example.com",
+                "frequency": "daily"
+            }
+
++ Response 201 (application/json)
+
+    + Body
+
+            {
+                "created_at": 1451520930,
+                "email_to": "test@example.com",
+                "frequency": "daily",
+                "id": 48,
+                "type": "stats_notification",
+                "updated_at": 1451520930
+            }
+
+## User Alerts Collection [/users/alerts/{user_alert_id}]
+
+### Get a User Alert [GET]
+
+Retrieve a specific alert.
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                "created_at": 1451520930,
+                "email_to": "test@example.com",
+                "frequency": "daily",
+                "id": 48,
+                "type": "stats_notification",
+                "updated_at": 1451520930
+            }
+
+### Delete a User Alert [DELETE]
+
+Delete a user alert.
+
++ Response 204
+
+### Update a User Alert [PATCH]
+
+Update a user alert.
+
++ Attributes
+    + email_to test@example.com (optional, string) - Update the send to email.
+    + frequency monthly (optional, string) - Frequency to send the stats_notification alert at.
+    + percentage 90 (optional, number) - Percentage to send the usage_limit alert at.
+
++ Request (application/json)
+
+    + Body
+
+            {
+                "email_to": "test@example.com"
+            }
+
++ Response 200
+
+    + Body
+
+            {
+                "created_at": 1451520930,
+                "email_to": "test@example.com",
+                "frequency": "daily",
+                "id": 48,
+                "type": "stats_notification",
+                "updated_at": 1451522691
+            }

--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -1,10 +1,20 @@
 ---
 layout: page
 title: Alerts API
-weight: 0
+weight: 100
 navigation:
   show: true
 ---
+
+Alerts allow you to specify an email address to receive notifications regarding your email usage or statistics.
+<br>
+<ul>
+  <li>Usage alerts allow you to set the threshold at which an alert will be sent. For example, if you want to be notified when you've used 90% of your current package's allotted emails, you would set the "percentage" parameter to 90.</li>
+  <li>Stats notifications allow you to set the frequency at which you would like to receive. For example, if you want to receive your stats notifications every day, simply set the "frequency" parameter to "daily".</li>
+</ul>
+<br>
+For more information about alerts, please visit our <a href="{{root_url}}/User_Guide/Settings/alerts.html">User Guide</a>.
+
 
 FORMAT: 1A
 
@@ -47,12 +57,13 @@ Retrieve all alerts.
 
 Create a new alert.
 <br>
+<br>
 
 + Attributes (object)
-    + type usage_alert (required, string) - Type of alert to create.
-    + email_to test@example.com (required, string) - Email to send the alert to.
-    + percentage 90 (optional, number) - Required for usage_alert. Threshold to send the email at.
-    + frequency daily (optional, string) - Required for stats_notification. How often to send the notification.
+    + type usage_alert (required, string) - The type of alert you want to create. Can be either usage_alert or stats_notification.
+    + email_to test@example.com (required, string) - The email address the alert will be sent to.
+    + percentage 90 (optional, number) - Required for usage_alert. When this usage threshold is reached, the alert will be sent.
+    + frequency daily (optional, string) - Required for stats_notification. How frequently the alert will be sent.
 
 
 + Request (application/json)
@@ -106,11 +117,13 @@ Delete a user alert.
 ### Update a User Alert [PATCH]
 
 Update a user alert.
+<br>
+<br>
 
 + Attributes
-    + email_to test@example.com (optional, string) - Update the send to email.
-    + frequency monthly (optional, string) - Frequency to send the stats_notification alert at.
-    + percentage 90 (optional, number) - Percentage to send the usage_limit alert at.
+    + email_to test@example.com (optional, string) - The new email address you want your alert to be sent to.
+    + frequency monthly (optional, string) - The new frequency at which to send the stats_notification alert.
+    + percentage 90 (optional, number) - The new percentage threshold at which the usage_limit alert will be sent.
 
 + Request (application/json)
 


### PR DESCRIPTION
* Added /API_Reference/Web_API_v3/alerts.html
 * Added documentation for the Alerts endpoints:
    * GET /v3/alerts - Retrieves all alerts
    * POST /v3/alerts - Creates a new alert.
    * GET /v3/alerts/{alert_id} - Retrieve a specific alert.
    * DELETE /v3/alerts/{alert_id} - Delete a specific alert.
    * PATCH /v3/alerts/{alert_id} - Update a specific alert.