### PR TITLE
Removed link to deleted Classroom article

### DIFF
--- a/source/Classroom/Troubleshooting/index.html
+++ b/source/Classroom/Troubleshooting/index.html
@@ -45,7 +45,6 @@ navigation:
             <li><a href="{{root_url}}Account_Administration/my_provision_was_declined_what_should_i_do.html">My provision was declined, what should I do?</a></li>
             <li><a href="{{root_url}}Account_Administration/you_cannot_change_your_package_at_this_time_because_your_account_is_not_active.html">Upgrade error message&#58; "You cannot change your package at this time because your account is not active."</a></li>
             <li><a href="{{root_url}}Account_Administration/your_account_is_still_being_provisioned_you_will_not_be_able_to_send_out_any_email.html">"Your account is still being provisioned, you may not be able to send emails"</a></li>
-            <li><a href="{{root_url}}Account_Administration/your_sendgrid_account_is_at_risk_for_suspension_what_should_i_do.html">I got an email saying, "Your SendGrid Account Is At Risk For Suspension". What should I do?</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
Removed the link to /Classroom/Troubleshooting/Account_Administration/your_sendgrid_account_is_at_risk_for_suspension_what_should_i_do.html
 * This article is out of date, and is being removed from the Classroom