### PR TITLE
Open Tracking Pixel Substitution Tag

### DIFF
--- a/source/API_Reference/Web_API_v3/Settings/tracking.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Settings/tracking.apiblueprint
@@ -128,6 +128,8 @@ FORMAT: 1A
 
 ### Update Open Tracking Settings [PATCH]
 
+<p>By default, the open tracking image used to determine when an email is opened is inserted at the end of your email. It is possible to specify an alternative location by using a replacement tag and the open tracking <a href="{{root_url}}/API_Reference/SMTP_API/apps.html#opentrack">SMTP API header</a>.</p>
+
 + Request (application/json)
 
     + Body

--- a/source/API_Reference/Web_API_v3/Settings/tracking.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Settings/tracking.apiblueprint
@@ -128,7 +128,14 @@ FORMAT: 1A
 
 ### Update Open Tracking Settings [PATCH]
 
-<p>By default, the open tracking image used to determine when an email is opened is inserted at the end of your email. It is possible to specify an alternative location by using a replacement tag and the open tracking <a href="{{root_url}}/API_Reference/SMTP_API/apps.html#opentrack">SMTP API header</a>.</p>
+<p>
+  By default, the open tracking image used to determine when an email is opened is inserted at the end of your email. It is possible to specify an alternative location by using a replacement tag and the open tracking <a href="{{root_url}}/API_Reference/SMTP_API/apps.html#opentrack">SMTP API header</a>.
+</p>
+
+<p>
+  If you are sending through the <a href="{{root_url}}/API_Reference/Web_API_v3/Mail/index.html">v3 Mail Send endpoint</a> then you can specify the substitution tag you want to use by setting the <code>enable</code> parameter to <code>true</code> within the <code>open_tracking</code> object and specifying the text you would like to use in the <code>substitution_tag</code> parameter. SendGrid will replace your <code>substitution_tag</code> text with the open tracking pixel wherever you insert it in your email.
+</p>
+
 
 + Request (application/json)
 

--- a/source/User_Guide/Settings/tracking.md
+++ b/source/User_Guide/Settings/tracking.md
@@ -64,6 +64,8 @@ Settings
 
 **Status** - On or Off
 
+**Replacement Tag** - If you do not want the open tracking image to be inserted at the end of your email, it is possible to specify an alternative location by using a replacement tag and the open tracking [SMTP API header]({{root_url}}/API_Reference/SMTP_API/apps.html#opentrack).
+
 **Related Information** - [How Google’s Image Caching effects your opens]({{site.blog_url}}/googles-new-image-caching-5-things-need-know/)
 
 {% anchor h2 %}

--- a/source/User_Guide/Settings/tracking.md
+++ b/source/User_Guide/Settings/tracking.md
@@ -66,6 +66,8 @@ Settings
 
 **Replacement Tag** - If you do not want the open tracking image to be inserted at the end of your email, it is possible to specify an alternative location by using a replacement tag and the open tracking [SMTP API header]({{root_url}}/API_Reference/SMTP_API/apps.html#opentrack).
 
+If you are sending email through our [v3 Web API]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html), you may also enable the `open_tracking` parameter, and set the `substitution_tag` parameter to a value of your choice. You may insert that substitution tag anywhere in your email, and it will be replaced with the open tracking image.
+
 **Related Information** - [How Google’s Image Caching effects your opens]({{site.blog_url}}/googles-new-image-caching-5-things-need-know/)
 
 {% anchor h2 %}

--- a/source/User_Guide/Settings/tracking.md
+++ b/source/User_Guide/Settings/tracking.md
@@ -54,7 +54,7 @@ Open Tracking
 If you are using email link whitelabeling, then your open tracking image will be served from your whitelabel domain instead of from SendGrid.net.
 {% endinfo %}
 
-Open Tracking adds an invisible image at the end of the email which can track email [opens]({{root_url}}/Glossary/opens.html). If the email recipient has images enabled on their email client, a request to SendGrid’s server for the invisible image is executed and an open event is logged. These events are logged in the  Statistics portal, Email Activity interface, and are reported by the Event Webhook.
+Open Tracking adds an invisible, one pixel image at the end of the email which can track email [opens]({{root_url}}/Glossary/opens.html). If the email recipient has images enabled on their email client and a request to SendGrid’s server for the invisible image is executed, then an open event is logged. These events are logged in the Statistics portal, Email Activity interface, and are reported by the Event Webhook.
 
 When using this service customers often ask the difference between a unique open versus an open. A unique open is logged only the first time a given recipient opens the email whereas normal opens are logged for all opens of the email in question.
 


### PR DESCRIPTION
* Added information to the User Guide and the API Reference about how users can specify the location in their email that SendGrid will insert the open tracking pixel.
 * /API_Reference/Web_API_v3/Settings/tracking.html
 * /User_Guide/Settings/tracking.html