### PR TITLE
Added Unicode limitation for "from" field, fixed indentation

### DIFF
--- a/source/API_Reference/Web_API_v3/Mail/index.html
+++ b/source/API_Reference/Web_API_v3/Mail/index.html
@@ -74,6 +74,7 @@ Limitations
   <li>The total number of recipients must be less than 1000. This includes all recipients defined within the <code>to</code>, <code>cc</code>, and <code>bcc</code> parameters, across each object that you include in the <code>personalizations</code> array.</li>
   <li>3000 requests/sec is the maximum rate at which you may call v3 Mail endpoint.</li>
   <li>The total length of custom arguments must be less than 10000 bytes.</li>
+  <li>Unicode encoding is not supported for the <code>from</code> field within the <code>personalizations</code> array.</li>
 </ul>
 
 For more specific, parameter level requirements and limitations, see the <a href="#-Request-Body-Parameters">Request Body Parameters documentation</a>.
@@ -108,7 +109,7 @@ Every request made to <code>/v3/mail/send</code> will require a request body for
     {% api_table_param substitutions "object" No "" "An object following the pattern &#34;substitution_tag&#34;:&#34;value to substitute&#34;. All are assumed to be strings. These substitutions will apply to the content of your email, in addition to the <code>subject</code> and <code>reply-to</code> parameters." 1 %}
     {% api_table_param custom_args "object" No "May not exceed 10,000 bytes" "These are values that are specific to this personalization that will be carried along with the email, activity data, and links. Substitutions will not be made on custom arguments. <code>personalizations[x].custom_args</code> will be merged with message level <code>custom_args</code>, overriding any conflicting keys. The combined total size of the resulting custom arguments, after merging, for each personalization may not exceed 10,000 bytes." 1 %}
     {% api_table_param send_at integer No "" "A unix timestamp allowing you to specify when you want your email to be sent from SendGrid. <b>This is not necessary if you want the email to be sent at the time of your API request.</b>" 1 %}
-  {% api_table_param from "object" No "" "An email object containing the email address and name of the sender." 0 %}
+  {% api_table_param from "object" No "May not include Unicode encoding." "An email object containing the email address and name of the sender. <strong>Unicode encoding is not supported for the <code>from</code> field</strong>." 0 %}
     {% api_table_param email string Yes "" "The email address of the sender." 1 %}
     {% api_table_param name string No "" "The name of the sender." 1 %}
   {% api_table_param reply_to "object" No "" "An email object containing the email address and name of the individual who should receive responses to your email." 0 %}
@@ -116,8 +117,8 @@ Every request made to <code>/v3/mail/send</code> will require a request body for
     {% api_table_param name string No "" "The name of the individual who will receive responses to the email." 1 %}
   {% api_table_param subject string Yes "" "The subject of your email. This may be overridden by <code>personalizations[x].subject</code>." 0 %}
   {% api_table_param content "array of objects" Yes "Min 1" "An array in which you may specify the content of your email. You can include multiple mime types of content, but you must specify at least one. To include more than one mime type, simply add another object to the array containing the <code>type</code> and <code>value</code> parameters. If included, text/plain and text/html must be the first indices of the array in this order. <b>If you choose to include the text/plain or text/html mime types, they must be the first indices of the <code>content<code> array in the order text/plain, text/html.</b>" 0 %}
-    {% api_table_param type string Yes "Min 1" "The mime type of the content you are including in your email. For example, text/plain or text/html." %}
-    {% api_table_param value string Yes "Min 1" "The actual content of the specified mime type that you are including in your email." %}
+    {% api_table_param type string Yes "Min 1" "The mime type of the content you are including in your email. For example, text/plain or text/html." 1 %}
+    {% api_table_param value string Yes "Min 1" "The actual content of the specified mime type that you are including in your email." 1 %}
   {% api_table_param attachments "array of objects" No "" "An array of objects in which you can specify any attachments you want to include." 0 %}
     {% api_table_param content string Yes "" "The Base64 encoded content of the attachment." 1 %}
     {% api_table_param type string No "" "The mime type of the content you are attaching. For example, application/pdf or image/jpeg." 1 %}


### PR DESCRIPTION
* /API_Reference/Web_API_v3/Mail/index.html
 * We do not support Unicode encoding in the from field of the personalizations array
 * Fixed the indentation for the "type" and "value" params within the "content" block in the JSON Schema table