### PR TITLE
Update index.html

### DIFF
--- a/source/Glossary/index.html
+++ b/source/Glossary/index.html
@@ -91,7 +91,6 @@ navigation:
         <a href="{{root_url}}/Glossary/imap.html">IMAP</a>
         <a href="{{root_url}}/Glossary/ip_address.html">IP Address</a>
         <a href="{{root_url}}/Glossary/ip_warmup.html">IP Warmup</a>
-        <a href="{{root_url}}/Glossary/ip_whitelabeling.html">IP Whitelabeling</a>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
Removed link to super old glossary item, will redirect to relevant Whitelabel stuff.