### PR TITLE
Add limit for characters in to.name, cc.name, and bcc.name

### DIFF
--- a/source/API_Reference/Web_API_v3/Mail/index.html
+++ b/source/API_Reference/Web_API_v3/Mail/index.html
@@ -75,6 +75,7 @@ Limitations
   <li>3000 requests/sec is the maximum rate at which you may call v3 Mail endpoint.</li>
   <li>The total length of custom arguments must be less than 10000 bytes.</li>
   <li>Unicode encoding is not supported for the <code>from</code> field within the <code>personalizations</code> array.</li>
+  <li>The <code>to.name</code>, <code>cc.name</code>, and <code>bcc.name</code> personalizations cannot include either the <code>;</code>, <code>,</code>, or <code>.</code> characters.</li>
 </ul>
 
 For more specific, parameter level requirements and limitations, see the <a href="#-Request-Body-Parameters">Request Body Parameters documentation</a>.
@@ -97,13 +98,13 @@ Every request made to <code>/v3/mail/send</code> will require a request body for
   {% api_table_param personalizations "array of objects" Yes "Min 1, Max 1000" "An array of messages and their metadata. Each object within personalizations can be thought of as an envelope - it defines who should receive an individual message and how that message should be handled. For more information, please see our <a href="https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html">documentation on Personalizations</a>. Parameters in personalizations will override the parameters of the same name from the message level." 0 %}
     {% api_table_param to "array of email objects" Yes "Min 1" "An array of recipients. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email." 1 %}
       {% api_table_param email string Yes "" "The email address of the recipient." 2 %}
-      {% api_table_param name string No "" "The name of the recipient." 2 %}
+      {% api_table_param name string No "" "The name of the recipient. May not contain <code>;</code>, <code>.</code>, or <code>,</code>" 2 %}
     {% api_table_param cc "array of email objects" No "" "An array of recipients who will receive a copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email." 1 %}
       {% api_table_param email string Yes "" "The email address of the recipient." 2 %}
-      {% api_table_param name string No "" "The name of the recipient." 2 %}
+      {% api_table_param name string No "" "The name of the recipient. May not contain <code>;</code>, <code>.</code>, or <code>,</code>" 2 %}
     {% api_table_param bcc "array of email objects" No "" "An array of recipients who will receive a blind carbon copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email." 1 %}
       {% api_table_param email string Yes "" "The email address of the recipient." 2 %}
-      {% api_table_param name string No "" "The name of the recipient." 2 %}
+      {% api_table_param name string No "" "The name of the recipient. May not contain <code>;</code>, <code>.</code>, or <code>,</code>" 2 %}
     {% api_table_param subject string No "" "The subject line of your email." 1 %}
     {% api_table_param headers "object" No "" "An object allowing you to specify specific handling instructions for your email." 1 %}
     {% api_table_param substitutions "object" No "" "An object following the pattern &#34;substitution_tag&#34;:&#34;value to substitute&#34;. All are assumed to be strings. These substitutions will apply to the content of your email, in addition to the <code>subject</code> and <code>reply-to</code> parameters." 1 %}


### PR DESCRIPTION
* Added limitation to /API_Reference/Web_API_v3/Mail/index.html
 * The personalizations.to.name, personalizations.cc.name, and personalizations.bcc.name may not include periods, commas, or semicolons