### PR TITLE
Updated Nested Substitution Tags Explanation

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -131,19 +131,14 @@ Email HTML content:
 Nested Substitutions
 {% endanchor %}
 
-It is possible to have up to 4 nested substitutions by using a combinatino of substitution and [section tags]({{root_url}}/API_Reference/SMTP_API/section_tags.html). Any deeper nesting beyond 4 levels of substitutions will result in the tag being printed in your email.
+It is possible to have up to 4 nested substitutions by using a combination of substitution and [section tags]({{root_url}}/API_Reference/SMTP_API/section_tags.html). Any deeper nesting beyond 4 levels of substitutions will result in the tag being printed in your email.
 
 Example: **substitution1** replaced by **section1** replaced by **substitution2** replaced by **section2** replaced by **[substitution5]** -- the email shows "[substitution5]"
- 
- Please note:
-
-* Substitution tags may be nested within section tags.
-* Section tags may be nested within substitution tags.
-* Section tags may be nested within other section tags.
-* Section tags can only be added via substitution tags.
 
 {% warning %}
-It is not possible to nest one substitution tag within another substitution tag.
+**Substitution tags can only be nested within section tags, and section tags can only be nested within substitution tags.**
+
+It is not possible to nest section tags within other section tags, nor subsitution tags within other substitution tags.
 {% endwarning %}
 
 {% anchor h2 %}

--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -131,20 +131,20 @@ Email HTML content:
 Nested Substitutions
 {% endanchor %}
 
-You can have up to 4 nested substitutions. Any deeper nesting will result in the tag being printed in your email.
-
-Example: **substitution1** replaced by **substitution2** replaced by **substitution3** replaced by **substitution4** replaced by **[substitution5]** - the email shows "[substitution5]"
-
-This works for [section tags]({{root_url}}/API_Reference/SMTP_API/section_tags.html) as well:
+It is possible to have up to 4 nested substitutions by using a combinatino of substitution and [section tags]({{root_url}}/API_Reference/SMTP_API/section_tags.html). Any deeper nesting beyond 4 levels of substitutions will result in the tag being printed in your email.
 
 Example: **substitution1** replaced by **section1** replaced by **substitution2** replaced by **section2** replaced by **[substitution5]** -- the email shows "[substitution5]"
  
  Please note:
 
-* Substitution tags within section tags work
-* Section tags within substitution tags work
-* Section tags within section tags work
-* Section tags can only be added via substitution tags
+* Substitution tags may be nested within section tags.
+* Section tags may be nested within substitution tags.
+* Section tags may be nested within other section tags.
+* Section tags can only be added via substitution tags.
+
+{% warning %}
+It is not possible to nest one substitution tag within another substitution tag.
+{% endwarning %}
 
 {% anchor h2 %}
 SendGrid Defined Substitution Tags


### PR DESCRIPTION
You can nest substitution tags by using section tags. Substitution tags cannot be nested on their own!