### PR TITLE
added redirect for Bulk Sender Notification

### DIFF
--- a/source/_redirects.htaccess
+++ b/source/_redirects.htaccess
@@ -456,6 +456,7 @@ Redirect 301 /Delivery_Metrics/email_reports.html https://sendgrid.com/docs/User
 
 Redirect 301 /Glossary/Email_Types/peer_invitations.html https://sendgrid.com/docs/Glossary/peer_invitations.html
 Redirect 301 /Glossary/ip_whitelabeling.html https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/ips.html
+Redirect 301 /Glossary/bulk_sender_notification.html https://sendgrid.com/docs/Glossary/index.html
 
 #######
 #


### PR DESCRIPTION
* We are deleting /Glossary/bulk_sender_notification.html
 * Redirecting that page to the /Glossary/index.html