### PR TITLE
added note about post_to_url requirements to v3 mail send docs

### DIFF
--- a/source/API_Reference/Web_API_v3/Mail/errors.md
+++ b/source/API_Reference/Web_API_v3/Mail/errors.md
@@ -491,6 +491,8 @@ Mail Settings Errors
   {% api_error_table_message "The spam check url must be a string." "" %}
 
   {% api_error_table_message "You must include the url to post to when using the spam check mail setting." "" %}
+
+  {% api_error_table_message "The `post_to_url` parameter must start with `http://` or `https://`." "" %}
 {% endapi_error_table %}
 
 {% api_error_table mail_settings.spam_check.threshold "" message.mail_settings.spam_check.threshold %}

--- a/source/API_Reference/Web_API_v3/Mail/index.html
+++ b/source/API_Reference/Web_API_v3/Mail/index.html
@@ -152,7 +152,7 @@ Every request made to <code>/v3/mail/send</code> will require a request body for
     {% api_table_param spam_check object No "" "This allows you to test the content of your email for spam." 1 %}
       {% api_table_param enable boolean No "true or false" "Indicates if this setting is enabled." 2 %}
       {% api_table_param threshold integer No "Max 10" "The threshold used to determine if your content qualifies as spam on a scale from 1 to 10, with 10 being most strict, or most likely to be considered as spam." 2 %}
-      {% api_table_param post_to_url string No "" "An Inbound Parse URL that you would like a copy of your email along with the spam report to be sent to." 2 %}
+      {% api_table_param post_to_url string No "" "An Inbound Parse URL that you would like a copy of your email along with the spam report to be sent to. The <code>post_to_url</code> parameter must start with <code>http://</code> or <code>https://</code>." 2 %}
   {% api_table_param tracking_settings object No "" "Settings to determine how you would like to track the metrics of how your recipients interact with your email." 0 %}
     {% api_table_param click_tracking object No "" "Allows you to track whether a recipient clicked a link in your email." 1 %}
       {% api_table_param enable boolean No "true or false" "Indicates if this setting is enabled." 2 %}


### PR DESCRIPTION
* /API_Reference/Web_API_v3/Mail/errors.html
* /API_Reference/Web_API_v3/Mail/index.html
 * Added requirement to both pages: "The post_to_url parameter must start with either 'http://' or 'https://'