### PR TITLE
Added Basic Auth documentation for v3 API

### DIFF
--- a/source/API_Reference/Web_API_v3/index.md
+++ b/source/API_Reference/Web_API_v3/index.md
@@ -43,7 +43,7 @@ Every API request you make to the Web API v3 must be authenticated by including 
 
 {% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/templates" -H "Authorization: Bearer Your.API.Key-HERE" -H "Content-Type: application/json" {% endcodeblock %}
 
-To access the API with the elevated permissions of the full user account, for example to change permission scope of an API Key, you can access the API with basic HTTP authentication. More information about basic auth can be found [here](https://sendgrid.com/blog/magic-behind-basic-http-authentication/).
+To access the API with the elevated permissions of the full user account, for example to change the permission scope of an API Key, you can also access the API with basic HTTP authentication. More information about basic auth can be found [here](https://sendgrid.com/blog/magic-behind-basic-http-authentication/).
 
 {% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/api_keys" -H "Authorization: Basic base64encoded.user:password-HERE" -H "Content-Type: application/json" {% endcodeblock %}
 

--- a/source/API_Reference/Web_API_v3/index.md
+++ b/source/API_Reference/Web_API_v3/index.md
@@ -43,6 +43,10 @@ Every API request you make to the Web API v3 must be authenticated by including 
 
 {% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/templates" -H "Authorization: Bearer Your.API.Key-HERE" -H "Content-Type: application/json" {% endcodeblock %}
 
+To access the API with the elevated permissions of the full user account, for example to change permission scope of an API Key, you can access the API with basic HTTP authentication. More information about basic auth can be found [here](https://sendgrid.com/blog/magic-behind-basic-http-authentication/).
+
+{% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/api_keys" -H "Authorization: Basic base64encoded.user:password-HERE" -H "Content-Type: application/json" {% endcodeblock %}
+
 ###[Requests]({{root_url}}/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/requests.html)
 
 All requests to the Web API v3 must be made via HTTPS. The Web API v3 is completely RESTful and accepts GET, POST, PUT, and DELETE requests, depending on the resource.


### PR DESCRIPTION
Basic Auth can be used to access the API with elevated rights, e.g.
needed to change the permissions of an API Key