### PR TITLE
Update when_do_credits_reset.md

### DIFF
--- a/source/Classroom/Basics/Billing/when_do_credits_reset.md
+++ b/source/Classroom/Basics/Billing/when_do_credits_reset.md
@@ -11,6 +11,6 @@ navigation:
   show: true
 ---
 
-Essentails, Pro, and Premier accounts will see their email credits reset the _1st day of each month_ at 12:01 PST.
+Free, Essentials, Pro, and Premier accounts will see their email credits reset the _1st day of each month_ at 12:01 PST.
 
-For Free, as well as [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html) accounts, credits will reset _daily_ at 12:01 PST.
+[Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html) accounts will see their credits reset _daily_ at 12:01 PST.


### PR DESCRIPTION
Free accounts are given 12k emails/month so the credits will reset monthly, not daily.