### PR TITLE
Correct wording for setting_up_the_inbound_parse_webhook.md

### DIFF
--- a/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
+++ b/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
@@ -74,7 +74,7 @@ The URL must be accessible from the public web.
 
   ![]({{root}}/images/setting_up_inbound_parse_1.png)
 
-  **(4)** (Optional) Check **Spam Check** if you want Inbound Parse to check incoming email and reject obvious spam. Checking this box will also include the spam report and spam score in the payload.
+  **(4)** (Optional) Check **Spam Check** if you want Inbound Parse to check incoming email for spam. Checking this box will also include the spam report and spam score in the payload.
 
   **(5)** (Optional) Check **Send Raw** if you would prefer to receive the full MIME message in encoded in JSON.
 


### PR DESCRIPTION
Wording needed to be corrected regarding Spam Check as we do not reject emails for parsing based on content.