### PR TITLE
Added Clarification: To address shown to BCC recipient is random

### DIFF
--- a/source/API_Reference/Web_API_v3/Mail/index.html
+++ b/source/API_Reference/Web_API_v3/Mail/index.html
@@ -102,7 +102,7 @@ Every request made to <code>/v3/mail/send</code> will require a request body for
     {% api_table_param cc "array of email objects" No "" "An array of recipients who will receive a copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email." 1 %}
       {% api_table_param email string Yes "" "The email address of the recipient." 2 %}
       {% api_table_param name string No "" "The name of the recipient. May not contain <code>;</code>, <code>.</code>, or <code>,</code>" 2 %}
-    {% api_table_param bcc "array of email objects" No "" "An array of recipients who will receive a blind carbon copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email." 1 %}
+    {% api_table_param bcc "array of email objects" No "" "An array of recipients who will receive a blind carbon copy of your email. Each email object within this array may contain the recipient’s name, but must always contain the recipient’s email. When including a BCC of your email, the recipient of the BCC will be shown the To address specified in the original message. However, if you are sending multiple personalizations with multiple To addresses, the BCC recipient will randomly be shown any one of these To addresses. There is no way to guarantee which To address will be included in the BCC's email." 1 %}
       {% api_table_param email string Yes "" "The email address of the recipient." 2 %}
       {% api_table_param name string No "" "The name of the recipient. May not contain <code>;</code>, <code>.</code>, or <code>,</code>" 2 %}
     {% api_table_param subject string No "" "The subject line of your email." 1 %}

--- a/source/Classroom/Send/v3_Mail_Send/personalizations.md
+++ b/source/Classroom/Send/v3_Mail_Send/personalizations.md
@@ -46,6 +46,12 @@ Keys within objects like custom_args will be merged. If any of the keys conflict
 All of the recipients in a single personalization object (either in the `to`, `cc`, or `bcc` fields), will see exactly the same email, as defined by the data in that personalization, as such we do not allow duplicate emails between these three arrays in a single personalization.
 {% endinfo %}
 
+{% warning %}
+When including a BCC of your email, the recipient of the BCC will be shown the To address specified in the original message.
+
+However, if you are sending multiple personalizations with multiple To addresses, the BCC recipient will randomly be shown any one of these To addresses. There is no way to guarantee which To address will be included in the BCC's email.
+{% endwarning %}
+
 Below are some examples of how you can use personalizations for various use cases.
 
 Personalization Examples Index


### PR DESCRIPTION
* Added a clarifying note explaining that the BCC recipient will see the To address specified in the original message, but if there are more than one To addresses specified in multiple personalizations, then the To address shown to the BCC recipient is random.
  * /API_Reference/Web_API_v3/Mail/index.html
  * /Classroom/Send/v3_Mail_Send/personalizations.md