### PR TITLE
Update alerts.apiblueprint

### DIFF
--- a/source/API_Reference/Web_API_v3/alerts.apiblueprint
+++ b/source/API_Reference/Web_API_v3/alerts.apiblueprint
@@ -61,9 +61,9 @@ Create a new alert. You can create the same alert multiple times, but with diffe
 <br>
 
 + Attributes (object)
-    + type usage_alert (required, string) - The type of alert you want to create. Can be either usage_alert or stats_notification.
+    + type usage_limit (required, string) - The type of alert you want to create. Can be either usage_limit or stats_notification.
     + email_to test@example.com (required, string) - The email address the alert will be sent to.
-    + percentage 90 (optional, number) - Required for usage_alert. When this usage threshold is reached, the alert will be sent.
+    + percentage 90 (optional, number) - Required for usage_limit. When this usage threshold is reached, the alert will be sent.
     + frequency daily (optional, string) - Required for stats_notification. How frequently the alert will be sent.
 
 


### PR DESCRIPTION
The type of "usage_alert" is not functional or does not exist. Any place where "usage_alert" was I replaced with "usage_limit".