### PR TITLE
Updated API Key Scopes Docs

### DIFF
--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -44,6 +44,7 @@ The following is a complete list of all possible permissions that you may assign
         <h3><a href="#Webhook">Webhook</a></h3>
         <h3><a href="#Whitelabel">Whitelabel</a></h3>
         <h3><a href="#Whitelist">Whitelist</a></h3>
+        <h3><a href="#Admin-API-Key-Scopes">Admin API Key Scopes</a></h3>
     </div>
 </div>
 
@@ -80,6 +81,7 @@ The following is a complete list of all possible permissions that you may assign
 {% anchor h2 %}Billing{% endanchor %}
 {% codeblock %}
 "scopes": [
+  "billing.create",
   "billing.delete",
   "billing.read",
   "billing.update"
@@ -142,9 +144,12 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "ips.pools.update",
   "ips.pools.ips.create",
   "ips.pools.ips.delete",
+  "ips.pools.ips.read",
+  "ips.pools.ips.update",
   "ips.warmup.create",
   "ips.warmup.delete",
-  "ips.warmup.read"
+  "ips.warmup.read",
+  "ips.warmup.update"
 ]
 {% endcodeblock %}
 
@@ -195,6 +200,17 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 ]
 {% endcodeblock %}
 
+{% anchor h2 %}Newsletter{% endanchor %}
+
+{% codeblock %}
+"scopes": [
+  "newsletter.create",
+  "newsletter.delete",
+  "newsletter.read",
+  "newsletter.update"
+]
+{% endcodeblock %}
+
 {% anchor h2 %}Partner Settings{% endanchor %}
 {% codeblock %}
 "scopes": [
@@ -223,8 +239,13 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "subusers.delete",
   "subusers.read",
   "subusers.update",
+  "subusers.credits.create",
+  "subusers.credits.delete",
   "subusers.credits.read",
   "subusers.credits.update",
+  "subusers.credits.remaining.create",
+  "subusers.credits.remaining.delete",
+  "subusers.credits.remaining.read",
   "subusers.credits.remaining.update",
   "subusers.monitor.create",
   "subusers.monitor.delete",
@@ -234,16 +255,37 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "subusers.stats.read",
   "subusers.stats.monthly.read",
   "subusers.stats.sums.read"
+  "subusers.summary.read"
 ]
 {% endcodeblock %}
 
-{% anchor h2 %}Suppression{% endanchor %}
+{% anchor h2 %}Suppressions{% endanchor %}
 {% codeblock %}
 "scopes": [
   "suppression.create",
   "suppression.delete",
   "suppression.read",
-  "suppression.update"
+  "suppression.update",
+  "suppression.bounces.create",
+  "suppression.bounces.read",
+  "suppression.bounces.update",
+  "suppression.bounces.delete",
+  "suppression.blocks.create",
+  "suppression.blocks.read",
+  "suppression.blocks.update",
+  "suppression.blocks.delete",
+  "suppression.invalid_emails.create",
+  "suppression.invalid_emails.read",
+  "suppression.invalid_emails.update",
+  "suppression.invalid_emails.delete",
+  "suppression.spam_reports.create",
+  "suppression.spam_reports.read",
+  "suppression.spam_reports.update",
+  "suppression.spam_reports.delete",
+  "suppression.unsubscribes.create",
+  "suppression.unsubscribes.read",
+  "suppression.unsubscribes.update",
+  "suppression.unsubscribes.delete"
 ]
 {% endcodeblock %}
 
@@ -283,14 +325,8 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 {% anchor h2 %}User Settings{% endanchor %}
 {% codeblock %}
 "scopes": [
-  "user.account.create",
-  "user.account.delete",
   "user.account.read",
-  "user.account.update",
-  "user.credits.create",
-  "user.credits.delete",
   "user.credits.read",
-  "user.credits.update",
   "user.email.create",
   "user.email.delete",
   "user.email.read",
@@ -299,24 +335,14 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "user.multifactor_authentication.delete",
   "user.multifactor_authentication.read",
   "user.multifactor_authentication.update",
-  "user.password.create",
-  "user.password.delete",
   "user.password.read",
   "user.password.update",
-  "user.profile.create",
-  "user.profile.delete",
   "user.profile.read",
   "user.profile.update",
-  "user.settings.enforced_tls.create",
-  "user.settings.enforced_tls.delete",
   "user.settings.enforced_tls.read",
   "user.settings.enforced_tls.update",
-  "user.timezone.create",
-  "user.timezone.delete",
   "user.timezone.read",
   "user.timezone.update",
-  "user.username.create",
-  "user.username.delete",
   "user.username.read",
   "user.username.update"
 ]
@@ -327,6 +353,9 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 "scopes": [
   "user.webhooks.event.settings.read",
   "user.webhooks.event.settings.update",
+  "user.webhooks.event.test.create",
+  "user.webhooks.event.test.read",
+  "user.webhooks.event.test.update",
   "user.webhooks.parse.settings.create",
   "user.webhooks.parse.settings.delete",
   "user.webhooks.parse.settings.read",
@@ -348,8 +377,216 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 {% anchor h2 %}Whitelist{% endanchor %}
 {% codeblock %}
 "scopes": [
+  "access_settings.activity.read",
+  "access_settings.whitelist.create",
   "access_settings.whitelist.delete",
   "access_settings.whitelist.read",
   "access_settings.whitelist.update"
+]
+{% endcodeblock %}
+
+{% anchor h2 %}Admin API Key Scopes{% endanchor %}
+
+Below is a complete list of every API Key scope to be given to an admin level API Key.
+
+{% codeblock %}
+"scopes": [
+  "access_settings.activity.read",
+  "access_settings.whitelist.create",
+  "access_settings.whitelist.delete",
+  "access_settings.whitelist.read",
+  "access_settings.whitelist.update",
+  "alerts.create",
+  "alerts.delete",
+  "alerts.read",
+  "alerts.update",
+  "api_keys.create",
+  "api_keys.delete",
+  "api_keys.read",
+  "api_keys.update",
+  "asm.groups.create",
+  "asm.groups.delete",
+  "asm.groups.read",
+  "asm.groups.update",
+  "billing.create",
+  "billing.delete",
+  "billing.read",
+  "billing.update",
+  "browsers.stats.read",
+  "categories.create",
+  "categories.delete",
+  "categories.read",
+  "categories.stats.read",
+  "categories.stats.sums.read",
+  "categories.update",
+  "clients.desktop.stats.read",
+  "clients.phone.stats.read",
+  "clients.stats.read",
+  "clients.tablet.stats.read",
+  "clients.webmail.stats.read",
+  "credentials.create",
+  "credentials.delete",
+  "credentials.read",
+  "credentials.update",
+  "devices.stats.read",
+  "email_activity.read",
+  "geo.stats.read",
+  "ips.assigned.read",
+  "ips.pools.create",
+  "ips.pools.delete",
+  "ips.pools.ips.create",
+  "ips.pools.ips.delete",
+  "ips.pools.ips.read",
+  "ips.pools.ips.update",
+  "ips.pools.read",
+  "ips.pools.update",
+  "ips.read",
+  "ips.warmup.create",
+  "ips.warmup.delete",
+  "ips.warmup.read",
+  "ips.warmup.update",
+  "mail_settings.address_whitelist.read",
+  "mail_settings.address_whitelist.update",
+  "mail_settings.bcc.read",
+  "mail_settings.bcc.update",
+  "mail_settings.bounce_purge.read",
+  "mail_settings.bounce_purge.update",
+  "mail_settings.footer.read",
+  "mail_settings.footer.update",
+  "mail_settings.forward_bounce.read",
+  "mail_settings.forward_bounce.update",
+  "mail_settings.forward_spam.read",
+  "mail_settings.forward_spam.update",
+  "mail_settings.plain_content.read",
+  "mail_settings.plain_content.update",
+  "mail_settings.read",
+  "mail_settings.spam_check.read",
+  "mail_settings.spam_check.update",
+  "mail_settings.template.read",
+  "mail_settings.template.update",
+  "mail.batch.create",
+  "mail.batch.delete",
+  "mail.batch.read",
+  "mail.batch.update",
+  "mail.send",
+  "mailbox_providers.stats.read",
+  "marketing_campaigns.create",
+  "marketing_campaigns.delete",
+  "marketing_campaigns.read",
+  "marketing_campaigns.update",
+  "newsletter.create",
+  "newsletter.delete",
+  "newsletter.read",
+  "newsletter.update",
+  "partner_settings.new_relic.read",
+  "partner_settings.new_relic.update",
+  "partner_settings.read",
+  "partner_settings.sendwithus.read",
+  "partner_settings.sendwithus.update",
+  "stats.global.read",
+  "stats.read",
+  "subusers.create",
+  "subusers.credits.create",
+  "subusers.credits.delete",
+  "subusers.credits.read",
+  "subusers.credits.remaining.create",
+  "subusers.credits.remaining.delete",
+  "subusers.credits.remaining.read",
+  "subusers.credits.remaining.update",
+  "subusers.credits.update",
+  "subusers.delete",
+  "subusers.monitor.create",
+  "subusers.monitor.delete",
+  "subusers.monitor.read",
+  "subusers.monitor.update",
+  "subusers.read",
+  "subusers.reputations.read",
+  "subusers.stats.monthly.read",
+  "subusers.stats.read",
+  "subusers.stats.sums.read",
+  "subusers.summary.read",
+  "subusers.update",
+  "suppression.blocks.create",
+  "suppression.blocks.delete",
+  "suppression.blocks.read",
+  "suppression.blocks.update",
+  "suppression.bounces.create",
+  "suppression.bounces.delete",
+  "suppression.bounces.read",
+  "suppression.bounces.update",
+  "suppression.create",
+  "suppression.delete",
+  "suppression.invalid_emails.create",
+  "suppression.invalid_emails.delete",
+  "suppression.invalid_emails.read",
+  "suppression.invalid_emails.update",
+  "suppression.read",
+  "suppression.spam_reports.create",
+  "suppression.spam_reports.delete",
+  "suppression.spam_reports.read",
+  "suppression.spam_reports.update",
+  "suppression.unsubscribes.create",
+  "suppression.unsubscribes.delete",
+  "suppression.unsubscribes.read",
+  "suppression.unsubscribes.update",
+  "suppression.update",
+  "templates.create",
+  "templates.delete",
+  "templates.read",
+  "templates.update",
+  "templates.versions.activate.create",
+  "templates.versions.activate.delete",
+  "templates.versions.activate.read",
+  "templates.versions.activate.update",
+  "templates.versions.create",
+  "templates.versions.delete",
+  "templates.versions.read",
+  "templates.versions.update",
+  "tracking_settings.click.read",
+  "tracking_settings.click.update",
+  "tracking_settings.google_analytics.read",
+  "tracking_settings.google_analytics.update",
+  "tracking_settings.open.read",
+  "tracking_settings.open.update",
+  "tracking_settings.read",
+  "tracking_settings.subscription.read",
+  "tracking_settings.subscription.update",
+  "user.account.read",
+  "user.credits.read",
+  "user.email.create",
+  "user.email.delete",
+  "user.email.read",
+  "user.email.update",
+  "user.multifactor_authentication.create",
+  "user.multifactor_authentication.delete",
+  "user.multifactor_authentication.read",
+  "user.multifactor_authentication.update",
+  "user.password.read",
+  "user.password.update",
+  "user.profile.read",
+  "user.profile.update",
+  "user.scheduled_sends.create",
+  "user.scheduled_sends.delete",
+  "user.scheduled_sends.read",
+  "user.scheduled_sends.update",
+  "user.settings.enforced_tls.read",
+  "user.settings.enforced_tls.update",
+  "user.timezone.read",
+  "user.username.read",
+  "user.username.update",
+  "user.webhooks.event.settings.read",
+  "user.webhooks.event.settings.update",
+  "user.webhooks.event.test.create",
+  "user.webhooks.event.test.read",
+  "user.webhooks.event.test.update",
+  "user.webhooks.parse.settings.create",
+  "user.webhooks.parse.settings.delete",
+  "user.webhooks.parse.settings.read",
+  "user.webhooks.parse.settings.update",
+  "user.webhooks.parse.stats.read",
+  "whitelabel.create",
+  "whitelabel.delete",
+  "whitelabel.read",
+  "whitelabel.update"
 ]
 {% endcodeblock %}

--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -85,7 +85,7 @@ Several specific use cases for an API Key and the permissions that you might wan
 Adding Additional API Key Permissons Not Listed In the User Interface
 {% endanchor h3 %}
 
-As it turns out, the [API Key Permissions List](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html) contains more permissions that can be added to your API key than those listed when creating a new API key. Currently, when you create new key in the user interface and give it full access, it excludes additional permissions that can be added via an API call. The best way to see what permissions your API key has is by making [this call](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/api_keys_permissions.html) using the same API key to make the request. 
+As it turns out, the [API Key Permissions List](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html) contains more permissions that can be added to your API key than those listed when creating a new API key. Currently, when you create new key in the user interface and give it full access, it excludes additional permissions that can be added via an API call. The best way to see what permissions your API key has is by making [this call](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/api_keys_permissions.html) using the same API key to make the request.
 
 For the user profile request you're attempting to make, you will need to make sure you have these permissions:
 
@@ -96,7 +96,7 @@ For the user profile request you're attempting to make, you will need to make su
 ]
 {% endcodeblock %}
 
-To give your API key these extra permissions you will need to make [this request](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/index.html#Update-the-name-amp-scopes-of-an-API-Key-PUT). 
+To give your API key these extra permissions you will need to make [this request](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/index.html#Update-the-name-amp-scopes-of-an-API-Key-PUT).
 
 **Important things** to know before making the above API request:
 
@@ -109,7 +109,7 @@ To give your API key these extra permissions you will need to make [this request
 We only recommend authenticating with your username and password when updating your API Key permissions. All other API calls should be authenticated via your API Key.
 {% endwarning %}
 
-**2.** Make sure that when you make the request, you add **all of the scopes** you want the API key to have. For example, if you make the request and just list "categories.read" as the scopes, you will then have a key with only the "categories.read" scope. Make sure to list everything you get from the [get existing key request](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/index.html#Get-an-existing-API-Key-GET) in addition to the new scopes you want to add. 
+**2.** Make sure that when you make the request, you add **all of the scopes** you want the API key to have. For example, if you make the request and just list "categories.read" as the scopes, you will then have a key with only the "categories.read" scope. Make sure to list everything you get from the [get existing key request](https://sendgrid.com/docs/API_Reference/Web_API_v3/API_Keys/index.html#Get-an-existing-API-Key-GET) in addition to the new scopes you want to add.
 
 {% anchor h2 %}
 Example Permissions for Common API Key Use Cases
@@ -136,6 +136,7 @@ Example Permissions for Common API Key Use Cases
   <li><a href="#-Full-Access-for-Mail-Settings">Mail Settings: Full Access</a></li>
   <li><a href="#-Read-Only-Access-for-Marketing-Campaigns">Marketing Campaigns: Read Only Access</a></li>
   <li><a href="#-Full-Access-for-Marketing-Campaigns">Marketing Campaigns: Full Access</a></li>
+  <li><a href="#-Admin-Level-API-Key-Scopes">Admin Level API Key Scopes</a></li>
 </ul>
 
 {% anchor h3 %}
@@ -387,5 +388,213 @@ Full Access for Marketing Campaigns
   "marketing_campaigns.read",
   "marketing_campaigns.update",
   "partner_settings.new_relic.read"
+]
+{% endcodeblock %}
+
+{% anchor h3 %}
+Admin Level API Key Scopes
+{% endanchor %}
+
+Below is a list of every scope included in an administrator level API Key.
+
+{% codeblock %}
+"scopes": [
+  "access_settings.activity.read",
+  "access_settings.whitelist.create",
+  "access_settings.whitelist.delete",
+  "access_settings.whitelist.read",
+  "access_settings.whitelist.update",
+  "alerts.create",
+  "alerts.delete",
+  "alerts.read",
+  "alerts.update",
+  "api_keys.create",
+  "api_keys.delete",
+  "api_keys.read",
+  "api_keys.update",
+  "asm.groups.create",
+  "asm.groups.delete",
+  "asm.groups.read",
+  "asm.groups.update",
+  "billing.create",
+  "billing.delete",
+  "billing.read",
+  "billing.update",
+  "browsers.stats.read",
+  "categories.create",
+  "categories.delete",
+  "categories.read",
+  "categories.stats.read",
+  "categories.stats.sums.read",
+  "categories.update",
+  "clients.desktop.stats.read",
+  "clients.phone.stats.read",
+  "clients.stats.read",
+  "clients.tablet.stats.read",
+  "clients.webmail.stats.read",
+  "credentials.create",
+  "credentials.delete",
+  "credentials.read",
+  "credentials.update",
+  "devices.stats.read",
+  "email_activity.read",
+  "geo.stats.read",
+  "ips.assigned.read",
+  "ips.pools.create",
+  "ips.pools.delete",
+  "ips.pools.ips.create",
+  "ips.pools.ips.delete",
+  "ips.pools.ips.read",
+  "ips.pools.ips.update",
+  "ips.pools.read",
+  "ips.pools.update",
+  "ips.read",
+  "ips.warmup.create",
+  "ips.warmup.delete",
+  "ips.warmup.read",
+  "ips.warmup.update",
+  "mail_settings.address_whitelist.read",
+  "mail_settings.address_whitelist.update",
+  "mail_settings.bcc.read",
+  "mail_settings.bcc.update",
+  "mail_settings.bounce_purge.read",
+  "mail_settings.bounce_purge.update",
+  "mail_settings.footer.read",
+  "mail_settings.footer.update",
+  "mail_settings.forward_bounce.read",
+  "mail_settings.forward_bounce.update",
+  "mail_settings.forward_spam.read",
+  "mail_settings.forward_spam.update",
+  "mail_settings.plain_content.read",
+  "mail_settings.plain_content.update",
+  "mail_settings.read",
+  "mail_settings.spam_check.read",
+  "mail_settings.spam_check.update",
+  "mail_settings.template.read",
+  "mail_settings.template.update",
+  "mail.batch.create",
+  "mail.batch.delete",
+  "mail.batch.read",
+  "mail.batch.update",
+  "mail.send",
+  "mailbox_providers.stats.read",
+  "marketing_campaigns.create",
+  "marketing_campaigns.delete",
+  "marketing_campaigns.read",
+  "marketing_campaigns.update",
+  "newsletter.create",
+  "newsletter.delete",
+  "newsletter.read",
+  "newsletter.update",
+  "partner_settings.new_relic.read",
+  "partner_settings.new_relic.update",
+  "partner_settings.read",
+  "partner_settings.sendwithus.read",
+  "partner_settings.sendwithus.update",
+  "stats.global.read",
+  "stats.read",
+  "subusers.create",
+  "subusers.credits.create",
+  "subusers.credits.delete",
+  "subusers.credits.read",
+  "subusers.credits.remaining.create",
+  "subusers.credits.remaining.delete",
+  "subusers.credits.remaining.read",
+  "subusers.credits.remaining.update",
+  "subusers.credits.update",
+  "subusers.delete",
+  "subusers.monitor.create",
+  "subusers.monitor.delete",
+  "subusers.monitor.read",
+  "subusers.monitor.update",
+  "subusers.read",
+  "subusers.reputations.read",
+  "subusers.stats.monthly.read",
+  "subusers.stats.read",
+  "subusers.stats.sums.read",
+  "subusers.summary.read",
+  "subusers.update",
+  "suppression.blocks.create",
+  "suppression.blocks.delete",
+  "suppression.blocks.read",
+  "suppression.blocks.update",
+  "suppression.bounces.create",
+  "suppression.bounces.delete",
+  "suppression.bounces.read",
+  "suppression.bounces.update",
+  "suppression.create",
+  "suppression.delete",
+  "suppression.invalid_emails.create",
+  "suppression.invalid_emails.delete",
+  "suppression.invalid_emails.read",
+  "suppression.invalid_emails.update",
+  "suppression.read",
+  "suppression.spam_reports.create",
+  "suppression.spam_reports.delete",
+  "suppression.spam_reports.read",
+  "suppression.spam_reports.update",
+  "suppression.unsubscribes.create",
+  "suppression.unsubscribes.delete",
+  "suppression.unsubscribes.read",
+  "suppression.unsubscribes.update",
+  "suppression.update",
+  "templates.create",
+  "templates.delete",
+  "templates.read",
+  "templates.update",
+  "templates.versions.activate.create",
+  "templates.versions.activate.delete",
+  "templates.versions.activate.read",
+  "templates.versions.activate.update",
+  "templates.versions.create",
+  "templates.versions.delete",
+  "templates.versions.read",
+  "templates.versions.update",
+  "tracking_settings.click.read",
+  "tracking_settings.click.update",
+  "tracking_settings.google_analytics.read",
+  "tracking_settings.google_analytics.update",
+  "tracking_settings.open.read",
+  "tracking_settings.open.update",
+  "tracking_settings.read",
+  "tracking_settings.subscription.read",
+  "tracking_settings.subscription.update",
+  "user.account.read",
+  "user.credits.read",
+  "user.email.create",
+  "user.email.delete",
+  "user.email.read",
+  "user.email.update",
+  "user.multifactor_authentication.create",
+  "user.multifactor_authentication.delete",
+  "user.multifactor_authentication.read",
+  "user.multifactor_authentication.update",
+  "user.password.read",
+  "user.password.update",
+  "user.profile.read",
+  "user.profile.update",
+  "user.scheduled_sends.create",
+  "user.scheduled_sends.delete",
+  "user.scheduled_sends.read",
+  "user.scheduled_sends.update",
+  "user.settings.enforced_tls.read",
+  "user.settings.enforced_tls.update",
+  "user.timezone.read",
+  "user.username.read",
+  "user.username.update",
+  "user.webhooks.event.settings.read",
+  "user.webhooks.event.settings.update",
+  "user.webhooks.event.test.create",
+  "user.webhooks.event.test.read",
+  "user.webhooks.event.test.update",
+  "user.webhooks.parse.settings.create",
+  "user.webhooks.parse.settings.delete",
+  "user.webhooks.parse.settings.read",
+  "user.webhooks.parse.settings.update",
+  "user.webhooks.parse.stats.read",
+  "whitelabel.create",
+  "whitelabel.delete",
+  "whitelabel.read",
+  "whitelabel.update"
 ]
 {% endcodeblock %}


### PR DESCRIPTION
* /API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
  * Includes complete list of API Key scopes (aka permissions)
  * Includes code example containing single list of all admin-specific scopes to make copy-pasting easier for users creating an administrator level API key from the API.
* /Classroom/Basics/API/api_key_permissions.html
  * Includes complete list of API Key scopes (aka permissions)
  * Includes code example containing single list of all admin-specific scopes to make copy-pasting easier for users creating an administrator level API key from the API.