### PR TITLE
added redirect for antiquated docs page

### DIFF
--- a/source/_redirects.htaccess
+++ b/source/_redirects.htaccess
@@ -398,6 +398,7 @@ Redirect 301 /Classroom/Track/how_do_i_unsubscribe_a_user.html https://sendgrid.
 Redirect 301 /Classroom/Track/unsubscribe_via_subscription_tracking.html https://sendgrid.com/docs/Classroom/Track/Unsubscribes/unsubscribe_via_subscription_tracking.html
 Redirect 301 /Classroom/Track/Introduction/what_do_all_these_delivery_statistics_mean.html https://sendgrid.com/docs/Classroom/Track/index.html
 Redirect 301 /Classroom/Track/Collecting_Data/sendwithus.html https://support.sendwithus.com/esp_accounts/connect_sendgrid/
+Redirect 301 /Classroom/Track/unsubscribe_via_the_subscription_tracking.html https://sendgrid.com/docs/Classroom/Track/Unsubscribes/unsubscribe_via_subscription_tracking.html
 
 #######
 #


### PR DESCRIPTION
https://sendgrid.com/docs/Classroom/Track/unsubscribe_via_the_subscription_tracking.html now redirects to https://sendgrid.com/docs/Classroom/Track/Unsubscribes/unsubscribe_via_subscription_tracking.html