### PR TITLE
Add new parameters to GET bounces call

### DIFF
--- a/source/API_Reference/Web_API_v3/bounces.apiblueprint
+++ b/source/API_Reference/Web_API_v3/bounces.apiblueprint
@@ -18,6 +18,8 @@ FORMAT: 1A
 
     + start_time (optional, number, `1443651141`) ... Refers start of the time range in unix timestamp when a bounce was created (inclusive).
     + end_time (optional, number, `1443651154`) ... Refers end of the time range in unix timestamp when a bounce was created (inclusive).
+    + limit (optional, number, Some integer (<= 500)) ... Optional field to limit the number of results returned. If not used, then 500 is the default limit.
+    + offset (optional, number Some integer) ... Optional beginning point in the list to retrieve from.
 
 ### List all bounces [GET]
 


### PR DESCRIPTION
The documentation doesn't mention about the default the limit of the results that can be returned, and also it doesn't mention that the "offset" or "limit" parameters can be used. I have added this information in the table of the "List all bounces [GET]" call.