### PR TITLE
Update to 'substitution' parameter name in the JSON

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -62,7 +62,7 @@ Email HTML content:
     "john.doe@gmail.com",
     "jane.doe@hotmail.com"
   ],
-  "sub": {
+  "substitutions": {
     "-name-": [
       "John",
       "Jane"


### PR DESCRIPTION
The name in the current version of the rd file is 'sub' when  it should be 'substitutions' according to the JSON body parameters in https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html