### PR TITLE
Update Teammate Usage Limits

### DIFF
--- a/source/API_Reference/Web_API_v3/teammates.md
+++ b/source/API_Reference/Web_API_v3/teammates.md
@@ -205,7 +205,7 @@ HTTP/1.1 204
 Invite a teammate [POST]
 {% endanchor %}
 
-This endpoint allows you to send a teammate invitation via email with a predefined set of scopes, or permissions. A teammate invite will expire after 7 days, but you may resend the invite at any time to reset the expiration date.
+This endpoint allows you to send a teammate invitation via email with a predefined set of scopes, or permissions. A teammate invite will expire after 7 days, but you may resend the invite at any time to reset the expiration date. **Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. There is not a teammate limit for Pro and higher plans.**
 
 {% apiv3example post POST https://api.sendgrid.com/v3/teammates %}
 

--- a/source/Classroom/Basics/Account/teammates_faq.md
+++ b/source/Classroom/Basics/Account/teammates_faq.md
@@ -37,7 +37,7 @@ Is Teammates available for all SendGrid pricing plans?
 SendGrid is releasing the Teammates Beta to users in phases. If you do not immediately have access to Teammates, you will shortly. Stay tuned!
 {% endwarning %}
 
-**Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. Pro level plans or higher can add up to 1,000 teammates.**
+**Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. There is not a teammate limit for Pro and higher plans.**
 
 If you have an Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), or Free Trial plan and have created more than one multiple credentialed user, all of those credentialed users [will be migrated to Teammates]({{root_url}}/Classroom/Basics/Account/teammates_faq.html#-What-will-happen-to-my-Multiple-User-Credentials). However you will not be able to create any additional teammates unless you [upgrade to the Pro plan or higher](https://sendgrid.com/pricing/).
 

--- a/source/User_Guide/Settings/teammates.md
+++ b/source/User_Guide/Settings/teammates.md
@@ -56,7 +56,7 @@ Who can use Teammates?
 Teammates is an improved and expanded version of what was previously referred to as Multiple User Credentials. If you had one or more Multiple User Credentials configured for your account, then those credentials will automatically be migrated to the Teammates platform.
 {% endinfo %}
 
-Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. Pro level plans or higher can add up to 1,000 teammates.
+Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. There is no teammate limit for Pro plans and higher.
 
 If you have an Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), or Free Trial plan and have created more than one multiple credentialed user, all of those credentialed users [will be migrated to Teammates]({{root_url}}/Classroom/Basics/Account/teammates_faq.html#-What-will-happen-to-my-Multiple-User-Credentials). However you will not be able to create any additional teammates unless you [upgrade to the Pro plan or higher](https://sendgrid.com/pricing/).
 
@@ -93,7 +93,7 @@ Click **Add Teammate** to open the modal window allowing you to specify the emai
 ![Teammates]({{root_url}}/images/teammates_1.png)
 
 {% info %}
-Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. Pro level plans or higher can add up to 1,000 teammates.
+Essentials, [Legacy Lite]({{root_url}}/Classroom/Basics/Billing/legacy_lite_plan.html), and Free Trial users may create up to one teammate per account. There is not a teammate limit for Pro and higher plans.
 {% endinfo %}
 
 You should now see a modal window titled "New Teammate." Here you will enter your teammate's email address and select the type of teammate you would like to add. The teammate type dictates what permissions your new teammate will have.


### PR DESCRIPTION
* Update the teammate usage limit on the following pages to explain that Pro plans and higher have no limit on the number of teammates they can create
  * /API_Reference/Web_API_v3/teammates.html
  * /Classroom/Basics/Account/teammates_faq.html
  * /User_Guide/Settings/teammates.html