### PR TITLE
Changed query param description

### DIFF
--- a/source/API_Reference/Web_API_v3/Stats/categories.md
+++ b/source/API_Reference/Web_API_v3/Stats/categories.md
@@ -18,7 +18,7 @@ Gets email statistics for the given categories. If you don't pass any parameters
  {% parameter start_date Yes 'Date formatted as YYYY-MM-DD' 'The starting date of the statistics to retrieve' %}
  {% parameter end_date No 'Date formatted as YYYY-MM-DD' 'The end date of the statistics to retrieve. Defaults to today.' %}
  {% parameter aggregated_by No 'Must be day|week|month' 'How to group the statistics' %}
- {% parameter categories Yes 'Array of strings' 'The categories to get statistics for, up to 10' %}
+ {% parameter categories Yes 'String' 'The categories to get statistics for, up to 10' %}
 {% endparameters %}
 
 {% apiv3example get GET https://api.sendgrid.com/v3/categories/stats?start_date=2015-01-01&end_date=2015-01-02&categories=cat1&categories=cat2 %}


### PR DESCRIPTION
The 'categories' query param is not an array of strings, it is a string. Users can concatenate additional categories by appending &categoryname.