### PR TITLE
Removed links to Sender Reputation Glossary Entry

### DIFF
--- a/source/Classroom/Deliver/Delivery_Introduction/warming_up_ips.md
+++ b/source/Classroom/Deliver/Delivery_Introduction/warming_up_ips.md
@@ -10,7 +10,7 @@ navigation:
 
 <iframe src="https://player.vimeo.com/video/80755248" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-Whether you are new to the email game or are an accomplished vet, you have probably run across the idea of warming up an [IP address]({{root_url}}/Glossary/ip_address.html) to improve delivery performance. [Warming up your IP]({{root_url}}/Glossary/ip_warmup.html) allows you to gradually establish a good [sender reputation]({{root_url}}/Glossary/sender_reputation.html), and is a critical step for new SendGrid users or users who are adding a new dedicated IP address to their account.
+Whether you are new to the email game or are an accomplished vet, you have probably run across the idea of warming up an [IP address]({{root_url}}/Glossary/ip_address.html) to improve delivery performance. [Warming up your IP]({{root_url}}/Glossary/ip_warmup.html) allows you to gradually establish a good [sender reputation]({{root_url}}/Classroom/Basics/Misc/your_reputation_what_is_it.html), and is a critical step for new SendGrid users or users who are adding a new dedicated IP address to their account.
 
 {% anchor h2 %}
 What does it actually mean to "warm up" an IP address?
@@ -30,7 +30,7 @@ It should be noted that taking this gradual, ramping approach does not guarantee
 Does my IP need to be warmed up? And if so, why?
 {% endanchor %}
 
-If you are sending email from a new or “cold" IP address, ISPs have no means of determining your [sender reputation]({{root_url}}/Glossary/sender_reputation.html). Since this reputation determines whether or not your emails are delivered to your recipients’ inboxes, it is vital to immediately begin establishing a good reputation.
+If you are sending email from a new or “cold" IP address, ISPs have no means of determining your [sender reputation]({{root_url}}/Classroom/Basics/Misc/your_reputation_what_is_it.html). Since this reputation determines whether or not your emails are delivered to your recipients’ inboxes, it is vital to immediately begin establishing a good reputation.
 
 {% info %}
 Remember that it is much easier to establish a positive reputation as a new sender, than it is to repair an existing reputation.

--- a/source/Glossary/drip_campaign.md
+++ b/source/Glossary/drip_campaign.md
@@ -19,7 +19,7 @@ period of time.
 
 Drip campaigns help you to send relevant and well timed emails that your customers are likely interested in
 seeing. Striving to send emails that are relevant to your recipients can help to improve your [sender
-reputation]({{root_url}}/Glossary/sender_reputation.html), cultivate customer satisfaction, and increase customer retention.
+reputation]({{root_url}}/Classroom/Basics/Misc/your_reputation_what_is_it.html), cultivate customer satisfaction, and increase customer retention.
 
 {% info %}
 It is important to avoid initiating a series of messages that your customer doesn’t want to receive. Make sure

--- a/source/Glossary/index.html
+++ b/source/Glossary/index.html
@@ -127,7 +127,6 @@ navigation:
         {% anchor h2 %}S{% endanchor %}
         <a href="{{root_url}}/Glossary/scheduled_emails.html">Scheduled Emails</a>
         <a href="{{root_url}}/Glossary/sender_id.html">Sender ID</a>
-        <a href="{{root_url}}/Glossary/sender_reputation.html">Sender Reputation</a>
         <a href="{{root_url}}/Glossary/smtp.html">SMTP</a>
         <a href="{{root_url}}/Glossary/smtp_api.html">SMTP API</a>
         <a href="{{root_url}}/Glossary/smtp_provider.html">SMTP Provider</a>

--- a/source/Glossary/opt_in_email.md
+++ b/source/Glossary/opt_in_email.md
@@ -20,7 +20,7 @@ There are several variations of opt-in email:
 
 - **Confirmed Opt-in** refers to the practice of sending confirmation emails to your recipients asking them to confirm their continued interest in receiving your future emails.
 
-Giving your recipients the option to opt-in to receive your email will help to improve your [sender reputation]({{root_url}}/Glossary/sender_reputation.html) and will prevent your emails from ending up in your recipients’ [spam folders]({{root_url}}/Glossary/bulk_mail_folder.html).
+Giving your recipients the option to opt-in to receive your email will help to improve your [sender reputation]({{root_url}}/Classroom/Basics/Misc/your_reputation_what_is_it.html) and will prevent your emails from ending up in your recipients’ [spam folders]({{root_url}}/Glossary/bulk_mail_folder.html).
 
 Regardless of your method of obtaining a recipient's permission, it is important to give them the option of **opting-out** of receiving your future emails by including an [unsubscribe link]({{root_url}}/User_Guide/Suppressions/index.html).
 

--- a/source/Glossary/subjects.md
+++ b/source/Glossary/subjects.md
@@ -49,7 +49,6 @@ There are a lot of things to know about email. So, we wanted to help you know as
         <a href="{{root_url}}/Glossary/opens.html">Opens</a>
         <a href="{{root_url}}/Glossary/rate_limiting.html">Rate Limiting</a>
         <a href="{{root_url}}/Glossary/request.html">Request</a>
-        <a href="{{root_url}}/Glossary/sender_reputation.html">Sender Reputation</a>
         <a href="{{root_url}}/Glossary/spam.html">Spam</a>
         <a href="{{root_url}}/Glossary/throttling.html">Throttling</a>
         <a href="{{root_url}}/Glossary/undelivered_email.html">Undelivered Email</a>


### PR DESCRIPTION
* /Glossary/sender_reputation.html links now point to /Classroom/Basics/Misc/your_reputation_what_is_it.html