### PR TITLE
Add Accept header to docs

### DIFF
--- a/source/API_Reference/Web_API_v3/index.md
+++ b/source/API_Reference/Web_API_v3/index.md
@@ -17,6 +17,7 @@ curl --request POST \
   --url https://api.sendgrid.com/v3/mail/send \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
+  --header 'Accept: application/json' \
   --data '{"personalizations": [{"to": [{"email": "your.email@example.com"}]}],"from": {"email": "example@example.com"},"subject": "Hello, World!","content": [{"type": "text/plain", "value": "Heya!"}]}'
 {% endcodeblock %}
 
@@ -41,7 +42,7 @@ Using the Web API v3
 
 Every API request you make to the Web API v3 must be authenticated by including an Authorization Header with your API Key.
 
-{% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/templates" -H "Authorization: Bearer Your.API.Key-HERE" -H "Content-Type: application/json" {% endcodeblock %}
+{% codeblock lang:bash %} curl -X "GET" "https://api.sendgrid.com/v3/templates" -H "Authorization: Bearer Your.API.Key-HERE" -H "Content-Type: application/json" -H "Accept: application/json" {% endcodeblock %}
 
 ###[Requests]({{root_url}}/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/requests.html)
 
@@ -50,6 +51,7 @@ All requests to the Web API v3 must be made via HTTPS. The Web API v3 is complet
 {% codeblock lang:http %}
 POST https://api.sendgrid.com/v3/templates/ HTTP/1.1
 Content-Type: application/json
+Accept: application/json
 
 {
   "name": "new template name"


### PR DESCRIPTION
Some API calls require the Accept Header. if it's not provided, the error is not clear, it just shows "Authorization" type errors. This is EXTREMELY confusing to Customers & Support, causing a lot of wasted cycles while we try to figure out what's wrong with the API call ,when it turns out that it's just an undocumented required header.
I know there's a counter argument to fix the APi call, but until that's done, we need some way to know/remember what's wrong. the `Accept` header is never contra-indicated. it doesn't hurt to have it in there, so why no advise people to use it?