### PR TITLE
Removed "restart" reference.

### DIFF
--- a/source/Integrate/Mail_Servers/ssmtp.md
+++ b/source/Integrate/Mail_Servers/ssmtp.md
@@ -13,4 +13,4 @@ AuthUser=sendgridusername
 AuthPass=sendgridpassword
 UseSTARTTLS=YES
 {% endcodeblock %}
-Then restart ssmtp. All set!
+All set!


### PR DESCRIPTION
There is no daemon to restart. SSMTP emulates the /usr/sbin/sendmail command. Next time the `ssmtp` command is run, the new settings are applied.