### PR TITLE
Batch id update

### DIFF
--- a/source/API_Reference/SMTP_API/scheduling_parameters.md
+++ b/source/API_Reference/SMTP_API/scheduling_parameters.md
@@ -65,7 +65,7 @@ To schedule a send request for individual recipients; use `send_each_at` to send
 }
 {% endcodeblock %}
 
-To allow for the cancellation of a scheduled send, you must include a batch id with your send. The endpoint for cancellation needs a batch id to cancel with. To generate a valid batch id, use the batch id generation endpoint
+To allow for the cancellation of a scheduled send, you must include a `batch_id` with your send. The endpoint for cancellation needs a `batch_id` to cancel with. To generate a valid `batch_id`, use the [batch id generation endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends).
 
 <h4>Example of including a batch_id</h4>
 {% codeblock lang:json %}

--- a/source/API_Reference/SMTP_API/scheduling_parameters.md
+++ b/source/API_Reference/SMTP_API/scheduling_parameters.md
@@ -65,7 +65,7 @@ To schedule a send request for individual recipients; use `send_each_at` to send
 }
 {% endcodeblock %}
 
-To allow for the cancellation of a scheduled send, you must include a `batch_id` with your send. The endpoint for cancellation needs a `batch_id` to cancel with. To generate a valid `batch_id`, use the [batch id generation endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends).
+To allow for the cancellation of a scheduled send, you must include a `batch_id` with your send. The endpoint for cancellation needs a `batch_id` to cancel with. To generate a valid `batch_id`, use the [batch id generation endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends). A `batch_id` is valid for 24 hours after generation.
 
 <h4>Example of including a batch_id</h4>
 {% codeblock lang:json %}

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -63,10 +63,16 @@ Validate whether or not a batch id is valid for the authenticating account.
 The Cancel Scheduled Sends feature allows the customer to cancel a scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) included in the SMTPAPI or Request Body. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
 <br>
 <br>
-**You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation or paused at one time.**
+When a Batch is **cancelled**, all messages associated with that batch will stay in your sending queue, but when their `send_at` value is reached, they will be discarded instead of attempting delivery.
+<br>
+<br>
+When a Batch is **paused**, all messages associated with that batch will stay in your sending queue, even past their `send_at` value. Any messages that are more than 72 hours old will be discarded as Expired.
+{% info %}
+You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation or paused at one time.
 <br>
 <br>
 If you submit a cancel or pause request after the maximum number of cancellation/pause requests has already been reached, an HTTP 400 error will be returned.
+{% endinfo %}
 
 ## Cancel or pause a scheduled send [/user/scheduled_sends]
 
@@ -148,7 +154,7 @@ Update the status of a scheduled send.
 
 ### Delete a cancellation or pause of a scheduled send [DELETE]
 
-Delete the cancellation/pause of a scheduled send.
+Delete the cancellation/pause of a scheduled send. Any messages still in the sending queue with this Batch ID will revert to an active state, and delivery will be attempted when their `send_at` value is reached. Any "past due" messages will begin being delivered immediately.
 
 + Request (application/json)
 

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -29,13 +29,6 @@ Generate a new Batch ID to associate with scheduled sends. A Batch ID is good fo
                 "batch_id": "YOUR_BATCH_ID"
             }
 
-## Batch ID Lookup [/mail/batch/{batch_id}]
-Generate a new Batch ID to associate with scheduled sends
-
-+ Parameters
-    + batch_id (required, string, `HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi`) ... The batch ID you want to check
-
-
 ### Validate Batch ID [GET]
 
 Validate whether or not a batch id is valid

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -154,7 +154,8 @@ Update the status of a scheduled send.
 
 ### Delete a cancellation or pause of a scheduled send [DELETE]
 
-Delete the cancellation/pause of a scheduled send. Any messages still in the sending queue with this Batch ID will revert to an active state, and delivery will be attempted when their `send_at` value is reached. Any "past due" messages will begin being delivered immediately.
+Delete the cancellation/pause of a scheduled send. Any messages still in the sending queue with this Batch ID will revert to an active state, and delivery will be attempted when their `send_at` value is reached. Any "past due" messages (such as those that were *paused*) will be attempted to be delivered immediately.
+
 
 + Request (application/json)
 

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -8,16 +8,13 @@ navigation:
 
 FORMAT: 1A
 
-# Cancellation of Scheduled Sends
-Canceling scheduled send
-
 # Group Batch IDs
 
-If you set the [SMTPAPI header batch_id]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html), it allows you to then cancel a scheduled send based on that batch_id by calling the [Cancel Scheduled Send endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends).
+If you set the batch id in the [SMTPAPI header]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) or [Web API Request Body]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html#-Request-Body-Parameters), it allows you to then cancel a scheduled send based on that batch_id by calling the [Cancel Scheduled Send endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends).
 
 ## Batch ID Generation [/mail/batch]
 
-Generate a new Batch ID to associate with scheduled sends
+Generate a new Batch ID to associate with scheduled sends. A Batch ID is good for 864,000 seconds from creation -- 1 day.
 
 ### Generate Batch ID [POST]
 

--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -29,9 +29,15 @@ Generate a new Batch ID to associate with scheduled sends. A Batch ID is good fo
                 "batch_id": "YOUR_BATCH_ID"
             }
 
+
+## Batch ID Lookup [/mail/batch/{batch_id}]
+
+Validate whether or not a batch id is valid for the authenticating account.
+
 ### Validate Batch ID [GET]
 
-Validate whether or not a batch id is valid
++ Parameters
+    + batch_id (required, string, `HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi`) ... The batch ID you want to check
 
 + Request (application/json)
 
@@ -54,10 +60,10 @@ Validate whether or not a batch id is valid
 
 # Group Cancel Scheduled Sends
 
-The Cancel Scheduled Sends feature allows the customer to cancel a scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) included in the SMTPAPI header. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
+The Cancel Scheduled Sends feature allows the customer to cancel a scheduled send based on a [Batch ID]({{root_url}}/API_Reference/SMTP_API/scheduling_parameters.html) included in the SMTPAPI or Request Body. Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
 <br>
 <br>
-**You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation at one time.**
+**You can have no more than 10 different batches, or 10 different groups of emails with each group identified by a unique batch id, pending cancellation or paused at one time.**
 <br>
 <br>
 If you submit a cancel or pause request after the maximum number of cancellation/pause requests has already been reached, an HTTP 400 error will be returned.
@@ -87,7 +93,7 @@ Cancel or pause a scheduled send.
             "batch_id" : "invalid batch id"
             "batch_id" : "a status for this batch id exists, try PATCH to update the status"
 
-### Retrieve all scheduled sends [GET]
+### Retrieve all Cancelled and Paused scheduled sends [GET]
 
 Get all cancel/paused scheduled send information.
 
@@ -105,8 +111,6 @@ Get all cancel/paused scheduled send information.
 
 
 ## Manage cancelled user scheduled sends [/user/scheduled_sends/{batch_id}]
-
-A CRUD for managing user scheduled send cancellations
 
 ### Retrieve a scheduled send [GET]
 

--- a/source/Classroom/Send/When_Emails_Are_Sent/can_i_stop_a_scheduled_send.md
+++ b/source/Classroom/Send/When_Emails_Are_Sent/can_i_stop_a_scheduled_send.md
@@ -24,10 +24,10 @@ Canceling Transactional Email
 Cancel Scheduled Sends
 {% endanchor %}
 
-There is a [/group of endpoints]({{root_url}}/API_Reference/Web_API_v3/cancel_schedule_send.html) in the SendGrid API v3 that makes it possible to batch transactional email together and to schedule a time for that batch to be delivered. You can also pause or cancel the delivery of one of these batches.
+There is a [group of endpoints]({{root_url}}/API_Reference/Web_API_v3/cancel_schedule_send.html) in the SendGrid API v3 that makes it possible to batch transactional email together and to schedule a time for that batch to be delivered. You can also pause or cancel the delivery of one of these batches.
 
 {% info %}
-You can have no more than 10 different batches (10 different groups of emails with each group identified by a unique batch id) pending cancellation at one time.
+You can have no more than 10 different batches (10 different groups of emails with each group identified by a unique `batch_id`) in a 'paused' or 'pending cancellation' state at one time.
 {% endinfo %}
 
 To create a batch ID, assign that ID to an email or group of emails, and cancel the send, refer to the following steps:
@@ -96,6 +96,10 @@ Scheduled sends cancelled less than 10 minutes before the scheduled time are not
 {% endinfo %}
 
 To only pause your scheduled send, simply set the `status` parameter in your request to "pause". To completely cancel your request, set `status` to "cancel".
+
+When a Batch is **cancelled**, all messages associated with that batch will stay in your sending queue, but when their `send_at` value is reached, they will be discarded instead of attempting delivery.
+
+When a Batch is **paused**, all messages associated with that batch will stay in your sending queue, even past their `send_at` value. Any messages that are more than 72 hours old will be discarded as Expired.
 
 {% apiv3example post POST https://api.sendgrid.com/v3/user/scheduled_sends %}
 {% apiv3requestbody %}


### PR DESCRIPTION
Updating a few pages related to Batch Id & Scheduled sends. Added the fact that a batch_id is only good for 24h from creation. Added definitions of what Pausing & Cancelling actually do.