### PR TITLE
add new MC v3/contactdb operators info

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
@@ -667,9 +667,9 @@ the list of recipients. To avoid this issue; iterate over pages until a 404 is r
 </p>
 
 <ul>
-  <li>Dates: "eq", "ne", "lt" (before), "gt" (after)</li>
-  <li>Text: "contains", "eq" (is - matches the full field), "ne" (is not - matches any field where the entire field is not the condition value)</li>
-  <li>Numbers: "eq", "lt", "gt"</li>
+  <li>Dates: "eq", "ne", "lt" (before), "gt" (after), "empty", "not_empty"</li>
+  <li>Text: "contains", "eq" (is - matches the full field), "ne" (is not - matches any field where the entire field is not the condition value), "empty", "not_empty"</li>
+  <li>Numbers: "eq", "lt", "gt", "empty", "not_empty"</li>
   <li>Email Clicks and Opens: "eq" (opened), "ne" (not opened)</li>
 </ul>
 


### PR DESCRIPTION
* added new `empty` and `not_empty` operators to MC `/v3/concactdb` API.
* This API functionality will be available around 5/31/17, but we don't want this documentation to be public until we get customers' feedback, so please don't merge this yet.
* https://jira.sendgrid.net/browse/MCON-807
* here's more info on segments' conditions in general: https://docs.google.com/document/d/14-ZmkrO95EPVUSSDWhXCMUOftgNuFf3ok-ompHzcpN4/edit