### PR TITLE
updating senders.md terminology and to make it more task based

### DIFF
--- a/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/Side_by_Side_Comparisons/pricing.html
+++ b/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/Side_by_Side_Comparisons/pricing.html
@@ -21,7 +21,7 @@ We will be offering Legacy Newsletter customers who migrate to Marketing Campaig
       Charged a premium for each email sent through Legacy Newsletter.
     </td>
     <td>
-      Choose how you pay.
+      If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you can <a target="_blank" href="https://app.sendgrid.com/settings/choose_how_you_pay">choose how you’d like to pay</a>. You can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns. 
     </td>
   </tr>
 

--- a/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/faq.md
+++ b/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/faq.md
@@ -107,7 +107,7 @@ Both Legacy Newsletter and Marketing Campaigns start with your base SendGrid pla
 
 From there, each email marketing solution charges a premium for sending through the user interface. With Legacy Newsletter it’s a **$0.25 fee per 1,000 emails you send**. For Marketing Campaigns, it’s a **$10 fee per 10,000 contacts you store**. Your first 2,000 contacts in Marketing Campaigns are free.
 
-As an incentive to migrate to Marketing Campaigns, you can [choose how you’d like to pay]( https://app.sendgrid.com/settings/choose_how_you_pay): 
+If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you can [choose how you’d like to pay]( https://app.sendgrid.com/settings/choose_how_you_pay). You can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns: 
 
 <table class="table" style="table-layout:fixed">
   <tr>

--- a/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/index.html
+++ b/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/index.html
@@ -89,7 +89,8 @@ seo:
   </div>
 </div>
 
-When you switch to Marketing Campaigns, you can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns:
+<p>If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you can choose how you’d like to pay. You can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns:</p>
+    
 <table class="table" style="table-layout:fixed">
   <tr>
     <td><p>Pay <b>per email</b> you send</p>

--- a/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/migration_checklist.md
+++ b/source/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/migration_checklist.md
@@ -30,7 +30,7 @@ Migration to Marketing Campaigns is not automatic. We’ve built a [robust toolk
 &nbsp; &#x274f; Practice by creating a test campaign and sending it to yourself.
 
 {% anchor h3 %}
-2. Choose how you’d like to pay: Legacy Newsletter customers have the choice to pay per email sent or per contact stored. 
+2. If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you can [choose how you’d like to pay]( https://app.sendgrid.com/settings/choose_how_you_pay). You can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns. 
 {% endanchor %}
 
 &nbsp; &#x274f; Estimate your per-email vs. per-contact cost using [the Marketing Campaigns pricing page]( https://app.sendgrid.com/settings/choose_how_you_pay).

--- a/source/User_Guide/Marketing_Campaigns/senders.md
+++ b/source/User_Guide/Marketing_Campaigns/senders.md
@@ -22,7 +22,7 @@ Before you begin, go to your SendGrid [account settings]({{site.app_url}}/user/a
 Adding a Sender
 {% endanchor h2 %}
 
-1. Click "Create New Sender"
+1. Click **Create New Sender**
 1. Fill out the entire "Add Sender Identity" form. This form is so extensive so that you are CAN-SPAM compliant. The footer of your emails includes the information you provide here.
 
    * **From Name** - This is user-friendly name that is displayed to the user when they receive their email.
@@ -30,12 +30,12 @@ Adding a Sender
    * **Reply-To Email Address** - If your user hits reply in their email, the reply will go to this address.
    * **Company Address, City, State, Zip Code, Country** - The address of your business, for CAN-SPAM compliance.
    * **Nickname** - This is the name of this sender identity, which can be useful for identifying this identity in your list of senders. It will not be visible to your recipients.
-   
+   </br>
    ![]({{root_url}}/images/sender_identity_1.png "Sender Identities")
 
-1. After you fill out the form, click "Save".
+1. After you fill out the form, click **Save**.
 1. Check the email account and click the link in the email to verify the Sender email.
-   * To resend your verification email, click the gear icon for this sender and select 'view' from the menu.
+   * To resend your verification email, click the gear icon under Actions on the Sender Management page and select Resend Verification.
    * If you have a [verified whitelabel domain]({{root_url}}/User_Guide/Settings/Whitelabel/index.html) and your sender email address matches that domain exactly, your sender identity will automatically verify.
    
 
@@ -52,7 +52,7 @@ Once you schedule a campaign, you won't be able to delete the sender identity us
 {% endwarning %}
 
 {% anchor h2 %}
-Using your preset Sender Information In Your Campaigns
+Using Your Preset Sender Information In Your Campaigns
 {% endanchor %}
 
 You can insert your sender identity information into your campaigns using the following tags within your campaign or template content:
@@ -67,7 +67,7 @@ You can insert your sender identity information into your campaigns using the fo
 
 **[Sender_Zip]** - The sender's zip.
 
-So, to show your full sender's address and information in the footer of the email, you can use the tags like so:
+To show your sender's full address and information in the footer of the email, add the tags as shown:
 
 {% codeblock %}
 [Sender_Name]

--- a/source/User_Guide/Marketing_Campaigns/senders.md
+++ b/source/User_Guide/Marketing_Campaigns/senders.md
@@ -30,25 +30,26 @@ Adding a Sender
    * **Reply-To Email Address** - If your user hits reply in their email, the reply will go to this address.
    * **Company Address, City, State, Zip Code, Country** - The address of your business, for CAN-SPAM compliance.
    * **Nickname** - This is the name of this sender identity, which can be useful for identifying this identity in your list of senders. It will not be visible to your recipients.
+   
    ![]({{root_url}}/images/sender_identity_1.png "Sender Identities")
-
-   {% warning %}
-   You must verify your sender identity before you can edit it or use it to send a campaign.
-   {% endwarning %}
-
-   {% warning %}
-   When you schedule a campaign, the sender identity used will not be able to be deleted.
-   {% endwarning %}
 
 1. After you fill out the form, click "Save".
 1. Check the email account and click the link in the email to verify the Sender email.
-   
-   {% info %}
-   Your verification link is only valid for 48 hours. After that time you will need to restart the verification process.
-   {% endinfo %}
-   
    * To resend your verification email, click the gear icon for this sender and select 'view' from the menu.
    * If you have a [verified whitelabel domain]({{root_url}}/User_Guide/Settings/Whitelabel/index.html) and your sender email address matches that domain exactly, your sender identity will automatically verify.
+   
+
+{% info %}
+Your verification link is only valid for 48 hours. After that time you will need to restart the verification process.
+{% endinfo %}
+
+{% warning %}
+You must verify your sender identity before you can edit it or use it to send a campaign.
+{% endwarning %}
+
+{% warning %}
+Once you schedule a campaign, you won't be able to delete the sender identity used.
+{% endwarning %}
 
 {% anchor h2 %}
 Using your preset Sender Information In Your Campaigns

--- a/source/User_Guide/Marketing_Campaigns/senders.md
+++ b/source/User_Guide/Marketing_Campaigns/senders.md
@@ -1,11 +1,11 @@
 ---
 layout: page
 weight: 50
-title: Sender Identities
+title: Senders
 navigation:
   show: true
 seo:
-  title: Sender Identities
+  title: Senders
   override: true
   description:
 ---
@@ -13,72 +13,48 @@ seo:
 <iframe src="https://player.vimeo.com/video/120703745" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 {% anchor h2 %}
-Verify Your Account Settings
+Before you begin
 {% endanchor h2 %}
 
-Go to your SendGrid [account settings]({{site.app_url}}/user/account) to modify or verify that your timezone and account email address are correct. This will ensure that you receive notifications when contacts have been uploaded and that your scheduled sends are delivered at the correct time.
+Before you begin, go to your SendGrid [account settings]({{site.app_url}}/user/account) to verify that your timezone and account email address are correct. Verifying your account information ensures that when you upload contacts, you receive notifications and that we deliver scheduled emails at the correct time.
 
 {% anchor h2 %}
-Create Your Sender Identity
+Adding a Sender
 {% endanchor h2 %}
 
-{% warning %}
-Your sender identity must be verified before you may edit it or use it to send a campaign.
-{% endwarning %}
+1. Click "Create New Sender"
+1. Fill out the entire "Add Sender Identity" form. This form is so extensive so that you are CAN-SPAM compliant. The footer of your emails includes the information you provide here.
 
-{% warning %}
-When you schedule a campaign, the sender identity used will not be able to be deleted.
-{% endwarning %}
+   * **From Name** - This is user-friendly name that is displayed to the user when they receive their email.
+   * **From Email Address** - This will display to the user as the email address who sent this email.
+   * **Reply-To Email Address** - If your user hits reply in their email, the reply will go to this address.
+   * **Company Address, City, State, Zip Code, Country** - The address of your business, for CAN-SPAM compliance.
+   * **Nickname** - This is the name of this sender identity, which can be useful for identifying this identity in your list of senders. It will not be visible to your recipients.
+   ![]({{root_url}}/images/sender_identity_1.png "Sender Identities")
 
-Whenever you send an email, in order to be CAN-SPAM compliant, you need to provide some basic sender information in your
-emails. We have set up a [sender management feature]({{site.marketing_campaigns_url}}/senders) for you,
-so that you can input the right information and add this to your emails.
+   {% warning %}
+   You must verify your sender identity before you can edit it or use it to send a campaign.
+   {% endwarning %}
 
-When you click “Create New Sender,” you will be shown a form where you can set up a sender identity.
+   {% warning %}
+   When you schedule a campaign, the sender identity used will not be able to be deleted.
+   {% endwarning %}
 
-{% info %}
-You can create up to 100 unique sender identities.
-{% endinfo %}
-
-![]({{root_url}}/images/sender_identity_1.png "Sender Identities")
-
-* **From Name** - This is the display or “user friendly” name that is displayed to the user when they receive their email.
-* **From Email Address** - This will display to the user as the email address who sent this email.
-* **Reply-To Email Address** - If your user hits reply in their email, the reply will go to this address.
-* **Company Address, City, State, Zip Code, Country** - The address of your business, for CAN-SPAM compliance.
-* **Nickname** - This is the name of this sender identity, which can be useful for identifying this identity in your list of senders. It will not be visible to your recipients.
-
-Once you fill out this information and hit “save,” you will then be able to verify your sender.
-
-{% anchor h2 %}
-Verifying Your Sender Identity
-{% endanchor %}
-
-We will not allow you to send with a sender identity that is not verified. This is a security feature that helps you be in compliance with [CAN-SPAM](http://www.business.ftc.gov/documents/bus61-can-spam-act-compliance-guide-business) when you send through SendGrid.
-
-To verify your identity, create the identity following the instructions above. Once you click “save,” we will send an email to the address you specified.
-
-{% info %}
-Your verification link is only valid for 48 hours. After that time you will need to start the verification process over.
-{% endinfo %}
-
-1. Check your email for the verification email we sent.
-2. Click the link provided in the verification email.
-3. Your sender identity is now verified!
-
-To resend your verfication email, click the gear icon for this sender and select 'view' from the menu.
+1. After you fill out the form, click "Save".
+1. Check the email account and click the link in the email to verify the Sender email.
+   
+   {% info %}
+   Your verification link is only valid for 48 hours. After that time you will need to restart the verification process.
+   {% endinfo %}
+   
+   * To resend your verification email, click the gear icon for this sender and select 'view' from the menu.
+   * If you have a [verified whitelabel domain]({{root_url}}/User_Guide/Settings/Whitelabel/index.html) and your sender email address matches that domain exactly, your sender identity will automatically verify.
 
 {% anchor h2 %}
-Automatically Verify Your Sender Identity
+Using your preset Sender Information In Your Campaigns
 {% endanchor %}
 
-If you have a [verified whitelabel domain]({{root_url}}/User_Guide/Settings/Whitelabel/index.html) and your sender email address matches that domain exactly, your sender identity will automatically verify.
-
-{% anchor h2 %}
-Use Sender Identity Information In Your Campaigns
-{% endanchor %}
-
-You can insert your sender identity information into your campaigns using the following tags within your campaign or template content.
+You can insert your sender identity information into your campaigns using the following tags within your campaign or template content:
 
 **[Sender_Name]** - The sender's name.
 
@@ -90,10 +66,7 @@ You can insert your sender identity information into your campaigns using the fo
 
 **[Sender_Zip]** - The sender's zip.
 
-{% anchor h3 %}
-Display Sender Info
-{% endanchor %}
-If you'd like to show your full sender's address and information you can use the tags like so:
+So, to show your full sender's address and information in the footer of the email, you can use the tags like so:
 
 {% codeblock %}
 [Sender_Name]


### PR DESCRIPTION
**Description of the change**: Updating to make it more task based and updating from "Sender identities" to "Senders" (except where it still says "Sender Identities" in the UI)
**Reason for the change**: The terminology has changed and docs initiative to make it more task based
**Link to original source**: https://sendgrid.com/docs/User_Guide/Marketing_Campaigns/senders.html

@Whatthefoxsays please pull this one in locally and verify the formatting as well as doing a copy edit
