### PR TITLE
Fix typo in `resubscription_of_users.md`.

### DIFF
--- a/source/Classroom/Send/Who_You_Can_Send_To/resubscription_of_users.md
+++ b/source/Classroom/Send/Who_You_Can_Send_To/resubscription_of_users.md
@@ -1,6 +1,6 @@
 ---
 seo:
-  title: Resubsription of Users
+  title: Resubscription of Users
 title: Resubscription of Users
 weight: 0
 layout: page


### PR DESCRIPTION
**Description of the change**:
Simple typo fix.

**Reason for the change**:
Because spelling is cool.

**Link to original source**:
https://sendgrid.com/docs/Classroom/Send/Who_You_Can_Send_To/resubscription_of_users.html

@ksigler7