### PR TITLE
removed a random alphanumeric string

### DIFF
--- a/source/Classroom/Build/Add_Content/content_delivery_networks.md
+++ b/source/Classroom/Build/Add_Content/content_delivery_networks.md
@@ -65,7 +65,6 @@ Contact SendGrid support to validate your CDN settings and enable SSL click and 
 {% info %}
 For more information, please visit [Fastly's documentation](https://docs.fastly.com/guides/basic-setup/working-with-services#creating-a-new-service).
 {% endinfo %}
->>>>>>> 301bb0db06824cf412d9e53bde0b7df211707675
 
 {% anchor h2 %}
 Using KeyCDN


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: Removed a random alphanumeric string
**Reason for the change**: There appeared to be a random alphanumeric string in the middle of the CDN documentation page. I don't see a reason why it should be there and it looks to me like it could be in error.
**Link to original source**: https://github.com/sendgrid/docs/blame/develop/source/Classroom/Build/Add_Content/content_delivery_networks.md#L68

@ksigler7
