### PR TITLE
Added Credentials to API Key Permissions List

### DIFF
--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -24,6 +24,7 @@ The following is a complete list of all possible permissions that you may assign
         <h3><a href="#Billing">Billing</a></h3>
         <h3><a href="#Categories">Categories</a></h3>
         <h3><a href="#Clients">Clients</a></h3>
+        <h3><a href="#Credentials">Credentials</a></h3>
         <h3><a href="#IPs">IPs</a></h3>
     </div>
     <div class="col-md-4">
@@ -102,6 +103,16 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "categories.update",
   "categories.stats.read",
   "categories.stats.sums.read"
+]
+{% endcodeblock %}
+
+{% anchor h2 %}Credentials{% endanchor %}
+{% codeblock %}
+"scopes": [
+  "credentials.create",
+  "credentials.delete",
+  "credentials.read",
+  "credentials.update"
 ]
 {% endcodeblock %}
 


### PR DESCRIPTION
Added Credentials API Key Permissions to list.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: Credentials were missing from the API Key Permissions List. Added text from Stoplight. 
**Reason for the change**:
**Link to original source**:

@ksigler7
