### PR TITLE
removing legacy newsletter note from mc pages

### DIFF
--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -22,20 +22,6 @@ layout: default
     </header>
     {% endif %}
 
-    <div class="content">
-
-      {% if page.url contains "/Marketing_Campaigns/" %}
-        <div class="callout callout-info">
-          <p>
-            Migrating from the Legacy Newsletter? <a href="{{root_url}}/User_Guide/Legacy_Newsletter/Legacy_Newsletter_Migration/index.html">Here</a> are some valuable resources to help get you started.
-          </p>
-        </div>
-      {% endif %}
-
-      {{ content }}
-
-    </div>
-
     {% if page.last_modified %}
       <meta itemprop="lastReviewed" content="{{ page.last_modified }}">
     {% endif %}

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -22,6 +22,12 @@ layout: default
     </header>
     {% endif %}
 
+ <div class="content">
+
+    {{ content }}
+
+ </div>
+      
     {% if page.last_modified %}
       <meta itemprop="lastReviewed" content="{{ page.last_modified }}">
     {% endif %}


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: removing legacy newsletter migration note from every page
**Reason for the change**: because Molly and I agree that it doesn't need to be there anymore