### PR TITLE
fixing typo in the User Guide index

### DIFF
--- a/source/User_Guide/index.html
+++ b/source/User_Guide/index.html
@@ -38,6 +38,6 @@ href="{{root_url}}/User_Guide/Apps/index.html" title="SendGrid Apps">apps</a>.</
 Marketing Campaigns
 {% endanchor %}
 
-<p>Our marketing Campaigns feature lets you compose and send email campaigns. We provide list management, delivery scheduling, A/B split testing, email analytics, and dynamic list segmentation. You can take a look at our <a href="{{root_url}}/User_Guide/Marketing_Campaigns/index.html" title="SendGrid Marketing Campaigns Documentation">Marketing Campaigns documentation</a> to learn more.</p>
+<p>Our Marketing Campaigns feature lets you compose and send email campaigns. We provide list management, delivery scheduling, A/B split testing, email analytics, and dynamic list segmentation. You can take a look at our <a href="{{root_url}}/User_Guide/Marketing_Campaigns/index.html" title="SendGrid Marketing Campaigns Documentation">Marketing Campaigns documentation</a> to learn more.</p>
 
 <p>We also provide a robust <a href="{{root_url}}/API_Reference/Web_API_v3/Marketing_Campaigns/index.html" title="Marketing Campaigns API">Marketing Campaigns API</a> if you want to integrate any of these features into your own application.</p>


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: fixing a typo
**Reason for the change**:
**Link to original source**:

@ksigler7
