### PR TITLE
mixed up two fields in universal link setup changes

### DIFF
--- a/source/Classroom/Build/Add_Content/universal_links.md
+++ b/source/Classroom/Build/Add_Content/universal_links.md
@@ -181,8 +181,8 @@ After creating your iOS "apple-app-site-association" file and/or your Android "d
 
     ![]({{root_url}}/images/universal_links_4.png)
 
-    * **Forward Headers:** Forward all, cache based on all
-    * **Forward Query Strings:** Yes
+    * **Forward Headers:** Yes
+    * **Forward Query Strings:** Forward all, cache based on all
 18. Under the **Distribution Settings** section, set the fields as follows:
 
     ![]({{root_url}}/images/universal_links_5.png)


### PR DESCRIPTION
**Description of the change**: Changed values for two fields in the CloudFront setup instructions for Universal Links
**Reason for the change**: Made some changes last week ( #2724 ) and edited the wrong field (https://github.com/sendgrid/docs/pull/2724/files#diff-d65ba170d973e5d43fd991a6c511b780R184). This makes the change for the correct field.
**Link to original source**: https://github.com/sendgrid/docs/blame/develop/source/Classroom/Build/Add_Content/universal_links.md#L184

@ksigler7
