### PR TITLE
Update custom field length limit, no longer 240

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/custom_fields.md
+++ b/source/User_Guide/Marketing_Campaigns/custom_fields.md
@@ -35,7 +35,7 @@ You can create up to 20 custom fields for each data type: date, text, and number
 {% endinfo %}
 
 {% warning %}
-Text custom fields are limited to a length of 240 characters.
+Text custom fields are limited to a length of 32,766 characters.
 {% endwarning %}
 
 ![]({{root_url}}/images/custom_fields_1.png "Default Custom Fields")


### PR DESCRIPTION
**Description of the change**:
Backend was changed to allow longer custom text fields.

**Reason for the change**:
To align with API limits

**Link to original source**:

@ksigler7
