### PR TITLE
Fixed typo in parse.apiblueprint

### DIFF
--- a/source/API_Reference/Web_API_v3/Webhooks/parse.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Webhooks/parse.apiblueprint
@@ -9,7 +9,7 @@ FORMAT: 1A
 
 The following Parse API settings allow you to manage the [Inbound Parse Webhook]({{root_url}}/API_Reference/Webhooks/parse.html).
 
-In addition to configuring the Inbound Parse via our API, you may also configure the Inbound Parse in the Settings menu available from your SendGrid dashboard. For more inforamtion, see our [User Guide]({{root_url}}/User_Guide/Settings/parse.html).
+In addition to configuring the Inbound Parse via our API, you may also configure the Inbound Parse in the Settings menu available from your SendGrid dashboard. For more information, see our [User Guide]({{root_url}}/User_Guide/Settings/parse.html).
 
 ## Parse Settings Collection [/user/webhooks/parse/settings?limit={limit}&offset={offset}]
 


### PR DESCRIPTION
Fixed typo in parse.apiblueprint file.
[Original Source](https://github.com/sendgrid/docs/blob/develop/source/API_Reference/Web_API_v3/Webhooks/parse.apiblueprint#L12)

@ksigler7