### PR TITLE
Remove deprecated third party Node.js library

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -110,7 +110,6 @@ Java
 JavaScript / Node.js
 {% endanchor %}
 
--   [sendgrid-mailer](https://www.npmjs.com/package/sendgrid-mailer) *by Adam Reis* - A simple wrapper around the official SendGrid library to make sending emails easy.
 -   [node-sendgrid-web](http://github.com/jesusabdullah/node-sendgrid-web) *by Joshua Holbrook* - Send emails via SendGrid using the JSON web API and the request module.
 -   [node-sendgrid](https://github.com/HerdHound/node-sendgrid) *by Branko Vukelick* - Generate X-SMTPAPI headers in node.js.
 -   [node_subscription_widget](https://github.com/devchas/sendgrid_subscription_widget) *by Devin Chasanoff* - General purpose subscription widget created in node.js


### PR DESCRIPTION
Removed Node.js sendgrid-mailer library, as it's being [deprecated by the author](https://github.com/sendgrid/sendgrid-nodejs/pull/378#issuecomment-316833293). 

@ksigler7
