### PR TITLE
Change to Bounces API. Fixed 'limit' row typo

### DIFF
--- a/source/API_Reference/Web_API_v3/bounces.apiblueprint
+++ b/source/API_Reference/Web_API_v3/bounces.apiblueprint
@@ -18,7 +18,7 @@ FORMAT: 1A
 
     + start_time (optional, number, `1443651141`) ... Refers start of the time range in unix timestamp when a bounce was created (inclusive).
     + end_time (optional, number, `1443651154`) ... Refers end of the time range in unix timestamp when a bounce was created (inclusive).
-    + limit (optional, number, Some integer (<= 500)) ... Optional field to limit the number of results returned. If not used, then 500 is the default limit.
+    + limit (optional, number Some integer <= 500) ... Optional field to limit the number of results returned. If not used, then 500 is the default limit.
     + offset (optional, number Some integer) ... Optional beginning point in the list to retrieve from.
 
 ### List all bounces [GET]


### PR DESCRIPTION
Line 21 seems to not be displaying correctly. 'limit' Required field displays ')'

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
