### PR TITLE
Add [Sender_Country] to Sub list

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/senders.md
+++ b/source/User_Guide/Marketing_Campaigns/senders.md
@@ -67,6 +67,8 @@ You can insert your sender identity information into your campaigns using the fo
 
 **[Sender_Zip]** - The sender's zip.
 
+**[Sender_Country]** - The sender's country.
+
 To show your sender's full address and information in the footer of the email, add the tags as shown:
 
 {% codeblock %}


### PR DESCRIPTION
I tested this with a client today and found you can also sub sender country and there is no Tag suggested in the UI or in the docs, but it works.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
