### PR TITLE
Implemented Updated Content

### DIFF
--- a/source/Glossary/clicks.md
+++ b/source/Glossary/clicks.md
@@ -16,9 +16,9 @@ In order to track clicks, you must have the [Click Tracking App]({{root_url}}/Us
 
 SendGrid can replace the links in your email templates with a custom link that when clicked, will redirect your customers to the original link from your template. When the user clicks, SendGrid will record the click event. SendGrid can track 1000 link clicks per email.
 
-In [Statistics]({{root_url}}/User_Guide/Delivery_Metrics/email_activity.html), “clicks percentage" is the total number of times your users have clicked on the various links within your emails, divided by the total number of Delivered messages. The “Unique clicks” percentage is the number of unique individuals that have clicked the links in your emails, divided by the total number of delivered messages.
+In [Stats]({{root_url}}/User_Guide/Delivery_Metrics/email_activity.html), The “Clicks” percentage is the total number of times your users have clicked on the various links within your emails, divided by the total number of Delivered messages. The “Unique clicks” percentage is the number of unique individuals that have clicked the links in your emails, divided by the total number of Delivered messages. This statistic requires that the Click Tracking feature be enabled under your Tracking Settings.
 
-Users clicking a SendGrid Unsubscribe link will not count as a Click. However, if you use a third-party unsubscribe link, it will be tracked as a click.
+Users clicking a SendGrid Unsubscribe link will not count as a Click. However, if you use a third-party unsubscribe link, it will be tracked as a Click.
 
 {% info %}
 SendGrid will store tracking data for unique click events for up to 7 days.


### PR DESCRIPTION
The “Clicks” percentage is the total number of times your users have clicked on the various links within your emails, divided by the total number of Delivered messages. The “Unique clicks” percentage is the number of unique individuals that have clicked the links in your emails, divided by the total number of Delivered messages. This requires that the Click Tracking app be enabled.

Users clicking a SendGrid Unsubscribe link will not count as a Click. However, if you use a third-party unsubscribe link, it will be tracked as a Click.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
