### PR TITLE
adding back in link that was breaking the build

### DIFF
--- a/source/Integrate/Partners/index.html
+++ b/source/Integrate/Partners/index.html
@@ -11,7 +11,9 @@ Partners
 {% endanchor %}
 
 <ul>
-  <li>Amazon Marketplace
+  <li><a href="Amazon_Marketplace.html">
+        Amazon Marketplace
+      </a>
     </li>
  <li>
       <a href="Microsoft_Azure.html">


### PR DESCRIPTION
**Description of the change**: adding link to partners integrations index
**Reason for the change**: because I couldn't for the actual release because it was breaking the build
**Link to original source**: https://sendgrid.com/docs/Integrate/Partners/index.html

