### PR TITLE
Add Release notes to  bottom of menu

### DIFF
--- a/source/Release_Notes/release_notes.md
+++ b/source/Release_Notes/release_notes.md
@@ -7,7 +7,7 @@ seo:
   description: The new features and changes to SendGrid
   keywords: release notes
 navigation:
-  show: true
+  show: false
 ---
 The following new features and changes to the service are available.
 

--- a/source/_includes/asides/page_navigation.html
+++ b/source/_includes/asides/page_navigation.html
@@ -12,6 +12,10 @@
         </div>
       </form>
 
-	  <nav itemscope itemtype="http://schema.org/SiteNavigationElement">{% navigation %}</nav>
+	  <nav itemscope itemtype="http://schema.org/SiteNavigationElement">{% navigation %}
+	    <ul id="nav-menu" class="nav nav-list">
+    		<li class="active"><a href="//sendgrid.com/docs/Release_Notes/release_notes.html">Release Notes</a></li>
+            </ul>
+	    </nav>
   </div>
 </div>

--- a/source/_includes/asides/page_navigation.html
+++ b/source/_includes/asides/page_navigation.html
@@ -13,7 +13,7 @@
       </form>
 
 	  <nav itemscope itemtype="http://schema.org/SiteNavigationElement">{% navigation %}
-	    <ul id="nav-menu" class="nav nav-list">
+	    <ul class="nav nav-list">
     		<li class="active"><a href="//sendgrid.com/docs/Release_Notes/release_notes.html">Release Notes</a></li>
             </ul>
 	    </nav>


### PR DESCRIPTION
**Description of the change**:
Having a nested menu of one item sucks. This hard codes the release notes link.

**Reason for the change**:
omg, serioulsly?

**Link to original source**:
No
@ksigler7
