### PR TITLE
Updates sendgrid django backend library to a more up-to-date version

### DIFF
--- a/source/Integrate/Frameworks/django.md
+++ b/source/Integrate/Frameworks/django.md
@@ -31,5 +31,5 @@ send_mail('Subject here', 'Here is the message.', 'from@example.com', ['to@examp
 
  
 {% info %}
-You may also send emails with Django by using the [sendgrid-django](https://github.com/elbuo8/sendgrid-django) library, which utilizes the [Web API]({{%20root_url%20}}/API_Reference/Web_API/index.html) instead of SMTP as the transport mechanism. 
+You may also send emails with Django by using the [django-sendgrid-v5](https://github.com/sklarsa/django-sendgrid-v5) library, which utilizes the [Web API]({{%20root_url%20}}/API_Reference/Web_API/index.html) instead of SMTP as the transport mechanism. 
 {% endinfo %}


### PR DESCRIPTION
The old library (https://github.com/elbuo8/sendgrid-django) is no longer compatible with v4+ of the `sendgrid-python` API and hasn't been updated since January.  I am maintaining this new library, am currently using it in production, and plan on maintaining it in the future.

@ksigler7
