### PR TITLE
Text custom field in bytes.md

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/custom_fields.md
+++ b/source/User_Guide/Marketing_Campaigns/custom_fields.md
@@ -35,7 +35,7 @@ You can create up to 20 custom fields for each data type: date, text, and number
 {% endinfo %}
 
 {% warning %}
-Text custom fields are limited to a length of 32,766 characters.
+Text custom fields are limited to a size of 32,766 bytes.
 {% endwarning %}
 
 ![]({{root_url}}/images/custom_fields_1.png "Default Custom Fields")


### PR DESCRIPTION
Found out the text custom fields limit is not in characters, but instead in bytes.