### PR TITLE
Added limitation of only 15 conditions per search

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
@@ -694,6 +694,10 @@ Search with conditions [POST]
   Field values must all be a string.
 </p>
 
+{% info %}
+You can search for up to 15 different conditions per request.
+{% endinfo %}
+
 <p>
   Search conditions using "eq" or "ne" for email clicks and opens should provide a "field" of either <code>clicks.campaign_identifier</code> or <code>opens.campaign_identifier</code>.
   The condition value should be a string containing the id of a completed campaign.


### PR DESCRIPTION
Added:

{% info %}
You can search for up to 15 different conditions per request.
{% endinfo %}

Under Search with conditions [POST]

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
