### PR TITLE
Updating where substitutions work substitution_tags.md

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -20,7 +20,7 @@ navigation:
 {% endcodeblock %}
 
 {% info %}
-Substitution tags will work in the Subject line as well as the body of the email. 
+Substitution tags will work in the Subject line, body of the email and in [Unique Arguments]({{root_url}}/API_Reference/SMTP_API/unique_arguments.html). 
 {% endinfo %}
 
 {% info %}


### PR DESCRIPTION
Found out the text custom fields limit is not in characters, but instead in bytes.