### PR TITLE
Substitution nesting warning added substitution_tag.md

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -35,6 +35,10 @@ How you format your substitution tags may depend on the library you use to creat
 Do not use spaces inside your substitution tags, e.g. %first name%
 {% endwarning %}
 
+{% warning %}
+Do not nest substitution tags in substitions as they will fail and your substitution will not take place.
+{% endwarning %}
+
 {% anchor h2%}
 Substitution Tag Example
 {% endanchor %}


### PR DESCRIPTION
A recent change to MP has made it so nesting substitutions no longer works. A warning has now been added to the docs to help prevent issues.