### PR TITLE
Added Info for Using V2 API in Integrate/Code_Examples/v2_Mail/ (Fixes #2840)

### DIFF
--- a/source/Integrate/Code_Examples/v2_Mail/csharp.md
+++ b/source/Integrate/Code_Examples/v2_Mail/csharp.md
@@ -10,6 +10,10 @@ navigation:
 We recommend using SendGrid C#, our client library, <a href="https://github.com/sendgrid/sendgrid-csharp">available on Github</a>, with full documentation.
 {% endgithub %}
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in C#](https://github.com/sendgrid/sendgrid-csharp/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %}Using SendGrid's C# Library{% endanchor %}
 {% codeblock lang:csharp %}
 // using SendGrid's C# Library - https://github.com/sendgrid/sendgrid-csharp

--- a/source/Integrate/Code_Examples/v2_Mail/go.md
+++ b/source/Integrate/Code_Examples/v2_Mail/go.md
@@ -10,6 +10,10 @@ navigation:
 We recommend using SendGrid Go, our client library, <a href="https://github.com/sendgrid/sendgrid-go">available on Github</a>, with full documentation.
 {% endgithub %}
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in Go](https://github.com/sendgrid/sendgrid-go/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %} Using SendGrid's Go Library {% endanchor %}
 {% codeblock lang:go %}
 // using SendGrid's Go Library

--- a/source/Integrate/Code_Examples/v2_Mail/java.md
+++ b/source/Integrate/Code_Examples/v2_Mail/java.md
@@ -7,6 +7,10 @@ navigation:
 ---
 {% github sendgrid/sendgrid-java#usage Java %} We recommend using SendGrid Java, our client library, <a href="https://github.com/sendgrid/sendgrid-java">available on Github</a>, with full documentation. {% endgithub %}
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in Java](https://github.com/sendgrid/sendgrid-java/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %} Using SendGrid's Java Library {% endanchor %}
 {% codeblock lang:java %}
 // using SendGrid's Java Library

--- a/source/Integrate/Code_Examples/v2_Mail/nodejs.md
+++ b/source/Integrate/Code_Examples/v2_Mail/nodejs.md
@@ -7,6 +7,10 @@ navigation:
 ---
 {% github sendgrid/sendgrid-nodejs#usage Node.js %} We recommend using <a href="https://sendgrid.com/docs/Integrate/Code_Examples/v3_Mail/nodejs.html">v3</a> SendGrid Node.js, our client library, <a href="https://github.com/sendgrid/sendgrid-nodejs">available on Github</a>, with full documentation. {% endgithub %}
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in Node.js](https://github.com/sendgrid/sendgrid-nodejs/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %} Using SendGrid's Node.js Library {% endanchor %}
 {% codeblock lang:js %}
 // using SendGrid's Node.js Library

--- a/source/Integrate/Code_Examples/v2_Mail/php.md
+++ b/source/Integrate/Code_Examples/v2_Mail/php.md
@@ -11,6 +11,10 @@ navigation:
 ---
 {% github sendgrid/sendgrid-php#usage PHP %} We recommend using SendGrid PHP, our client library, <a href="https://github.com/sendgrid/sendgrid-php">available on Github</a>, with full documentation. {% endgithub %} 
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in PHP](https://github.com/sendgrid/sendgrid-php/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %}Using SendGrid's PHP Library{% endanchor %}
 {% codeblock lang:php %}
 // using SendGrid's PHP Library

--- a/source/Integrate/Code_Examples/v2_Mail/python.md
+++ b/source/Integrate/Code_Examples/v2_Mail/python.md
@@ -10,6 +10,10 @@ navigation:
 We recommend using SendGrid Python, our client library, <a href="https://github.com/sendgrid/sendgrid-python">available on Github</a>, with full documentation.
 {% endgithub %}
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in Python](https://github.com/sendgrid/sendgrid-python/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %} Using SendGrid's Python Library {% endanchor %}
 {% codeblock lang:python %}
 # using SendGrid's Python Library

--- a/source/Integrate/Code_Examples/v2_Mail/ruby.md
+++ b/source/Integrate/Code_Examples/v2_Mail/ruby.md
@@ -8,6 +8,10 @@ navigation:
 
 {% github sendgrid/sendgrid-ruby#usage PHP %} We recommend using SendGrid Ruby, our client library, <a href="https://github.com/sendgrid/sendgrid-ruby">available on Github</a>, with full documentation. {% endgithub %} 
 
+{% info %}
+The library does not officially support the V2 API, but you can use V2 with an older version of the library. For more information, see [Continue Using V2 in Ruby](https://github.com/sendgrid/sendgrid-ruby/blob/master/TROUBLESHOOTING.md#v2).
+{% endinfo %}
+
 {% anchor h2 %} Using SendGrid's Ruby Library {% endanchor %}
 {% codeblock lang:ruby %}
 # using SendGrid's Ruby Library


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: Added information note for using the V2 API in the code examples for  `v2_Mail`. Couldn't add it for Perl since `sendgrid-perl` doesn't seem to have a `TROUBLESHOOTING.md` file. Fixes #2840.

**Reason for the change**: Out-dated pages for code examples.

**Link to original source**: https://github.com/sendgrid/docs/issues/2840

@ksigler7
