### PR TITLE
Added  limitation of 15 conditions - Creating a Segment

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
@@ -704,6 +704,7 @@ Search with conditions [POST]
   The first condition in the conditions list must have an empty "and_or", and subsequent conditions must all specify an "and_or".
 </p>
 
+
 + Request
 
     + Body
@@ -841,6 +842,10 @@ The JSON accepted by this endpoint is identical to that of the [POST search with
             {"id":1,"name":"Last Name Miller","list_id":4,"conditions":[{"field":"last_name", "value":"Miller", "operator":"eq", "and_or":""},{"field":"last_clicked", "value":"01/02/2015", "operator": "gt", "and_or": "and"},{"field": "clicks.campaign_identifier", "value": "513", "operator": "eq", "and_or": "or"}], "recipient_count":0}
 
 {% warning %}The response of the initial `POST` will return a `recipient_count` of 0 because it takes some time to populate. Follow up with a `GET` to verfiy segment size.{% endwarning %}
+
+{% info %}
+You can add up to 15 different conditions per segment.
+{% endinfo %}
 
 + Response 400
 


### PR DESCRIPTION
Added:

{% info %}
You can add up to 15 different conditions per segment.
{% endinfo %}

Under Create a Segment - POST

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
