### PR TITLE
Update gmail_dmarc_changes.md

### DIFF
--- a/source/Classroom/Deliver/Sender_Authentication/gmail_dmarc_changes.md
+++ b/source/Classroom/Deliver/Sender_Authentication/gmail_dmarc_changes.md
@@ -14,15 +14,15 @@ navigation:
   show: true
 ---
 
-Gmail has recently decided to embrace  [DMARC](http://sendgrid.com/blog/dmarc-domain-based-message-authentication-reporting-conformance/) more explicitly, much like their email brethren, Yahoo and AOL. You may have started seeing bounce messages with the Reason of:
+Gmail has recently decided to embrace  [DMARC](http://sendgrid.com/blog/dmarc-domain-based-message-authentication-reporting-conformance/) more explicitly, much like their email brethren, Yahoo and AOL. You may soon start seeing bounce messages with the Reason of:
 
 **550 5.7.1 Unauthenticated email from domain.tld is not accepted due to domain's DMARC policy. Please contact administrator of domain.tld domain if this was a legitimate mail. Please visit [https://support.google.com/mail/answer/2451690](https://support.google.com/mail/answer/2451690) to learn about DMARC initiative. 62si14044909itw.103 - gsmtp **
 
-This is because Gmail will no longer be accepting messages where the From domain is a Gmail address and the message originates from a non-approved Gmail mail domain server/service. This is a security measure they have implemented to help reduce potential address spoofing of their mail domains. 
+This is because Gmail will no longer be accepting messages where the From domain is a Gmail address and the message originates from a non-approved Gmail mail domain server/service. This is a security measure they will be implementing to help reduce potential address spoofing of their mail domains. 
 
  
 
-**What this means:**  As of June, 2016, you can no longer send with the From address being anything from a Gmail address when sending to a domain that checks DMARC before accepting mail. 
+**What this means:**  Soon, you will no longer be able send with the From address being anything from a Gmail address when sending to a domain that checks DMARC before accepting mail. 
 
 **What you can do: ** You will need to change the From address you use in emails to a non-Gmail address. We recommend using one at your own mail domain, or one you control that is legitimate. You can then set the Reply-To field to be the original Gmail address that previously was used in the From field. 
 


### PR DESCRIPTION
Gmail still has a DMARC policy of "p=none".  They've indicated that they will implement a stricter policy in the future.

This article is still relevant, as senders should prepare for this upcoming change. I made some changes to the language around the dates/timing.

@ksigler7
