### PR TITLE
Added API Key Limitation

### DIFF
--- a/source/Classroom/Send/How_Emails_Are_Sent/api_keys.md
+++ b/source/Classroom/Send/How_Emails_Are_Sent/api_keys.md
@@ -28,6 +28,8 @@ Managing API Keys
 
 You can [manage your API Keys]({{site.app_url}}/settings/api_keys) from the SendGrid UI. Additionally, you can [manage your API keys via the API itself]({{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html).
 
+(% info %) There is a limit of 100 API Keys per account. (% endinfo %)
+
 {% anchor h2%}
 Using API Keys
 {% endanchor %}

--- a/source/Classroom/Send/How_Emails_Are_Sent/api_keys.md
+++ b/source/Classroom/Send/How_Emails_Are_Sent/api_keys.md
@@ -28,7 +28,7 @@ Managing API Keys
 
 You can [manage your API Keys]({{site.app_url}}/settings/api_keys) from the SendGrid UI. Additionally, you can [manage your API keys via the API itself]({{root_url}}/API_Reference/Web_API_v3/API_Keys/index.html).
 
-(% info %) There is a limit of 100 API Keys per account. (% endinfo %)
+{% info %} There is a limit of 100 API Keys per account. {% endinfo %}
 
 {% anchor h2%}
 Using API Keys


### PR DESCRIPTION
(% info %) There is a limit of 100 API Keys per account. (% endinfo %)

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
