### PR TITLE
Added API Key Limitation

### DIFF
--- a/source/User_Guide/Settings/api_keys.md
+++ b/source/User_Guide/Settings/api_keys.md
@@ -52,6 +52,8 @@ When you click the “Create API Key” button, a dropdown menu will appear allo
 
 The API Key name will follow your API key around through the SendGrid UI, so it is important that you choose a name that is meaningful to you.
 
+{% info %} There is a limit of 100 API Keys per account. {% endinfo %}
+
 {% warning %}
 You will only be shown your API key one time. Please store it somewhere safe as we will not be able to retrieve or restore this generated token.
 {% endwarning %}


### PR DESCRIPTION
{% info %} There is a limit of 100 API Keys per account. {% endinfo %}

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
