### PR TITLE
Add API Key Limitation

### DIFF
--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -75,6 +75,8 @@ You will then be able to name your key and assign it permissions.
 
 ![]({{root_url}}/images/select_billing_api_key_permissions.png)
 
+{% info %} There is a limit of 100 API Keys per account. {% endinfo %}
+
 API Key permissions are not permanent and may be changed any time after the key has been created. Simply click the gear icon next to the API Key you would like to make changes to, and click "Edit Details".
 
 ![]({{root_url}}/images/editing_api_keys.png)


### PR DESCRIPTION
{% info %} There is a limit of 100 API Keys per account. {% endinfo %}

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:

@ksigler7
