### PR TITLE
Update https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/index.html

### DIFF
--- a/source/API_Reference/Web_API_v3/Stats/index.html
+++ b/source/API_Reference/Web_API_v3/Stats/index.html
@@ -30,23 +30,23 @@ Not all metrics are returned for all endpoints. For example, the browser endpoin
 Email statistics consist of the following metrics:
 
 <ul>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Blocks">Blocks</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Bounces-amp-Repeat-Bounces">Bounces</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Blocks">Blocks</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Bounces-amp-Repeat-Bounces">Bounces</a></li>
   <li><a href="{{root_url}}/Glossary/drops.html">Bounce Drops</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Clicks-amp-Unique-Clicks">Clicks</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Delivered">Delivered</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Deferrals">Deferrals</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Clicks-amp-Unique-Clicks">Clicks</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Delivered">Delivered</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Deferrals">Deferrals</a></li>
   <li><a href="{{root_url}}/Glossary/drops.html">Drops</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Invalid-email">Invalid Emails</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Opens-amp-Unique-Opens">Processed</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Invalid-email">Invalid Emails</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Opens-amp-Unique-Opens">Processed</a></li>
   <li><a href="{{root_url}}/API_Reference/Webhooks/parse.html">Received</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Requests">Requests</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Spam-reports-amp-repeat-spam-reports">Spam Reports</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Clicks-amp-Unique-Clicks">Unique Clicks</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Opens-amp-Unique-Opens">Unique Opens</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Requests">Requests</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Spam-reports-amp-repeat-spam-reports">Spam Reports</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Clicks-amp-Unique-Clicks">Unique Clicks</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Opens-amp-Unique-Opens">Unique Opens</a></li>
   <li><a href="{{root_url}}/Glossary/drops.html">Spam Report Drops</a></li>
   <li><a href="{{root_url}}/Glossary/drops.html">Unsubscribe Drops</a></li>
-  <li><a href="{{root_url}}/User_Guide/Delivery_Metrics/metrics.html#-Unsubscribes">Unsubscribes</a></li>
+  <li><a href="{{root_url}}/User_Guide/Statistics/metrics.html#-Unsubscribes">Unsubscribes</a></li>
 </ul>
 
 


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:

I updated source/API_Reference/Web_API_v3/Stats/index.html

Specifically, I replaced all instances of "Delivery Metrics" with "Statistics"

**Reason for the change**:

SendGrid is no longer using the term "Delivery Metrics" and is using "Statistics" instead per:
https://github.com/sendgrid/docs/issues/2965

**Link to original source**:

https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/index.html

@ksigler7
