### PR TITLE
Added backticks around <pre> tag

### DIFF
--- a/source/Classroom/Build/Format_Content/plain_text_emails_converted_to_html.md
+++ b/source/Classroom/Build/Format_Content/plain_text_emails_converted_to_html.md
@@ -29,7 +29,7 @@ The following filters convert plain text emails to HTML so the proper HTML tags 
 **How can I control the resulting conversion (see update below)**
 
 1. You can turn off the filters causing the conversion from plain text to HTML.
-2. If you start each line with a space, this will add a "preformatted" <pre> tag around the line.
+2. If you start each line with a space, this will add a "preformatted" `<pre>` tag around the line.
 3. You can separate new sentences with double newlines, which will add a "paragraph" <p> tag around the sentence.
 4. You can convert your message to HTML, bypassing our need to convert it altogether
 


### PR DESCRIPTION

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: The `<pre>` tag wasn't escaped so it was rendering preformatted text mid-sentence. Added backticks to display the pre tag inline.
**Reason for the change**: Fix broken html on the page (pre tag was rendering when it shouldn't and looked back)
**Link to original source**: https://sendgrid.com/docs/Classroom/Build/Format_Content/plain_text_emails_converted_to_html.html

@ksigler7
