### PR TITLE
Update google_analytics_demystified_ga_statistics_vs_sg_statistics.md

### DIFF
--- a/source/Classroom/Track/Collecting_Data/google_analytics_demystified_ga_statistics_vs_sg_statistics.md
+++ b/source/Classroom/Track/Collecting_Data/google_analytics_demystified_ga_statistics_vs_sg_statistics.md
@@ -19,7 +19,7 @@ This article describes differences in the results and terminology of both.  In g
 
 _For general guidance on how our Google Analytics app works, please refer to our [documentation](http://sendgrid.com/docs/Apps/google_analytics.html)._
 
-Google Analytics has Clicks, Visits, Visitors, Pageviews, and Unique Pageviews. SendGrid has Clicks & Opens, as well as all of our [Delivery Metrics](http://sendgrid.com/docs/Delivery_Metrics/index.html).  
+Google Analytics has Clicks, Visits, Visitors, Pageviews, and Unique Pageviews. SendGrid has Clicks & Opens, as well as all of our [Statistics](http://sendgrid.com/docs/Delivery_Metrics/index.html).  
 The key here is that Google Analytics Clicks **are in no way related**  to SendGrid Clicks.
 
 Google Analytics **Visits** should generally correlate to Sendgrid **Unique Clicks**. However:


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:

I replaced all instances of "delivery metrics" with "statistics" per: https://github.com/sendgrid/docs/issues/2965

**Reason for the change**:

SendGrid is no longer using the term "Delivery Metrics" and is using "Statistics" instead.

**Link to original source**:

https://sendgrid.com/docs/Classroom/Track/Collecting_Data/google_analytics_demystified_ga_statistics_vs_sg_statistics.html

@ksigler7
