### PR TITLE
Fix typo on the using_the_web_api.md page

### DIFF
--- a/source/API_Reference/Web_API/using_the_web_api.md
+++ b/source/API_Reference/Web_API/using_the_web_api.md
@@ -114,7 +114,7 @@ https://api.sendgrid.com/api/blocks.get.json?api_user=your_sendgrid_username&api
 The Data
 {% endanchor %}
 
-When you send data a GET request, it usually means that you're sending data in the URL's query string,the part after the '?' in the url, as a key/value pair. The key is defined by the place where you are sending the data and is assumed to be URL-safe, however the data you provide may not be. So, you should urlencode the value (or the data part) of any URL-passed information. 
+When you send data a GET request, it usually means that you're sending data in the URL's query string, the part after the '?' in the url, as a key/value pair. The key is defined by the place where you are sending the data and is assumed to be URL-safe, however the data you provide may not be. So, you should urlencode the value (or the data part) of any URL-passed information. 
 
 For example, when you query google.com for "sendgrid.com/docs/" you get the following URL: 
 


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: Added a space after a comma that was missing one.
**Reason for the change**: Correct typo.
**Link to original source**: https://sendgrid.com/docs/API_Reference/Web_API/using_the_web_api.html#-The-Data
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

@ksigler7
