### PR TITLE
Added missing scopes in the admin permissions block.

### DIFF
--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -536,7 +536,7 @@ Below is a list of every scope included in an administrator level API Key.
   "teammates.create",
   "teammates.delete",
   "teammates.read",
-  "teammates.update"
+  "teammates.update",
   "templates.create",
   "templates.delete",
   "templates.read",

--- a/source/Classroom/Basics/API/api_key_permissions.md
+++ b/source/Classroom/Basics/API/api_key_permissions.md
@@ -533,6 +533,10 @@ Below is a list of every scope included in an administrator level API Key.
   "suppression.unsubscribes.read",
   "suppression.unsubscribes.update",
   "suppression.update",
+  "teammates.create",
+  "teammates.delete",
+  "teammates.read",
+  "teammates.update"
   "templates.create",
   "templates.delete",
   "templates.read",
@@ -575,6 +579,7 @@ Below is a list of every scope included in an administrator level API Key.
   "user.settings.enforced_tls.read",
   "user.settings.enforced_tls.update",
   "user.timezone.read",
+  "user.timezone.update",
   "user.username.read",
   "user.username.update",
   "user.webhooks.event.settings.read",


### PR DESCRIPTION
**Description of the change**: The admin permissions should contain the set of all possible permission scopes
**Reason for the change**: Improving SendGrid documentation
**Link to original source**: https://github.com/sendgrid/docs/pull/3082/files#diff-ed803c6b4fd35759afe9c8eeb9fdcefd
Closes #3081 

@ksigler7
