### PR TITLE
Creates Glossary entry for 'Expired'

### DIFF
--- a/source/API_Reference/Webhooks/event.md
+++ b/source/API_Reference/Webhooks/event.md
@@ -553,7 +553,7 @@ Bounce
          <td>Message recipient</td>
          <td>Status code string, e.g. 5.5.0</td>
          <td>Bounce reason from MTA</td>
-         <td><a href="{{root_url}}/Glossary/bounces.html">Bounce</a></li>/<a href="{{root_url}}/Glossary/blocks.html">Blocked</a>/Expired</td>
+         <td><a href="{{root_url}}/Glossary/bounces.html">Bounce</a></li>/<a href="{{root_url}}/Glossary/blocks.html">Blocked</a>/<a href="{{root_url}}/Glossary/expired.html">Expired</a></td>
          <td>The category you assigned</td>
       </tr>
    </tbody>

--- a/source/Glossary/expired.md
+++ b/source/Glossary/expired.md
@@ -23,7 +23,7 @@ Bounced emails are commonly due to SMTP 4.X.X errors or SMTP 5.X.X errors, which
 * Too many invalid recipients
 
 {% anchor h3 %}
-Helpful Knowledge Base articles:
+Additional Resources
 {% endanchor %}
 
 * [Bounces]({{root_url}}/Glossary/bounces.html)

--- a/source/Glossary/expired.md
+++ b/source/Glossary/expired.md
@@ -1,0 +1,31 @@
+---
+seo:
+  title: Expired
+  description: Bounced - Expired emails are emails that are unable to be delivered within 72 hours.
+  keywords: expired, bounce, undelivered email
+title: Expired
+weight: 0
+layout: page
+navigation:
+  show: false
+---
+
+If an email bounces, we will retry for up to 72 hours. If the email is unable to be delivered within the last 72 hours, it will expire and be marked as Bounced - Expired.
+
+Bounced emails are commonly due to SMTP 4.X.X errors or SMTP 5.X.X errors, which cause an email to be undeliverable:
+
+* An expired, inactive, or disabled recipient address
+* The recipient's mailbox has exceeded it's limit
+* An incorrect receipient email address
+* Domain frequency limited
+* Connection frequency limited
+* IP frequency limited
+* Too many invalid recipients
+
+{% anchor h3 %}
+Helpful Knowledge Base articles:
+{% endanchor %}
+
+* [Bounces]({{root_url}}/Glossary/bounces.html)
+* [Retrieve and Edit your List of Bounces]({{root_url}}/API_Reference/Web_API/bounces.html)
+* [Email Activity & Bounces](https://sendgrid.com/docs/User_Guide/email_activity.html)

--- a/source/Glossary/index.html
+++ b/source/Glossary/index.html
@@ -77,6 +77,7 @@ navigation:
         <a href="{{root_url}}/Glossary/email_marketing.html">Email Marketing</a>
         <a href="{{root_url}}/Glossary/email_service_provider.html">Email Service Provider</a>
         <a href="{{root_url}}/Glossary/event_webhook.html">Event Webhook</a>
+        <a href="{{root_url}}/Glossary/expired.html">Expired</a>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:

- Creates new Glossary page for 'Expired'
- Adds link on `API_Reference/Webhooks/event.html`, to new Glossary 'Expired' page
- Adds link on `Glossary/index.html`, to new Glossary 'Expired' page

**Reason for the change**:
Lack of information on "Bounce Type = Expired" causing confusion for customers

**Link to original source**:


<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #702

@ksigler7 @kylearoberts @mbernier Please help verify that the information provided on the new Glossary 'Expired' page is sufficient and correct?
