### PR TITLE
Clearer warning about subdomain selection in setting_up_the_inbound_parse_webhook.md

### DIFF
--- a/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
+++ b/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
@@ -64,7 +64,7 @@ Pointing to a Hostname and URL
 
   Here you will specify the subdomain and root domain of the receiving domain (or hostname). All emails sent to this receiving domain will be parsed.
 
-  The subdomain-domain combination must be unique. We recommend adding a subdomain such as "parse" to ensure that only emails sent to the @parse.example.com are parsed.
+  If you use the same subdomain as your Whitelabeled Domain, you must have Automatic Security disabled on the Domain Whitelabel. Otherwise, those messages will bounce due to an infinite CNAME>MX loop.
 
 {% info %}
 The URL must be accessible from the public web.


### PR DESCRIPTION
Clearer warning about subdomain selection. 

Closes #3105 