### PR TITLE
Improve text format consistency in code_editor.md and design_editor.md

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/code_editor.md
+++ b/source/User_Guide/Marketing_Campaigns/code_editor.md
@@ -24,19 +24,19 @@ Getting Started with the Code Editor
 
 1. From the left-hand navigation, select **Marketing**, and then click **Campaigns**. 
 
-1. Click **Create Campaign**. To create a campaign from an existing one, find the version you want to use and click the **action menu** next to the campaign and then select **Edit** or **Duplicate**.
+1. Click **Create Campaign**.
+   <br>To create a campaign from an existing one, find the version you want to use and click the **action menu** next to the campaign and then select **Edit** or **Duplicate**.
 
    ![]({{root_url}}/images/duplicate_campaign.png)
 
-1. Select the template that you want to use for your campaign. You can select a Blank Template, a custom template that you have already created, or one of SendGrid's pre-built templates. For more information, see [Working With Templates](https://sendgrid.com/docs/User_Guide/Marketing_Campaigns/templates.html).
+1. Select the template that you want to use for your campaign.
+   <br>You can select a Blank Template, a custom template that you have already created, or one of SendGrid's pre-built templates. For more information, see [Working With Templates](https://sendgrid.com/docs/User_Guide/Marketing_Campaigns/templates.html).
 
 1. Select **Code Editor**, and then click **Continue**.
-
-    If you have already built the HTML that you want to use in another application, copy and paste that code directly into the     content area of the code editor. You can also write the HTML for your campaign or template directly in the code editor.      The code editor has predictive text completion, color-coded syntax highlighting, and detailed error messages.
+   <br>If you have already built the HTML that you want to use in another application, copy and paste that code directly into the     content area of the code editor. You can also write the HTML for your campaign or template directly in the code editor.      The code editor has predictive text completion, color-coded syntax highlighting, and detailed error messages.
 
 1. Preview your campaign or template by clicking **Preview**.
-
-You can toggle between a preview of how your campaign or template will appear on a recipient's desktop and mobile phone by clicking either the desktop or mobile phone icons above the content area. You can also view a plain-text version of your campaign or template by clicking the **T** icon. When in this preview mode, you can edit the plain text content of your campaign or template by clicking the **Edit Plain Text** button.
+   <br>You can toggle between a preview of how your campaign or template will appear on a recipient's desktop and mobile phone by clicking either the desktop or mobile phone icons above the content area. You can also view a plain-text version of your campaign or template by clicking the **T** icon. When in this preview mode, you can edit the plain text content of your campaign or template by clicking the **Edit Plain Text** button.
 
 {% warning %}
 Once you create a new campaign or template in the Code Editor, you cannot switch to the Design Editor.

--- a/source/User_Guide/Marketing_Campaigns/design_editor.md
+++ b/source/User_Guide/Marketing_Campaigns/design_editor.md
@@ -33,9 +33,8 @@ Getting Started With the Design Editor
 {% endanchor h3 %}
 
 1. From the left-hand navigation, select **Marketing**, and then click **Campaigns**. 
-1. Click **Create Campaign**. 
-
-   To create a campaign using an existing campaign, find the campaign you want to use and click the action menu next to the campaign and then select Edit or Duplicate.
+1. Click **Create Campaign**.
+   <br>To create a campaign using an existing campaign, find the campaign you want to use and click the action menu next to the campaign and then select Edit or Duplicate.
 
    ![]({{root_url}}/images/duplicate_campaign.png)
 


### PR DESCRIPTION
I found that some of sentences in 'Getting Start' section are quite similar but they have different format. ex. sentences in _design_editor.md_ start with new line but that doesn't apply to the sentence in _code_editor.md_. So I change some of them to have the same format