### PR TITLE
Added table of contents to /User_Guide/Statistics/index.html

### DIFF
--- a/source/User_Guide/Statistics/index.html
+++ b/source/User_Guide/Statistics/index.html
@@ -21,12 +21,10 @@ Tracking your emails is an important part of being a good sender and learning ab
 We have broken up stats in specific ways so that you can get at-a-glance data, as well as allowing you to get into the details of how your email is being used.
 </p>
 
-<ul>
-<li><a href="#--Available-Email-Statistics-Reports">Available Email Statistics Reports</a></li>
-<li><a href="#-Metrics">Metrics</a></li>
-<li><a href="#-Statistics-Filters">Statistics Filter</a></li>
-<li><a href="#-Top-5-Categories">Top 5 Categories</a></li>
-</ul>
+- [Available Email Statistics Reports](#--Available-Email-Statistics-Reports)
+- [Metrics](#-Metrics)
+- [Statistics Filter](#-Statistics-Filters)
+- [Top 5 Categories](#-Top-5-Categories)
 
 {% anchor h2 %}
 Available Email Statistics Reports

--- a/source/User_Guide/Statistics/index.html
+++ b/source/User_Guide/Statistics/index.html
@@ -21,6 +21,13 @@ Tracking your emails is an important part of being a good sender and learning ab
 We have broken up stats in specific ways so that you can get at-a-glance data, as well as allowing you to get into the details of how your email is being used.
 </p>
 
+<ul>
+<li><a href="#--Available-Email-Statistics-Reports">Available Email Statistics Reports</a></li>
+<li><a href="#-Metrics">Metrics</a></li>
+<li><a href="#-Statistics-Filters">Statistics Filter</a></li>
+<li><a href="#-Top-5-Categories">Top 5 Categories</a></li>
+</ul>
+
 {% anchor h2 %}
 Available Email Statistics Reports
 {% endanchor %}


### PR DESCRIPTION

**Description of the change**: Added unordered-list table of contents to the Statistics User Guide page.
**Reason for the change**: ToC requested in https://github.com/sendgrid/docs/issues/3088
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/source/User_Guide/Statistics/index.html

**Notes**: I'm not certain this is exactly what you're looking for, I tried to match the style of the Design Editor page given as an example in the issue. If something needs tweaking with my addition, please let me know!
