### PR TITLE
Update setting_up_the_inbound_parse_webhook.md

### DIFF
--- a/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
+++ b/source/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.md
@@ -64,7 +64,8 @@ Pointing to a Hostname and URL
 
   Here you will specify the subdomain and root domain of the receiving domain (or hostname). All emails sent to this receiving domain will be parsed.
 
-  The subdomain-domain combination must be unique. We recommend adding a subdomain such as "parse" to ensure that only emails sent to the @parse.example.com are parsed.
+  Parse should be a unique subdomain of Whitelabeled Domain, not the same subdomain.
+If you use the same subdomain as your Whitelabeled Domain, you must have Automatic Security disabled on the Domain Whitelabel. Otherwise, those messages will bounce due to an infinite CNAME>MX loop.
 
 {% info %}
 The URL must be accessible from the public web.


### PR DESCRIPTION
added a clearer warning about subdomain selection.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
added a clearer warning about subdomain selection.
**Reason for the change**:
https://github.com/sendgrid/docs/issues/3105
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

@ksigler7
