### PR TITLE
Add Creating Categories section to Design Editor page

### DIFF
--- a/source/User_Guide/Marketing_Campaigns/design_editor.md
+++ b/source/User_Guide/Marketing_Campaigns/design_editor.md
@@ -27,12 +27,13 @@ The design editor is where you build your templates and campaigns using drag & d
     * [Drag & Drop Markup](#-Drag--Drop-Markup)
     * [Drag & Drop Code Examples](#-Drag--Drop-Code-Examples)
 * [Exporting HTML From the Design Editor](#-Exporting-HTML-From-the-Design-Editor)
+* [Creating Categories](#-Creating-Categories)
 
 {% anchor h3 %}
 Getting Started With the Design Editor
 {% endanchor h3 %}
 
-1. From the left-hand navigation, select **Marketing**, and then click **Campaigns**. 
+1. From the left-hand navigation, select **Marketing**, and then click **Campaigns**.
 1. Click **Create Campaign**.
    <br>To create a campaign using an existing campaign, find the campaign you want to use and click the action menu next to the campaign and then select Edit or Duplicate.
 
@@ -56,8 +57,8 @@ Drag & drop editing helps you swiftly build your campaign using pre-built conten
 
    ![]({{root_url}}/images/design_editor_drag_drop.png)
 
-2. Find the module tile you want to add to your campaign and drag and drop it into your content area. 
-3. Edit the module settings and add your custom content to build your campaign.  
+2. Find the module tile you want to add to your campaign and drag and drop it into your content area.
+3. Edit the module settings and add your custom content to build your campaign.
 
 
 {% anchor h3 %}
@@ -135,7 +136,7 @@ Under the Global Styles dropdown menu in the left hand sidebar, click **Email Bo
 <table class="table" style="table-layout:fixed">
 <tr>
     <th>Global Style</th>
-    <th>Style Options</th>  
+    <th>Style Options</th>
 </tr>
   <tr>
     <td><b>Email Body</b></td>
@@ -162,7 +163,7 @@ Editing Module HTML
 
 1. Select the module in the design editor and click the **&lt; &gt;** icon.
 <br>A window opens where you can edit the module HTML.
-1. When you are finished editing the HTML, click **Update**. 
+1. When you are finished editing the HTML, click **Update**.
 
 {% info %}
 If you make any structural code changes, you need to convert the module to a code module.
@@ -186,16 +187,16 @@ Adding Images
 
 1. Navigate to the **Build** tab, and then click **Add Modules**.
 1. Select the Images module, and drag and drop it into your content area.
-<br>This opens a window where you can upload images to your image library. 
+<br>This opens a window where you can upload images to your image library.
 1. Drag and drop the image you want to use from your files or select **Choose images** to upload.
 
 *To insert an image:*
 
 1. Navigate to the **Build** tab, and then click **Add Modules**.
-1. Drag and drop the **Images** module into your content area. 
-   <br>A window opens where you can select images from the image library. 
+1. Drag and drop the **Images** module into your content area.
+   <br>A window opens where you can select images from the image library.
 1. Select the image you want to add to your campaign.
-   <br>The Image Details tab opens. 
+   <br>The Image Details tab opens.
 1. Insert your image in the campaign by clicking **Save Image**.
 
 {% anchor h3 %}
@@ -206,7 +207,7 @@ Substitution tags allow you to easily generate dynamic content for each recipien
 
 *To add a substitution tag to your campaign:*
 
-1. Navigate to the **Tags** tab. 
+1. Navigate to the **Tags** tab.
 1. Locate the tag you want to add to your campaign and click the **copy** icon.
 1. Paste the tag into the module.
 
@@ -352,8 +353,8 @@ If you are writing your own custom HTML that you plan on importing into the desi
 *To import custom HTML:*
 
 1. Navigate to the **Build** tab in the left-hand navigation.
-1. Scroll down and select the **Advanced** drop-down menu. 
-1. Expand the option titled **Import/Export**. 
+1. Scroll down and select the **Advanced** drop-down menu.
+1. Expand the option titled **Import/Export**.
 1. Click **Import**.
    <br>A window opens where you can paste in your own HTML.
 
@@ -371,7 +372,7 @@ Drag & Drop Markup
 
 SendGrid parses your custom HTML, looking for any [drag & drop compatible modules](#-Drag-&-Drop-Code-Examples).
 
-  * First, we look for any HTML elements that contain the attribute `role="modules-container"`. 
+  * First, we look for any HTML elements that contain the attribute `role="modules-container"`.
   * Next, we look for all HTML elements with the attribute `role="module"` that are descendants of the "modules-container" element.
 
 The `role="modules-container"` attribute is required so that we know where your drag and drop modules are located. All of the SendGrid pre-built templates include the `role="modules-container"` by default. You are only required to include this attribute when creating a campaign or template from scratch that you want to be compatible with the design editor.
@@ -467,7 +468,7 @@ Drag & Drop Code Examples
   </tr>
 </table>
 {% endcodeblock %}</td>
-  </tr>  
+  </tr>
   <tr>
     <td>Text</td>
     <td>{% codeblock lang:html %}
@@ -528,7 +529,7 @@ Drag & Drop Code Examples
       </table>
     </td>
   </tr>
-</table>   
+</table>
 {% endcodeblock %}</td>
   </tr>
   <tr>
@@ -568,7 +569,7 @@ Drag & Drop Code Examples
     <table>
      <tbody>
       <tr>
-       [MODULE CONTENT]           
+       [MODULE CONTENT]
       </tr>
      </tbody>
     </table>
@@ -600,6 +601,16 @@ SendGrid hosts the images included in the pre-built templates and any images you
 1. Click **New Campaign**, and then select **Blank Template**.
 1. Select **Code Editor**.
 1. Paste the raw SendGrid template HTML into the code editor.
+
+{% anchor h3 %}
+Creating Categories
+{% endanchor h3 %}
+
+Creating categories to your campaign allows you to track statistics across multiple similar campaigns. You can easily add categories by simply typing them in the "Categories" section of the left hand sidebar.
+
+*To add a category:*
+1. Click on the **Categories** text field under **Campaign Settings**.
+2. Type the name of your category and press enter.
 
 {% anchor h3 %}
 Additional Resources

--- a/source/User_Guide/Marketing_Campaigns/design_editor.md
+++ b/source/User_Guide/Marketing_Campaigns/design_editor.md
@@ -606,11 +606,13 @@ SendGrid hosts the images included in the pre-built templates and any images you
 Creating Categories
 {% endanchor h3 %}
 
-Creating categories to your campaign allows you to track statistics across multiple similar campaigns. You can easily add categories by simply typing them in the "Categories" section of the left hand sidebar.
+Assigning categories to a campaign allows you to track emails based on your own categorization system. By assigning your campaign to a category, you can track statistics across multiple similar campaigns. Example categories: “Weekly Digest,” “Product Announcements.”
 
 *To add a category:*
-1. Click on the **Categories** text field under **Campaign Settings**.
-2. Type the name of your category and press enter.
+
+1. Navigate to the *Settings* tab, and click **Campaign Settings** to expand the menu.
+1. Find the *Categories* field.
+1. Enter the name of a new category or select a previously used category from the drop-down menu. 
 
 {% anchor h3 %}
 Additional Resources


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
Adds a "Creating Categories" section to the design_editor.md docs page.

**Reason for the change**:
Resolves issue #3098.

**Link to original source**:
https://github.com/sendgrid/docs/blob/develop/source/User_Guide/Marketing_Campaigns/design_editor.md

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3098

@ksigler7
