### PR TITLE
Clarify POST IPs request body.

### DIFF
--- a/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
+++ b/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md
@@ -19,6 +19,8 @@ address to be added to a pool after your request is made.
 {% parameters post %}   
   {% parameter ip Yes 'Valid IP address' 'IP address to add to the pool' %}    
 {% endparameters %}   
+
+{% apiv3requestbody %} {"ip":"0.0.0.0"} {% endapiv3requestbody %}
     
 {% apiv3example post POST https://api.sendgrid.com/v3/ips/pools/:pool_name/ips ip=0.0.0.0 %}    
   {% v3response %}    


### PR DESCRIPTION
The parameter is mentioned as a URI Parameter which gives the impression that it should be included in the URL as a query parameter rather than in the body. Adding a request body example will prevent misunderstandings.

**Description of the change**:  Adding a request body example.
**Reason for the change**: Prevent misunderstanding of how the parameter should be passed.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/source/API_Reference/Web_API_v3/IP_Management/ip_addresses.md

@ksigler7
