### PR TITLE
Added a glossary entry for "unknown user" for issue #3126

### DIFF
--- a/source/Glossary/index.html
+++ b/source/Glossary/index.html
@@ -90,7 +90,7 @@ navigation:
         <a href="{{root_url}}/Glossary/header.html">Header</a>
     </div>
     <div class="col-md-4 glossary-section">
-        {% anchor h2 %}I{% endanchor %}    
+        {% anchor h2 %}I{% endanchor %}
         <a href="{{root_url}}/Glossary/imap.html">IMAP</a>
         <a href="{{root_url}}/Glossary/ip_address.html">IP Address</a>
         <a href="{{root_url}}/Glossary/ip_warmup.html">IP Warmup</a>
@@ -170,6 +170,7 @@ navigation:
     <div class="col-md-4 glossary-section">
         {% anchor h2 %}U{% endanchor %}
         <a href="{{root_url}}/Glossary/undelivered_email.html">Undelivered Email</a>
+        <a href="{{root_url}}/Glossary/unknown_user.html">Undelivered Email</a>
     </div>
     <div class="col-md-4 glossary-section">
         {% anchor h2 %}W{% endanchor %}

--- a/source/Glossary/unknown_user
+++ b/source/Glossary/unknown_user
@@ -1,0 +1,24 @@
+---
+ seo:
+   title: Unknown User
+   description: Bounced - Unknown User is an error indicating the email address does not exist.
+   keywords: unknown, user, bounce, undelivered, email
+ title: Unknown User
+ weight: 0
+ layout: page
+ navigation:
+   show: false
+ ---
+
+ If an email address (user) does not exist at the organization or domain, it will recieve Unknown User - a hard bounce error.
+
+ It is usually caused due to SMTP 5.5.0 errors which cause an email to be undeliverable to an inactive, incorrect, or disabled recipient address.
+
+ {% anchor h3 %}
+ Additional Resources
+ {% endanchor %}
+
+ * [Delivery Metrics]({{root_url}}/User_Guide/Statistics/index.html)
+ * [Bounces]({{root_url}}/Glossary/bounces.html)
+ * [Subscriber List Management]({{root_url}}/Glossary/subscriber_list_management.html)
+ * [Deliverability Center](https://sendgrid.com/deliverabilitycenter)


### PR DESCRIPTION
added the unknown user in the glossary and linked to the index.html in the same
**Description of the change**: Link to Delivery Metrics, Link to Bounces, Link to Subscriber List Management
Link to Deliverability Center
**Reason for the change**:Unknown User - A hard bounce error indicating the email address (user) does not exist at the organization or domain.
<!-- 
issue no #3126  
-->
Closes #

@ksigler7