### PR TITLE
event webhook doc update

### DIFF
--- a/source/API_Reference/Webhooks/event.md
+++ b/source/API_Reference/Webhooks/event.md
@@ -107,7 +107,7 @@ Duplicate Events
 
 **It is possible to see duplicate events in the data posted by the Event Webhook.**
 
-We recommend that you use some form of deduplication when processing or storing your Event Webhook data using the `sg_event_id` as a differentiator, since this ID is unique for every event.
+We recommend that you use some form of deduplication when processing or storing your Event Webhook data using the `sg_event_id` as a differentiator, since this ID is unique for every event where `sg_event_id` is present.
 
 {% anchor h2 %}
 Event Types


### PR DESCRIPTION
* sg_event_id can't be used as a differentiator where its not present. Made an update in event.md 

**Description of the change**: Updated event.md doc
**Reason for the change**:  sg_event_id can't be used as a differentiator where its not present.
**Link to original source**: https://github.com/sendgrid/docs/issues/2862

Closes #2862 

@ksigler7
