### PR TITLE
fixed issue #3211

### DIFF
--- a/source/User_Guide/Suppressions/invalid_emails.md
+++ b/source/User_Guide/Suppressions/invalid_emails.md
@@ -14,6 +14,8 @@ An invalid email occurs when you attempt to send email to an address that is for
 
 The list provided here can be filtered by email address or date.
 
+Before you send, SendGrid does a check against the format of the email address to attempt to verify its validity. If the recipient server checks the address and doesn't find it, they will send back a 550 bounce to say that this is an invalid email address.
+
 {% anchor h2 %}
 Searching Invalid Emails by Date
 {% endanchor %}


### PR DESCRIPTION
On page: https://sendgrid.com/docs/User_Guide/Suppressions/invalid_emails.html

Added the following to the end of the first paragraph:

Before you send, SendGrid does a check against the format of the email address to attempt to verify its validity. If the recipient server checks the address and doesn't find it, they will send back a 550 bounce to say that this is an invalid email address.

Closes #3211
