### PR TITLE
Additional Resources added to Statistics module

### DIFF
--- a/source/User_Guide/Statistics/browser.md
+++ b/source/User_Guide/Statistics/browser.md
@@ -33,3 +33,11 @@ Figures
 The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your stats (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April based on the browser, this is a great place to look.
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Account Settings]({{root_url}}/User_Guide/Settings/account.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Browser Comparison]({{root_url}}/User_Guide/Statistics/browser_compare.html)

--- a/source/User_Guide/Statistics/browser_compare.md
+++ b/source/User_Guide/Statistics/browser_compare.md
@@ -39,3 +39,11 @@ Individual Metrics Figures
 This table will be titled “Figures for Delivered” and will show you the actual delivery numbers over time for each of the compared browsers.
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Subusers]({{root_url}}/User_Guide/Settings/Subusers/index.html)
+[Statistics]({{root_url}}/User_Guide/Statistics/index.html)

--- a/source/User_Guide/Statistics/categories.md
+++ b/source/User_Guide/Statistics/categories.md
@@ -35,3 +35,11 @@ Using the API
 {% endanchor %}
 
 [Using Categories with the SMTP API]({{root_url}}/API_Reference/SMTP_API/categories.html)
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Email Activity]({{root_url}}/User_Guide/email_activity.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Account Settings]({{root_url}}/User_Guide/Settings/account.html)

--- a/source/User_Guide/Statistics/category_compare.md
+++ b/source/User_Guide/Statistics/category_compare.md
@@ -55,3 +55,11 @@ You can remove individual categories from the list of categories you selected in
 To change this graph to see another metric, click the button inline with the graph title and choose another metric.
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Subusers]({{root_url}}/User_Guide/Settings/Subusers/index.html)
+[Using Categories with the SMTP API]({{root_url}}/API_Reference/SMTP_API/categories.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)

--- a/source/User_Guide/Statistics/device.md
+++ b/source/User_Guide/Statistics/device.md
@@ -72,3 +72,11 @@ When you initially choose the devices to compare, this graph will show you the a
 You can remove individual devices from the list of devices at the top of this page. The graph will refresh, showing only the selected subusers.
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Subusers]({{root_url}}/User_Guide/Settings/Subusers/index.html)
+[SendGrid for Mobile]({{root_url}}/User_Guide/SendGrid_for_Mobile/index.html)

--- a/source/User_Guide/Statistics/geo.md
+++ b/source/User_Guide/Statistics/geo.md
@@ -37,3 +37,11 @@ The figures table gives you all of the specific counts or percentages of each ev
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
 
 To see only the figures from a specific geographic area, change the Activity Map to be either the world view or a specific country, then select the countries or states you want to see in the figures table using the buttons just above and to the right of the figures data.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Global Stats]({{root_url}}s/API_Reference/Web_API_v3/Stats/global.html)
+[Timezones]({{root_url}}/Glossary/timezone.html)

--- a/source/User_Guide/Statistics/geo.md
+++ b/source/User_Guide/Statistics/geo.md
@@ -43,5 +43,5 @@ Additional Resources
 {% endanchor %}
 
 [Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
-[Global Stats]({{root_url}}s/API_Reference/Web_API_v3/Stats/global.html)
+[Global Stats]({{root_url}}/API_Reference/Web_API_v3/Stats/global.html)
 [Timezones]({{root_url}}/Glossary/timezone.html)

--- a/source/User_Guide/Statistics/global.md
+++ b/source/User_Guide/Statistics/global.md
@@ -12,7 +12,7 @@ navigation:
 
 
 {% info %}
-Global stats shown are not an aggregate total for parent accounts and subusers. The stats outlined will only contain data for whichever account you are currently accessing. Subuser stats can, however, be accessed from the Parent account's Stats menu either on an individual basis, or by comparing multiple subusers. 
+Global stats shown are not an aggregate total for parent accounts and subusers. The stats outlined will only contain data for whichever account you are currently accessing. Subuser stats can, however, be accessed from the Parent account's Stats menu either on an individual basis, or by comparing multiple subusers.
 {% endinfo %}
 
 Your Global Stats page is where you can really dig into your email stats. From here you will be able to filter through your stats by type, but you will also be able to look at the actual numbers for each stat by date. You can change which metrics, date, or grouping by adjusting the [statistics filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters).
@@ -24,3 +24,11 @@ Figures
 The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your stats (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the 2nd week of April, this is a great place to check.
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Global Stats]({{root_url}}s/API_Reference/Web_API_v3/Stats/global.html)
+[Timezones]({{root_url}}/Glossary/timezone.html)

--- a/source/User_Guide/Statistics/global.md
+++ b/source/User_Guide/Statistics/global.md
@@ -30,5 +30,5 @@ Additional Resources
 {% endanchor %}
 
 [Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
-[Global Stats]({{root_url}}s/API_Reference/Web_API_v3/Stats/global.html)
+[Global Stats]({{root_url}}/API_Reference/Web_API_v3/Stats/global.html)
 [Timezones]({{root_url}}/Glossary/timezone.html)

--- a/source/User_Guide/Statistics/index.html
+++ b/source/User_Guide/Statistics/index.html
@@ -113,3 +113,14 @@ Top 5 Categories
 <p>
   The Top 5 Categories report allows you to see your top 5 most used categories by number of requests. Switch your view by actual number of emails or percentage using the toggle at the top right of this section.
 </p>
+
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+<ul>
+  <li><a href="{{root_url}}/docs/API_Reference/Web_API_v3/Stats/index.html" target="_blank">Stats Overview</a><li>
+  <li><a href="{{root_url}}/docs/API_Reference/Web_API/Statistics/index.html" target="_blank">General Statistics</a><li>
+  <li><a href="{{root_url}}/docs/API_Reference/Web_API/Statistics/statistics_advanced.html" target="_blank">Advanced Statistics</a></li>
+</ul>

--- a/source/User_Guide/Statistics/mailbox_provider.md
+++ b/source/User_Guide/Statistics/mailbox_provider.md
@@ -27,3 +27,11 @@ Figures
 The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your stats (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April, this is a great place to check.
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Mailbox Provider Stats]({{site.app_url}}/statistics/mailbox_provider)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Account Settings]({{root_url}}/User_Guide/Settings/account.html)

--- a/source/User_Guide/Statistics/mailbox_provider_compare.md
+++ b/source/User_Guide/Statistics/mailbox_provider_compare.md
@@ -38,3 +38,11 @@ Individual Metrics Figures
 This table will be titled “Figures for Delivered” and will show you the actual delivery numbers over time for each of the compared providers.
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Mailbox Provider Stats]({{site.app_url}}/statistics/mailbox_provider)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)
+[Account Settings]({{root_url}}/User_Guide/Settings/account.html)

--- a/source/User_Guide/Statistics/parse.md
+++ b/source/User_Guide/Statistics/parse.md
@@ -21,3 +21,11 @@ Using the API
 {% endanchor %}
 
 To use the Inbound Parse Webhook, please check out [Setting Up the Inbound Parse Webhook]({{root_url}}/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html) and our [Inbound Parse API documentation]({{root_url}}/API_Reference/Webhooks/parse.html).
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Webhooks Overview]({{root_url}}/API_Reference/Webhooks/index.html)
+[Debugging a Webhook]({{root_url}}/API_Reference/Webhooks/debug.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)

--- a/source/User_Guide/Statistics/subuser.md
+++ b/source/User_Guide/Statistics/subuser.md
@@ -25,3 +25,11 @@ Figures
 The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your stats (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April, this is a great place to check.
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Subuser Stats]({{root_url}}/API_Reference/Web_API_v3/Stats/subusers.html)
+[Email Activity]({{root_url}}/User_Guide/email_activity.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)

--- a/source/User_Guide/Statistics/subuser_compare.md
+++ b/source/User_Guide/Statistics/subuser_compare.md
@@ -55,3 +55,11 @@ You can remove individual subusers from the list of categories you selected init
 To change this graph to see another metric, click the button inline with the graph title and choose another metric.
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+
+{% anchor h2 %}
+Additional Resources
+{% endanchor %}
+
+[Subuser Stats]({{root_url}}/API_Reference/Web_API_v3/Stats/subusers.html)
+[Email Activity]({{root_url}}/User_Guide/email_activity.html)
+[Statistics Filters]({{root_url}}/User_Guide/Statistics/index.html#-Statistics-Filters)


### PR DESCRIPTION
Added Additional Resources section and links to each User Guide page in Statistics.

**Description of the change**: Statistics module of User Guide has a Additional Resources section added
**Reason for the change**: Relates to Issue #3089 

@ksigler7
