### PR TITLE
Add Invalid Email glossary page and link on index

### DIFF
--- a/source/Glossary/index.html
+++ b/source/Glossary/index.html
@@ -92,6 +92,7 @@ navigation:
     <div class="col-md-4 glossary-section">
         {% anchor h2 %}I{% endanchor %}    
         <a href="{{root_url}}/Glossary/imap.html">IMAP</a>
+        <a href="{{root_url}}/Glossary/invalid_email.html">Invalid Email</a>
         <a href="{{root_url}}/Glossary/ip_address.html">IP Address</a>
         <a href="{{root_url}}/Glossary/ip_warmup.html">IP Warmup</a>
     </div>

--- a/source/Glossary/invalid_email.md
+++ b/source/Glossary/invalid_email.md
@@ -1,0 +1,13 @@
+---
+layout: page
+weight: 0
+title: Invalid Email
+navigation:
+  show: false
+seo:
+  title: Invalid Email
+  override: true
+  description: 
+---
+
+An invalid email occurs when you attempt to send email to an address that is formatted in a manner that does not meet internet email format standards. Examples include addresses without the “@” sign or addresses that include certain special characters and/or spaces. This response comes from our own server since an invalid email is impossible to even attempt to send to its [non-existent] destination.


### PR DESCRIPTION

**Description of the change**: Adds an Invalid Email page in the Glossary. Adds link to page in appropriate place in Glossary Index
**Reason for the change**: Page was requested in issue #3213
**Link to original source**: 

Closes #3213

@ksigler7
