### PR TITLE
Replaced instances of the term "action cog" with "action menu"

### DIFF
--- a/source/Classroom/Basics/Account/teammates_faq.md
+++ b/source/Classroom/Basics/Account/teammates_faq.md
@@ -132,7 +132,7 @@ How do I grant access to a SendGrid feature?
 
 As an administrator, you can grant access to a feature several ways. If a teammate has requested access to a feature, simply log in to your account, navigate to **Settings** in the left hand sidebar, and click **Teammates**. You will see three tabs labeled **All**, **Requesting Access**, and **Invited**. Click **Requesting Access** to view a list of all Teammates who have requested access along with the name of the feature they requested access to. Select either **Deny** or **Approve**.
 
-You also can give feature access to a teammate by editing that Teammate's permissions settings. Simply navigate to the teammates overview, and find the teammate under the **All** tab. Click the Action Cog next to that teammate and click **Edit**. This will open a window allowing you to change that teammate's various permissions. For more information, please visit our [User Guide]({{root_url}}/User_Guide/Settings/teammates.html).
+You also can give feature access to a teammate by editing that Teammate's permissions settings. Simply navigate to the teammates overview, and find the teammate under the **All** tab. Click the action menu next to that teammate and click **Edit**. This will open a window allowing you to change that teammate's various permissions. For more information, please visit our [User Guide]({{root_url}}/User_Guide/Settings/teammates.html).
 
 {% anchor h2 %}
 How do I set up Two-Factor Authentication for a teammate?

--- a/source/Classroom/Basics/Marketing_Campaigns/how_to_remove_unusable_contacts.md
+++ b/source/Classroom/Basics/Marketing_Campaigns/how_to_remove_unusable_contacts.md
@@ -16,7 +16,7 @@ The following steps will show you how to remove all of your unusable Marketing C
 
 1. When viewing your dashboard, navigate to the left hand menu and click **Suppressions**.
 
-2. Open a specific group, such as Bounces or Spam Reports, click the settings cog in the upper right corner, then select **Download as CSV**.
+2. Open a specific group, such as Bounces or Spam Reports, click the action menu in the upper right corner, then select **Download as CSV**.
 
     ![]({{root_url}}/images/remove_unusable_contacts_1.png)
 
@@ -28,7 +28,7 @@ The following steps will show you how to remove all of your unusable Marketing C
 
 6. You will be presented with a dialogue box. Select the option to **Create New List** and name it something obvious, like "Remove Invalid Emails."
 
-7. Once uploaded, click the cog to the right of that new list and select **Delete**.
+7. Once uploaded, click the action menu to the right of that new list and select **Delete**.
 
 8. Another dialogue box will open asking if you wish to delete "all contacts associated with this list". Make sure that box is checked, and then you're good to go!
 

--- a/source/Classroom/Basics/Marketing_Campaigns/marketing_campaigns_faqs.md
+++ b/source/Classroom/Basics/Marketing_Campaigns/marketing_campaigns_faqs.md
@@ -399,7 +399,7 @@ It can take up to 5 minutes before an unsubscribed contact will appear in an uns
 How do I unschedule a campaign that I don't want to send?
 {% endanchor %}
 
-You can unschedule a campaign by navigating to your list of campaigns, clicking the action cog next to the campaign you want to stop and clicking **Unschedule**. This returns the campaign to "draft" form. Also see _[How do I edit a scheduled campaign?](#-How-do-I-edit-a-scheduled-campaign)_ for additional detail.
+You can unschedule a campaign by navigating to your list of campaigns, clicking the action menu next to the campaign you want to stop and clicking **Unschedule**. This returns the campaign to "draft" form. Also see _[How do I edit a scheduled campaign?](#-How-do-I-edit-a-scheduled-campaign)_ for additional detail.
 
 {% anchor h3 %}
 How do I stop a campaign send?
@@ -453,7 +453,7 @@ Sender Verification
 Why didn't I receive a sender ID verification email?
 {% endanchor %}
 
-If you didn't receive a sender ID verification email, try requesting the verification email to be resent. Simply navigate to Marketing Campaigns in the left hand navigation menu and click on **Senders**. Next to the sender you need to verify, click the action cog and select **Resend Verification**.
+If you didn't receive a sender ID verification email, try requesting the verification email to be resent. Simply navigate to Marketing Campaigns in the left hand navigation menu and click on **Senders**. Next to the sender you need to verify, click the action menu and select **Resend Verification**.
 
 ![]({{root_url}}/images/mc_faq_4.gif)
 
@@ -467,7 +467,7 @@ If you clicked the link in your sender ID verification email, but had to sign in
 How long is the sender ID verification link valid?
 {% endanchor %}
 
-The URL in your sender ID verification email is valid for 48 hours. After 48 hours you will have to request a new verification email to be delivered. To resend your verification email, navigate to Marketing Campaigns in the left hand navigation menu and click **Senders**. Next to the sender you need to verify, click the action cog and select **Resend Verification**.
+The URL in your sender ID verification email is valid for 48 hours. After 48 hours you will have to request a new verification email to be delivered. To resend your verification email, navigate to Marketing Campaigns in the left hand navigation menu and click **Senders**. Next to the sender you need to verify, click the action menu and select **Resend Verification**.
 
 **********
 
@@ -505,6 +505,6 @@ Currently, you can see your aggregate stats over all time, and the graph display
 How do I view statistics for a specific campaign?
 {% endanchor %}
 
-Under **Marketing Campaigns** in the left hand navigation menu, select **Campaigns**. Find the campaign you want to see stats for in the list and click the action cog on the right. Click **Stats** to view statistics for that specific campaign.
+Under **Marketing Campaigns** in the left hand navigation menu, select **Campaigns**. Find the campaign you want to see stats for in the list and click the action menu on the right. Click **Stats** to view statistics for that specific campaign.
 
 ![]({{root_url}}/images/mc_faq_9.gif)

--- a/source/Classroom/Basics/Marketing_Campaigns/unsubscribe_groups.md
+++ b/source/Classroom/Basics/Marketing_Campaigns/unsubscribe_groups.md
@@ -51,7 +51,7 @@ Adding Your Unsubscribe Group to Your Campaign
 
 Once you've created your unsubscribe group, navigate to **Marketing** in the left hand nav and click **Campaigns**.
 
-Select the campaign you want to add the group unsubscribe link to. Click **Edit** in the preview modal that appears or click the action cog and select **Edit** from the dropdown menu.
+Select the campaign you want to add the group unsubscribe link to. Click **Edit** in the preview modal that appears or click the action menu and select **Edit** from the dropdown menu.
 
 Look for **Settings** in the left hand sidebar. Under the **Recipients** dropdown menu in this sidebar, select your unsubscribe group.
 

--- a/source/Classroom/Basics/Whitelabel/setup_domain_whitelabel.md
+++ b/source/Classroom/Basics/Whitelabel/setup_domain_whitelabel.md
@@ -91,11 +91,11 @@ Once you have created and validated your domain whitelabel, there is little work
 
 Any time that you send email with a FROM address whose domain matches the domain of your new whitelabel, SendGrid will apply that whitelabel to your email.
 
-You can change a whitelabel's default status at any time by navigating to your whitelabel settings page, clicking the action cog next to your default whitelabel and clicking **Remove Default Status**.
+You can change a whitelabel's default status at any time by navigating to your whitelabel settings page, clicking the action menu next to your default whitelabel and clicking **Remove Default Status**.
 
 ![]({{root_url}}/images/domain_whitelabel_setup_8.png)
 
-To delete one of your domain whitelabels, navigate to your whitelabel settings page, click to view the whitelabel you want to delete and click **Delete**. Alternatively, you can click the action cog next to your domain whitelabel and click **Delete**.
+To delete one of your domain whitelabels, navigate to your whitelabel settings page, click to view the whitelabel you want to delete and click **Delete**. Alternatively, you can click the action menu next to your domain whitelabel and click **Delete**.
 
 {% anchor h2 %}
 Related Resources

--- a/source/Classroom/Basics/Whitelabel/setup_ip_whitelabel.md
+++ b/source/Classroom/Basics/Whitelabel/setup_ip_whitelabel.md
@@ -73,7 +73,7 @@ Whenever you add a dedicated IP address to your account, you should make sure to
 Deleting an IP Whitelabel
 {% endanchor %}
 
-You can delete an IP whitelabel at any time. Simply navigating to your SendGrid dashboard, click **Settings** in the lefthand sidebar, and click **IPs** under **Whitelabels**. You will see a list of your IP whitelabels. Click the action cog next to the whitelabel you want to delete and click **Delete**.
+You can delete an IP whitelabel at any time. Simply navigating to your SendGrid dashboard, click **Settings** in the lefthand sidebar, and click **IPs** under **Whitelabels**. You will see a list of your IP whitelabels. Click the action menu next to the whitelabel you want to delete and click **Delete**.
 
 {% warning %}
 Deleting an IP whitelabel is permanent! You cannot recover a deleted IP whitelabel.

--- a/source/Classroom/Send/How_Emails_Are_Sent/sending.md
+++ b/source/Classroom/Send/How_Emails_Are_Sent/sending.md
@@ -49,7 +49,7 @@ I accidentally scheduled a campaign I didn’t want to send.
 
   -
 
-A: You can Unschedule the campaign from the action cog menu and it will return to a Draft form. Whew!
+A: You can Unschedule the campaign from the action menu menu and it will return to a Draft form. Whew!
 
 -
 

--- a/source/Classroom/Send/When_Emails_Are_Sent/can_i_stop_a_scheduled_send.md
+++ b/source/Classroom/Send/When_Emails_Are_Sent/can_i_stop_a_scheduled_send.md
@@ -123,7 +123,7 @@ Canceling a Marketing Campaign
 Using the User Interface
 {% endanchor %}
 
-If you scheduled a specific time to send your campaign, it's easy to unschedule this campaign to make changes or reschedule it. Simply navigate to your [Campaigns page](https://sendgrid.com/marketing_campaigns/ui/campaigns) by clicking **Marketing Campaigns** in the left hand navigation menu and selecting **Campaigns**. Next to the campaign you want to unschedule, click the action cog and select **Unschedule**.
+If you scheduled a specific time to send your campaign, it's easy to unschedule this campaign to make changes or reschedule it. Simply navigate to your [Campaigns page](https://sendgrid.com/marketing_campaigns/ui/campaigns) by clicking **Marketing Campaigns** in the left hand navigation menu and selecting **Campaigns**. Next to the campaign you want to unschedule, click the action menu and select **Unschedule**.
 
 ![]({{root_url}}/images/unschedule_campaign.gif)
 

--- a/source/Classroom/Track/Clicks/click_tracking_links_with_substitution_tags.md
+++ b/source/Classroom/Track/Clicks/click_tracking_links_with_substitution_tags.md
@@ -9,7 +9,7 @@ layout: page
 navigation:
   show: true
 ---
-It is possible to track the number of times each link in one of your [campaigns]({{root_url}}/User_Guide/Marketing_Campaigns/index.html) was clicked. All you need to do is enable [click tracking]({{root_url}}/User_Guide/Settings/tracking.html) in your tracking settings. When you navigate to your [campaigns]({{site.app_url}}/marketing_campaigns/campaigns), click the Action Cog next to the campaign, and select Stats. You will then be able to see the detailed statistics for the campaign, including a table displaying a list of your links along with the number of unique clicks, and total clicks, for each link.
+It is possible to track the number of times each link in one of your [campaigns]({{root_url}}/User_Guide/Marketing_Campaigns/index.html) was clicked. All you need to do is enable [click tracking]({{root_url}}/User_Guide/Settings/tracking.html) in your tracking settings. When you navigate to your [campaigns]({{site.app_url}}/marketing_campaigns/campaigns), click the action menu next to the campaign, and select Stats. You will then be able to see the detailed statistics for the campaign, including a table displaying a list of your links along with the number of unique clicks, and total clicks, for each link.
 
 ![]({{root_url}}/images/link_tracking.png)
 

--- a/source/User_Guide/Marketing_Campaigns/templates.md
+++ b/source/User_Guide/Marketing_Campaigns/templates.md
@@ -64,7 +64,7 @@ You can easily duplicate a pre-built template provided by SendGrid.
 
 1. From the left-hand navigation, select **Campaigns**  
 1. Click **Templates**. 
-1. Locate the template you want to duplicate and then click the action cog.
+1. Locate the template you want to duplicate and then click the action menu.
 1. Select **Duplicate**. The duplicate opens in the design editor.
 
 {% anchor h3 %}

--- a/source/User_Guide/Settings/Whitelabel/domains.md
+++ b/source/User_Guide/Settings/Whitelabel/domains.md
@@ -188,7 +188,7 @@ Deleting a Domain Whitelabel
 You cannot recover deleted domain whitelabels.
 {% endinfo %}
 
-To delete one of your domain whitelabels, navigate to your domain whitelabel settings and click the action cog next to the whitelabel you want to delete and click **Delete**. Alternatively, if you are already viewing the details for your domain whitelabel, click the **Delete** button in the bottom right hand corner.
+To delete one of your domain whitelabels, navigate to your domain whitelabel settings and click the action menu next to the whitelabel you want to delete and click **Delete**. Alternatively, if you are already viewing the details for your domain whitelabel, click the **Delete** button in the bottom right hand corner.
 
 {% info %}
 You can NOT delete the default domain whitelabel. You must replace it if you want to change it.

--- a/source/User_Guide/Settings/teammates.md
+++ b/source/User_Guide/Settings/teammates.md
@@ -74,7 +74,7 @@ Only administrator teammates may impersonate subusers!
 
 To invite a teammate to your account, navigate to **Settings**, and click on **Teammates** in the sidebar.
 
-This is where you can see the list of all of your current teammates with their details: username, email address, first name, and last name. By clicking the action cog under **Actions** you can either delete the teammate, or edit that teammate.
+This is where you can see the list of all of your current teammates with their details: username, email address, first name, and last name. By clicking the action menu under **Actions** you can either delete the teammate, or edit that teammate.
 
 If you have already sent a teammate invitation, you will see a list titled **Pending Invites**. Under this list you will see the email address the invite was sent to along with the invitation expiration date.
 
@@ -114,7 +114,7 @@ Only administrator teammates may impersonate subusers!
 
 Once you select a teammate type and have entered a valid email address, you may either click **Create** to send the teammate invitation, or you can further customize the permissions levels for your teammate.
 
-After you have sent the teammate invitation, you will see a new entry underneath **Pending Invites** on the Teammates page under **Settings**. Teammate invitations expire after 7 days. You can delete an invitation, or resend the invitation, by clicking the action cog under Actions.
+After you have sent the teammate invitation, you will see a new entry underneath **Pending Invites** on the Teammates page under **Settings**. Teammate invitations expire after 7 days. You can delete an invitation, or resend the invitation, by clicking the action menu under Actions.
 
 {% anchor h3 %}
 Accepting a Teammate Invitation
@@ -170,11 +170,11 @@ A notification email will be sent to the teammate when they are either granted o
 Managing Teammates
 {% endanchor %}
 
-To modify an existing teammate's permissions, navigate to the **Teammates Page** under **Settings**. Under the list of current teammates, click the action cog next to the teammate you would like to edit.
+To modify an existing teammate's permissions, navigate to the **Teammates Page** under **Settings**. Under the list of current teammates, click the action menu next to the teammate you would like to edit.
 
 Click **Edit** to open a modal window presenting the teammate's current permissions. Make your desired changes and click **Update**.
 
-To delete a teammate, navigate to the **Teammates Page** under **Settings**. Click the action cog next to the teammate you want to delete and click **Delete**.
+To delete a teammate, navigate to the **Teammates Page** under **Settings**. Click the action menu next to the teammate you want to delete and click **Delete**.
 
 ![Deleting a Teammate]({{root_url}}/images/teammates_10.png)
 

--- a/source/User_Guide/Settings/two_factor_authentication.md
+++ b/source/User_Guide/Settings/two_factor_authentication.md
@@ -99,7 +99,7 @@ Once setup, you will always be required to use Two-Factor Authentication to perf
 Disabling Two-Factor Authentication
 {% endanchor h2 %}
 
-To disable or delete a Two-Factor Authentication setting, navigate to the **Two-Factor Authentication overview page**. Find the setting you would like to delete, click the **Action Cog**, and select **Delete**.
+To disable or delete a Two-Factor Authentication setting, navigate to the **Two-Factor Authentication overview page**. Find the setting you would like to delete, click the **action menu**, and select **Delete**.
 
 <div class="row">
   <div class="clearfix col-md-6">


### PR DESCRIPTION
# Fixes # 
This pull request resolves #3285.

### Short description of what this PR does:
- This pull request addresses the use of the text 'action cog' and replaces it with the more familiar and user friendly term 'action menu.' 
- The original issue calls for the replacement of any image representation of the cog, but no uses of the image were found in the source.

