### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,25 @@ WORKDIR /docs
 SHELL ["/bin/bash", "-lc"]
 
 # Java
-RUN apt-get update && \
-  apt-get install -y openjdk-7-jdk && \
+RUN apt-get update -qq && \
+  apt-get install -y -qq openjdk-7-jdk && \
   rm -rf /var/lib/apt/lists/*
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 # Node.js
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-ADD .nvmrc /docs
+COPY .nvmrc /docs
 RUN nvm install $(cat .nvmrc)
-RUN npm install -g bower
 
-ADD package.json package-lock.json /docs/
-RUN npm install
-ADD bower.json .bowerrc /docs/
+COPY package.json package-lock.json /docs/
+RUN npm install -g bower && \
+  npm install
+COPY bower.json .bowerrc /docs/
 RUN bower install --allow-root
-ADD Gemfile Gemfile.lock /docs/
+COPY Gemfile Gemfile.lock /docs/
 RUN bundle install -j 4
 
-ADD . /docs
+COPY . /docs
 
 COPY _config.sample.yml _config.yml
 


### PR DESCRIPTION
* Use COPY in Dockerfile instead of ADD
* Reduce number of layers

COPY is recommended over ADD unless using the extra features of ADD.

The number of layers can probably be reduced some more but the
separation of install commands might be preferred.

I also added the `-qq` flag to apt commands for quieter output