### PR TITLE
Update cancel_schedule_send.apiblueprint

### DIFF
--- a/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
+++ b/source/API_Reference/Web_API_v3/cancel_schedule_send.apiblueprint
@@ -152,9 +152,9 @@ Update the status of a scheduled send.
 
             "" : "batch id not found"
 
-### Delete a cancellation or pause of a scheduled send [DELETE]
+### Delete a cancellation or pause state of a scheduled send [DELETE]
 
-Delete the cancellation/pause of a scheduled send. Any messages still in the sending queue with this Batch ID will revert to an active state, and delivery will be attempted when their `send_at` value is reached. Any "past due" messages (such as those that were *paused*) will be attempted to be delivered immediately.
+Delete the cancellation/pause state of a scheduled send. Any messages still in the sending queue with this Batch ID will revert to an active state, and delivery will be attempted when their `send_at` value is reached. Any paused messages past their scheduled send time will be attempted to be delivered immediately. Any cancelled messages past their scheduled sent time will be dropped. 
 
 
 + Request (application/json)


### PR DESCRIPTION
put in the word "state" after delete a cancellation or pause...
to clarify the state of the batch id is what is being deleted, and not the batch/send itself. 

clarified the paused send will be sent immediately while the cancelled will be dropped.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [Sendgrid](mailto:docs@sendgrid.com), or file a Github Issue in this repository.
