### PR TITLE
Spelling fix in Validate domain stub

### DIFF
--- a/source/API_Reference/Web_API_v3/Whitelabel/domains.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Whitelabel/domains.apiblueprint
@@ -469,7 +469,7 @@ You may create up to a maximum of 1500 domain whitelabels.
         {
           "id": 1,
           "valid": true,
-          "validation_resuts": {
+          "validation_results": {
             "mail_cname": {
                 "valid": false,
                 "reason": "Expected your MX record to be \"mx.sendgrid.net\" but found \"example.com\"."


### PR DESCRIPTION
Fixed (very) minor spelling mistake in Validate domain Stub

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Fixed spelling mistake for validate domain stub

If you have questions, please send an email to [Sendgrid](mailto:docs@sendgrid.com), or file a Github Issue in this repository.
