### PR TITLE
Clarify universal=true

### DIFF
--- a/source/Classroom/Build/Add_Content/universal_links.md
+++ b/source/Classroom/Build/Add_Content/universal_links.md
@@ -95,9 +95,9 @@ Example apple-app-site-association file:
 }
 {% endcodeblock %}
 
-{% info %}
+{% warning %}
 **Do not** append the .json file extension to your apple-app-site-association file!
-{% endinfo %}
+{% endwarning %}
 
 {% anchor h3 %}
 Example assetlinks.json file:
@@ -121,9 +121,7 @@ Example assetlinks.json file:
 {% endcodeblock %}
 
 {% info %}
-When configuring your universal links for Android devices, you must specify which URLs should be handled by the app and which should not.
-
-For iOS this is set in the "apple-app-site-association" file by including "paths": ["/uni/\*"], indicating that any URL containing the path "/uni/" should be opened in your app.
+When configuring your universal links in iOS, you specify which paths you want to be handled by the app by using the `paths` argument in the `apple-app-site-association` file. By specifing only the path `["/uni/*"]`, and using the `universal=true` attribute on your links as documented below, only appropriate links will be handled by the app, and others will be opened in the phone's browser.
 
 Android requires that you specify these paths inside your app, rather than the assetlinks.json file. This is accomplished by adding intent filters for specific hosts and paths. Please visit [Google's Developer Documentation](https://developer.android.com/training/app-indexing/deep-linking.html) to learn how to add an intent filter to your app manifest that can handle your universal links.
 {% endinfo %}
@@ -306,7 +304,10 @@ For example:
 
 `<a href="links.example.com" universal="true">Link to your app!</a>`
 
+This way, as long as your association file has the `paths` restricted to `/uni/*` as we recommend above, only the links that you want to be handled by your app will be.
+
 If you exclude the `universal="true"` attribute, your links will still function, but they will take your recipient to their mobile browser.
+If you exclude the `/uni/*` path in your `apple-app-site-association`, the _all_ links for your Whitelabeled domain will be forwarded for your app to handle, which may cause issues.
 
 {% anchor h2 %}
 Resolving SendGrid Click Tracking Links


### PR DESCRIPTION
Coming from https://sendgrid.zendesk.com/agent/tickets/1301598, user didn't understand `universal=true`, since they didn't fully read the docs. I clarified the intent of it, both up in the association file section, and in the attribute flagging section.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

