### PR TITLE
adding in status page to our release notes page based on feedback

### DIFF
--- a/source/release_notes.md
+++ b/source/release_notes.md
@@ -12,6 +12,8 @@ navigation:
 ---
 ![]({{root_url}}/images/release_notes.png "release notes")
 
+If you are looking for SendGrids opererational status, see our [Status Page](http://status.sendgrid.com/).
+
 The following new features and changes to the service are available.
 
 <table class="table" style="table-layout:fixed">


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**: adding in SendGrid operational status link 
**Reason for the change**: Because people might end up on our release notes if there's an outage
**Link to original source**: https://sendgrid.com/docs/release_notes.html
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

