### PR TITLE
Warning about needing an unsubscribe tag

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/campaigns.apiblueprint
@@ -44,6 +44,8 @@ A campaign requires a title to be created.
 In order to send or schedule the campaign, you will be required to provide a subject, sender ID, content (we suggest both html and plain text), and at least one list or segment ID.
 {% endinfo %}
 
+{% warning %} We require that both the html and plain text content have an `[unsubscribe]` tag in them.{% endwarning %}
+
 ### Create a Campaign [POST]
 
 + Request (application/json)


### PR DESCRIPTION
Added a warning about requiring an unsubscribe tag in both the html and plain text content. This is due to a new change for the unsubscribe module that is being added.
