### PR TITLE
Update to Spam Check point

### DIFF
--- a/source/User_Guide/Settings/parse.md
+++ b/source/User_Guide/Settings/parse.md
@@ -30,7 +30,7 @@ When entering your host name (also referred to as the receiving domain), the sub
 
 **URL** - The URL for the Inbound Parse Webhook to POST all parsed email information.
 
-**Spam Check** - Inbound Parse will check incoming emails for spam and reject the emails that are obviously spam. Selecting this option will also include a spam report.
+**Spam Check** - Inbound Parse will check incoming emails for spam, then assign them a spam score and report. This will be reflected under `spam_score` and `spam_report` in your Parse Webhook post. The user can then determine how this score is interpreted and the severity.
 
 **Send Raw** - Select this option if you would prefer to receive the full MIME message.
 


### PR DESCRIPTION
Added "Inbound Parse will check incoming emails for spam, then assign them a spam score and report. This will be reflected under `spam_score` and `spam_report` in your Parse Webhook post. The user can then determine how this score is interpreted and the severity."

Since we do not do anything based on spam score it, it is only reported and the user must take action based on what we post.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

