### PR TITLE
Add exclude flag to Get all Segments

### DIFF
--- a/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Marketing_Campaigns/contactdb.apiblueprint
@@ -872,6 +872,9 @@ You can add up to 15 different conditions per segment.
 
 ### List All Segments [GET]
 
++ Parameters
+    + exclude = "count" (optional, string) ... add this argument if you don't need the Segment `recipient_count` value updated. This will speed up the query return.
+
 + Response 200
 
      + Body


### PR DESCRIPTION
HV User having issue of this call timing out. talking to Devs, there's no pagination, but there's this "skip count" flag option, which tells the system to use the last-known count value, instead of re-counting. IT speeds up the query drastically, and thereby prevents some timeouts for users with very large Segments & Contact DBs.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

