### PR TITLE
clarifying the Accept Header requirements

### DIFF
--- a/source/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/requests.md
+++ b/source/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/requests.md
@@ -67,9 +67,7 @@ Depending on the resource, we support the following HTTP verbs:
 Accept Header
 {% endanchor %}
 
-The API provides JSON responses. The [accept header](http://www.soapui.org/Best-Practices/understanding-rest-headers-and-parameters.html) is not currently
-required, though it may be required in the future. If not set, the
-API will use `application/json`.
+The API provides JSON responses. The [accept header](http://www.soapui.org/Best-Practices/understanding-rest-headers-and-parameters.html) is currently required for some API calls, and is recommended for all of them. It should be set to `application/json`.
 
 {% codeblock lang:http %}
 GET https://api.sendgrid.com/v3/endpoint HTTP/1.1


### PR DESCRIPTION
the Accept Header is required for _some_ APi calls, so we should advise users to use it for all.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

