### PR TITLE
Adding multiple-address DELETE options

### DIFF
--- a/source/API_Reference/Web_API_v3/Suppression_Management/global_suppressions.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Suppression_Management/global_suppressions.apiblueprint
@@ -82,3 +82,37 @@ If the email address does not belongs to the Global Unsubscribes collection:
 ### Remove an email address from the Global Unsubscribes collection [DELETE]
 
 + Response 204 (application/json)
+
+## Global Unsubscribes Collection [/suppression/unsubscribe]
+
+### Remove multiple email addresses from the Global Unsubscribes collection [DELETE]
+
+{%info%}
+Maximum of 500 addresses in the `emails` Array.
+{%endinfo%}
+
++ Request (application/json)
+
+    + Body
+
+                {
+                  "emails": [
+                    "test1@example.com",
+                    "test2@example.com"
+                  ]
+                }
+
++ Response 204 (application/json)
+
+## Global Unsubscribes Collection [/suppression/unsubscribe]
+
+### Remove all email addresses from the Global Unsubscribes collection [DELETE]
++ Request (application/json)
+
+    + Body
+
+                {
+                  "delete_all": true
+                }
+
++ Response 204 (application/json)


### PR DESCRIPTION
After confirming with Mako Engineers, adding these calls so that they're documented, and we don't have to ask oncall to confirm again.
I'm not sure if my formatting it correct; the grouping in this doc format is weird...

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

