### PR TITLE
simple fix for dom xss in apidocs_iframe func

### DIFF
--- a/source/_assets/javascripts/iframe_docs.js
+++ b/source/_assets/javascripts/iframe_docs.js
@@ -14,6 +14,7 @@ function apidocs_iframe() {
     }
 
     $('#content .iframe-container').html('<iframe frameborder="0" src="'+url+'" width="1500" height="1000"></iframe>');
+    $('#content .iframe-container').html($('<iframe frameborder="0" width="1500" height="1000"></iframe>').attr('src', url));
   }
 }
 


### PR DESCRIPTION
* * fix an issue where the url hash is used without sanitization in apidocs_iframe
