### PR TITLE
Remove Choose How You Pay

### DIFF
--- a/source/User_Guide/Legacy_Newsletter/index.html
+++ b/source/User_Guide/Legacy_Newsletter/index.html
@@ -88,7 +88,7 @@ For assistance please For assistance please <a href="https://support.sendgrid.co
   </div>
 </div>
 
-<p>If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you can choose how you’d like to pay. You can continue to pay per email sent or you can choose to pay per contact you store in Marketing Campaigns:</p>
+<p>If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you could choose how you wanted to pay. You could continue to pay per email sent or you could choose to pay per contact you store in Marketing Campaigns:</p>
 
 <table class="table" style="table-layout:fixed">
   <tr>
@@ -107,7 +107,6 @@ For assistance please For assistance please <a href="https://support.sendgrid.co
   </tr>
 </table>
 </br>
-<a href="https://app.sendgrid.com/settings/choose_how_you_pay" class="btn btn-large btn-primary logged-out">Pricing Calculator</a>
 <a href="mailto:LegacyMigration@sendgrid.com" class="btn btn-large btn-secondary">Migration Feedback</a>
 
 {% anchor h2 %}

--- a/source/User_Guide/Legacy_Newsletter/index.html
+++ b/source/User_Guide/Legacy_Newsletter/index.html
@@ -88,7 +88,7 @@ For assistance please For assistance please <a href="https://support.sendgrid.co
   </div>
 </div>
 
-<p>If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you could choose how you wanted to pay. You could continue to pay per email sent or you could choose to pay per contact you store in Marketing Campaigns:</p>
+<p>If you used Legacy Newsletter between 1 August 2016 and 30 March 2017, when you switch to Marketing Campaigns, you could choose how you wanted to pay. This option is no longer available. All Marketing Campaigns customers must pay per contact stored in Marketing Campaigns:</p>
 
 <table class="table" style="table-layout:fixed">
   <tr>


### PR DESCRIPTION
Remove https://app.sendgrid.com/settings/choose_how_you_pay and options around this, the pay option and link expired on February 1st.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

