### PR TITLE
added ` for code view.

### DIFF
--- a/source/API_Reference/Webhooks/event.md
+++ b/source/API_Reference/Webhooks/event.md
@@ -108,7 +108,7 @@ Duplicate Events
 **It is possible to see duplicate events in the data posted by the Event Webhook.**
 
 We recommend that you use some form of deduplication when processing or storing your Event Webhook data using the `sg_event_id` as a differentiator, since this ID is unique for every event where `sg_event_id` is present.
-sg_event_id` comes in two different lengths. One that is 22 characaters long and a second that is 48 characters long. `sg_event_id` is actually a `UUID`. A `UUID` is 128 bit number that is usually presented as text.
+`sg_event_id` comes in two different lengths. One that is 22 characaters long and a second that is 48 characters long. `sg_event_id` is actually a `UUID`. A `UUID` is 128 bit number that is usually presented as text.
 
 48 character `sg_event_id` is a `UUIDv4` encoded and `Base64` decoded string.
 22 character `sg_event_id` is a `Base64url` encoded string.


### PR DESCRIPTION
One `sg_event_id` was missing it's leading `, which threw off the visual of the whole paragraph.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

