### PR TITLE
60 days to 30 days and storage limited to launch - not in beta

### DIFF
--- a/source/User_Guide/email_activity_beta.md
+++ b/source/User_Guide/email_activity_beta.md
@@ -36,7 +36,7 @@ With the Email Activity feed you can:
 * Troubleshoot email delivery issues faster with comprehensive and sequential event data by email message.
 * Pinpoint specific emails easily with advanced search and filter options --including subject line and email metadata.
 * Customize your data independently with CSV download/export option.
-* Increase storage available for up to 60 days for historical visibility within the UI by purchasing an upgrade.
+* Increase storage available for up to 30 days for historical visibility within the UI by purchasing an upgrade. (Not available in beta).
 * Call all events by an email from the API with additional storage purchase.
 
 


### PR DESCRIPTION
Edited the bullet re: 60 days storage, not available until Launch

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

