### PR TITLE
TOC anchor links not working?

### DIFF
--- a/source/User_Guide/Settings/dedicated_ip_addresses.md
+++ b/source/User_Guide/Settings/dedicated_ip_addresses.md
@@ -14,7 +14,7 @@ navigation:
 - [Why would I want a Dedicated IP Address?]()
 - [Do I have a Dedicated IP Address?]()
 - [How many Dedicated IPs should I have?]()
-- [Adding an additional Dedicated IP Address]()
+- [Adding an additional Dedicated IP Address](https://sendgrid.com/docs/User_Guide/Settings/dedicated_ip_addresses.html#-Adding-an-additional-Dedicated-IP-Address)
 - [Reputation Monitoring for Dedicated IP Accounts]()
 - [Warming Up a Dedicated IP Address]()
 - [Automatic IP Warmup Schedule]()

--- a/source/User_Guide/Settings/dedicated_ip_addresses.md
+++ b/source/User_Guide/Settings/dedicated_ip_addresses.md
@@ -10,14 +10,14 @@ navigation:
   show: true
 ---
 
-- [What are Dedicated IP Addresses?]()
-- [Why would I want a Dedicated IP Address?]()
-- [Do I have a Dedicated IP Address?]()
-- [How many Dedicated IPs should I have?]()
-- [Adding an additional Dedicated IP Address](https://sendgrid.com/docs/User_Guide/Settings/dedicated_ip_addresses.html#-Adding-an-additional-Dedicated-IP-Address)
-- [Reputation Monitoring for Dedicated IP Accounts]()
-- [Warming Up a Dedicated IP Address]()
-- [Automatic IP Warmup Schedule]()
+- [What are Dedicated IP Addresses?](#-What-are-Dedicated-IP-Addresses)
+- [Why would I want a Dedicated IP Address?](#-Why-would-I-want-a-Dedicated-IP-Address)
+- [Do I have a Dedicated IP Address?](#-Do-I-have-a-Dedicated-IP-Address)
+- [How many Dedicated IPs should I have?](#-How-many-Dedicated-IPs-should-I-have)
+- [Adding an additional Dedicated IP Address](#-Adding-an-additional-Dedicated-IP-Address)
+- [Reputation Monitoring for Dedicated IP Accounts](#-Reputation-Monitoring-for-Dedicated-IP-Accounts)
+- [Warming up a Dedicated IP Address](#-Warming-up-a-Dedicated-IP-Address)
+- [Automatic IP Warmup Schedule](#-Automatic-IP-Warmup-Schedule)
 
 {% anchor h2 %}
 What are Dedicated IP Addresses?
@@ -96,7 +96,7 @@ In addition, SendGrid does offer [Delivery Consultation](https://sendgrid.com/ma
 Warming Up a Dedicated IP Address
 {% endanchor %}
 
-For more information on warming up an IP Address, see [Warming up IPS]().ß
+For more information on warming up an IP Address, see [Warming up IPS]().
 
 {% anchor h2 %}
 Additional Resources

--- a/source/User_Guide/Settings/dedicated_ip_addresses.md
+++ b/source/User_Guide/Settings/dedicated_ip_addresses.md
@@ -96,7 +96,7 @@ In addition, SendGrid does offer [Delivery Consultation](https://sendgrid.com/ma
 Warming Up a Dedicated IP Address
 {% endanchor %}
 
-For more information on warming up an IP Address, see [Warming up IPS]().
+For more information on warming up an IP Address, see [Warming up a dedicated IP]({{root_url}}/User_Guide/Settings/ip_warmup.html).
 
 {% anchor h2 %}
 Additional Resources


### PR DESCRIPTION
It appears as though the topics listed at the beginnging are a table of contents? but they don't link down to the associated heading?

I only updated 'adding' because that's how I found it.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

