### PR TITLE
Update api_key_id definition 

### DIFF
--- a/source/API_Reference/Web_API_v3/Tutorials/getting_started_email_activity_api.md
+++ b/source/API_Reference/Web_API_v3/Tutorials/getting_started_email_activity_api.md
@@ -254,7 +254,7 @@ This is a full list of basic query types and examples: (replace the data in quot
  </tr>
  <tr>
    <td><code>api_key_id</code></td>
-   <td><code>api_key_id="-hVjtoFgGUNPq3DPPPkJN3mCIDIwrl3qdFZcqYKnlq94"</code> (everything after the middle dot in the API key)</td>
+   <td><code>api_key_id="SG.xxxxxxxxxxxxxxxx"</code> (everything before the middle dot in the API key)</td>
  </tr>
  <tr>
    <td><code>api_key_name</code></td>


### PR DESCRIPTION
API Key ID was defined as "everything after the middle dot in the API key" but an API Key ID is everything before the middle dot in the API key. ex SG.xxxxxxxxxxxxxxxx. Feel free to create a better dummy API Key ID.

<!-- 
Please explain WHAT you changed and WHY.

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

Fill out this form in the body:
-->

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

