### PR TITLE
Updated warning about TLS certificates

### DIFF
--- a/source/API_Reference/Webhooks/event.md
+++ b/source/API_Reference/Webhooks/event.md
@@ -42,7 +42,7 @@ The Event Webhook will not follow redirects. Please make sure to use the correct
 {% endwarning %}
 
 {% warning %}
-If you wish to receive encrypted posts, we require that your callback URL support TLS 1.2.
+If you wish to receive encrypted posts, we require that your callback URL support TLS 1.2. Self-signed or expired certificates will not be accepted.
 {% endwarning %}
 
 {% anchor h2 %}


### PR DESCRIPTION
"Self-signed or expired certificates will not be accepted." Updating doc to reflect potential failures customers may experience with the new event system rollout.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

