### PR TITLE
Remove period from unordered list in ip_address.md

### DIFF
--- a/source/Glossary/ip_address.md
+++ b/source/Glossary/ip_address.md
@@ -20,5 +20,5 @@ If you are on a Pro 100k or above plan you can see your IP reputation and IP add
 
 For more information:
 
-* [SendGrid Email Infrastructure Guide.](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)
+* [SendGrid Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html)
 * [Whitelabeling your IP]({{root_url}}/User_Guide/Setting_Up_Your_Server/Whitelabeling/index.html)


### PR DESCRIPTION
**Description of the change**: Removed the period at the end of the link to the SendGrid Infrastructure Guide.
**Reason for the change**: Other unordered lists don't contain periods at the end of links.
**Link to original source**: https://sendgrid.com/docs/Glossary/ip_address.html