### PR TITLE
View Event History Anchor

### DIFF
--- a/source/User_Guide/email_activity_feed.md
+++ b/source/User_Guide/email_activity_feed.md
@@ -150,7 +150,7 @@ or
 * Search emails by **all** of the following - This search will return fewer results and will pull in events that meet *every* criteria specified by the selected filters. 
 
 {% anchor H2 %}
-Viewing Event History
+Viewing event history 
 {% endanchor %}
 
 *To view event history:*


### PR DESCRIPTION
 - * [Viewing event history](#-Viewing-event-history) Does not direct to proper section
 - Can we add the pricing break down for self-serve as well?

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

