### PR TITLE
Removed Activity Feed warning

### DIFF
--- a/source/API_Reference/Web_API_v3/Stats/advanced.md
+++ b/source/API_Reference/Web_API_v3/Stats/advanced.md
@@ -6,10 +6,6 @@ navigation:
   show: true
 ---
 
-{% info %}
-We store 7 days of email activity in our database and the default is 500 items returned per request via these API endpoints.
-{% endinfo %}
-
 Advanced Stats provide a more in-depth view of your statistics and the actions of the recipients segmented by geography, browser type, and more. You can read more about them in the [Statistics]({{root_url}}/User_Guide/Statistics/index.html) section of our User Guide.
 
 {% anchor h2 %}


### PR DESCRIPTION
Activity feed does not reflect the same data as the stats section so this was confusing to customers expecting things such as geolocation to be stored in Activity Feed metadata

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

