### PR TITLE
added non-breaking changes to the WL API comment

### DIFF
--- a/source/release_notes.md
+++ b/source/release_notes.md
@@ -53,7 +53,7 @@ Whitelabel has a new name!
 <table class="table" style="width: 100%;">
   <tr>
     <td style="width:75px; height:75px"><img src="{{root_url}}/images/ui_icon.png" alt="An update to the UI" ></td>
-    <td>An update to the UI SendGrid’s whitelabel has become sender authentication, which simplifies the process for senders to demonstrate domain ownership through multiple authentication methods to recipient mailbox providers in order to improve their email delivery. This launch includes improvements to the set up flow and a more accurate name for the functionality. All pending and verified whitelabels can be found under sender authentication.</td>
+    <td>An update to the UI SendGrid’s whitelabel has become sender authentication, which simplifies the process for senders to demonstrate domain ownership through multiple authentication methods to recipient mailbox providers in order to improve their email delivery. This launch includes improvements to the set up flow and a more accurate name for the functionality. All pending and verified whitelabels can be found under sender authentication and only non-breakding additive updates have been made to the whitelabel API.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Should we add the API icon (to display with the UI icon) on the improvements post and link to the WL API docs as well?

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

