### PR TITLE
Can we redirect another link to this doc?

### DIFF
--- a/source/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_dns.md
+++ b/source/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_dns.md
@@ -5,7 +5,7 @@ title: How to set up reverse DNS
 navigation:
   show: true
 seo:
-  title: How to set up Reverse DNS
+  title: How to set up reverse DNS
   override: true
   description: Set up reverse DNS to improve your deliverability and security of your emails.
 ---

--- a/source/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_dns.md
+++ b/source/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_dns.md
@@ -5,7 +5,7 @@ title: How to set up reverse DNS
 navigation:
   show: true
 seo:
-  title: How to set up reverse DNS
+  title: How to set up Reverse DNS
   override: true
   description: Set up reverse DNS to improve your deliverability and security of your emails.
 ---

--- a/source/_redirects.htaccess
+++ b/source/_redirects.htaccess
@@ -1024,4 +1024,5 @@ Redirect 301 /Classroom/Basics/Whitelabel/link_whitelabels_explained.html https:
 Redirect 301 /Classroom/Basics/Whitelabel/index.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/How_to_set_up_domain_authentication.html
 Redirect 301 /User_Guide/Settings/Whitelabel/providers.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/providers.html
 Redirect 301 /User_Guide/Settings/Whitelabel/faq.html https://sendgrid.com/docs/Glossary/whitelabel.html
+Redirect 301 /User_Guide/Settings/Sender_Authentication/How_to_set_up_Reverse_DNS.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_DNS.html 
 

--- a/source/_redirects.htaccess
+++ b/source/_redirects.htaccess
@@ -1024,5 +1024,5 @@ Redirect 301 /Classroom/Basics/Whitelabel/link_whitelabels_explained.html https:
 Redirect 301 /Classroom/Basics/Whitelabel/index.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/How_to_set_up_domain_authentication.html
 Redirect 301 /User_Guide/Settings/Whitelabel/providers.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/providers.html
 Redirect 301 /User_Guide/Settings/Whitelabel/faq.html https://sendgrid.com/docs/Glossary/whitelabel.html
-Redirect 301 /User_Guide/Settings/Sender_Authentication/How_to_set_up_Reverse_DNS.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_DNS.html 
+Redirect 301 /User_Guide/Settings/Sender_Authentication/How_to_set_up_reverse_DNS.html https://sendgrid.com/docs/User_Guide/Settings/Sender_authentication/How_to_set_up_reverse_DNS.html 
 


### PR DESCRIPTION
Redirect https://sendgrid.com/docs/User_Guide/Settings/Sender_Authentication/How_to_set_up_reverse_DNS.html to this documentation.

That link is in the 'Learn More' option for Sender Auth > Reverse DNS and errors out when selected, so we would like to redirect the incorrect link to this doc until this is fixed in the UI.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

