### PR TITLE
subdomain no longer required

### DIFF
--- a/source/API_Reference/Web_API_v3/Whitelabel/domains.apiblueprint
+++ b/source/API_Reference/Web_API_v3/Whitelabel/domains.apiblueprint
@@ -117,7 +117,7 @@ the customer will just need to create a few CNAMEs to SendGrid, and SendGrid wil
 
 + Attributes (object)
     + domain example.com (required, string) - Domain being whitelabeled.
-    + subdomain news (required, string) - Subdomain being whitelabeled.
+    + subdomain news (optional, string) - Subdomain being whitelabeled. If you do not provide one, our system will generate one and provide it in the Response Body.
     + automatic_security false (optional, boolean) - Whether to allow SendGrid to manage your SPF records, DKIM keys, and DKIM key rotation.
     + ips ["192.168.1.1"] (optional, array[string]) - Specify IPs to be used in your SPF record.
     + custom_spf true (optional, boolean) - Specify whether to use a custom spf or allow SendGrid to manage your SPF. This option is only available to domain whitelabels setup for manual security.


### PR DESCRIPTION
with the Domain Authentication update, `subdomain` is no longer required.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

