### PR TITLE
Revert "Updated Sender Auth links"

### DIFF
--- a/source/release_notes.md
+++ b/source/release_notes.md
@@ -57,10 +57,10 @@ Improved Sender Authentication Process (formerly "Whitelabel")
   </tr>
 </table>
 
-For more information on the new process for sender authentication: 
-- Access [Sender Authentication](https://app.sendgrid.com/settings/sender_auth)
-- Read the [blog post](https://sendgrid.com/blog/new-sender-authentication/) about Sender Authentication.
-- Check out our how to docs on [How to set up domain authentication]({{root_url}}/User_Guide/Settings/Sender_authentication/How_to_set_up_domain_authentication.html) and [How to set up link branding]({{root_url}}/User_Guide/Settings/Sender_authentication/How_to_set_up_link_branding.html)
+For more information on the new process for sender authentication, check out our how to docs:
+
+- [How to set up domain authentication]({{root_url}}/User_Guide/Settings/Sender_authentication/How_to_set_up_domain_authentication.html)
+- [How to set up link branding]({{root_url}}/User_Guide/Settings/Sender_authentication/How_to_set_up_link_branding.html)
 
 
 {% anchor h2 %}


### PR DESCRIPTION
Reverts sendgrid/docs#3614

broken cross reference.