### PR TITLE
remove 48 char long sg_event_id description

### DIFF
--- a/source/API_Reference/Event_Webhook/troubleshooting.md
+++ b/source/API_Reference/Event_Webhook/troubleshooting.md
@@ -42,10 +42,8 @@ Duplicate events
 **It is possible to see duplicate events in the data posted by the Event Webhook.**
 
 We recommend that you use some form of deduplication when processing or storing your Event Webhook data using the `sg_event_id` as a differentiator since this ID is unique for every event where `sg_event_id` is present.
-`sg_event_id` comes in two different lengths. One that is 22 characters long and a second that is 48 characters long. `sg_event_id` is actually a `UUID`. A `UUID` is 128-bit number presented as text.
 
-48 character `sg_event_id` is a `UUIDv4` encoded and `Base64` decoded string.
-22 character `sg_event_id` is a `Base64url` encoded string.
+`sg_event_id` is a [UUIDv4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) that is `Base64url` encoded string. 
 
 {% anchor h3 %}
 Load handling


### PR DESCRIPTION
**Description of the change**:
Streamlined sg_event_id description
**Reason for the change**:
linkd no longer generates (incorrectly) a 48 char sg_event_id

**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

