### PR TITLE
Update dkim.md

### DIFF
--- a/source/Glossary/dkim.md
+++ b/source/Glossary/dkim.md
@@ -41,8 +41,8 @@ Example DKIM Record: Automated Security ON
 {% codeblock %}
 
 subdomain.yourdomain.com. | CNAME | uXXXXXXX.wlXXX.sendgrid.net
-s1.domainkey.yourdomain.com. | CNAME | s1.domainkey.uXXX.wlXXX.sendgrid.net.
-s2.domainkey.yourdomain.com. | CNAME | s2.domainkey.uXXX.wlXXX.sendgrid.net.
+s1._domainkey.yourdomain.com. | CNAME | s1._domainkey.uXXX.wlXXX.sendgrid.net.
+s2._domainkey.yourdomain.com. | CNAME | s2._domainkey.uXXX.wlXXX.sendgrid.net.
 
 {% endcodeblock %}
 


### PR DESCRIPTION
Changed the DKIM values for the automated security example. The examples were missing the underscore in front of the 'd' in '.domainkey'.  This change now matches what the customers will receive/see when going through Sender Authentication for their sending domain.

**Description of the change**: Updated the example automated security DKIM  to match what the customer actually receives from our system
**Reason for the change**: Caused customer confusion because the example didn't match our system generated DNS values. 
**Link to original source**: https://sendgrid.com/docs/Glossary/dkim.html
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

