### PR TITLE
Remove language about preventing unsubscribe group deletes.

### DIFF
--- a/source/API_Reference/Web_API_v3/Suppression_Management/groups.md
+++ b/source/API_Reference/Web_API_v3/Suppression_Management/groups.md
@@ -173,7 +173,6 @@ DELETE
 Delete a suppression group.
 
 {% info %}
-You can only delete groups that have not been attached to sent mail in the last 60 days.
 If a recipient uses the "one-click unsubscribe" option on an email
 associated with a deleted group, that recipient will be added to the
 global suppression list.


### PR DESCRIPTION
The API no longer prevents deletes for groups sent to in the last 60 days. It seems the functionality was removed in this ticket: https://jira.sendgrid.net/browse/MAKO-1469

