### PR TITLE
Update how_to_send_an_email_with_transactional_templates.md

### DIFF
--- a/source/User_Guide/Transactional_Templates/how_to_send_an_email_with_transactional_templates.md
+++ b/source/User_Guide/Transactional_Templates/how_to_send_an_email_with_transactional_templates.md
@@ -91,10 +91,10 @@ curl -X "POST" "https://api.sendgrid.com/v3/mail/send" \
             "city":"Place",
             "state":"CO",
             "zip":"80202"
-         },
-         "template_id":"[template_id]"
+         }
       }
-   ]
+   ],
+   "template_id":"[template_id]"
 }'
 {% endcodeblock %}
 


### PR DESCRIPTION
The template id property needs to be at the top level, instead of under template data.
