### PR TITLE
Awkward spacing on first header

### DIFF
--- a/content/docs/for-developers/tracking-events/event-kit.md
+++ b/content/docs/for-developers/tracking-events/event-kit.md
@@ -21,7 +21,7 @@ Our open source EventKit app alleviates the hassle of needing to set up an endpo
 [Click here](https://github.com/sendgrid/eventkit-rails) to visit the EventKit Github repository.
 
 
-## Learn how to install the EventKit app using a free [Heroku](https://www.heroku.com/) instance by watching this step-by-step video:
+## Learn how to install the Event Kit app using a free [Heroku](https://www.heroku.com/) instance by watching this step-by-step video:
 
 <iframe src="https://player.vimeo.com/video/167121552" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 


### PR DESCRIPTION
The first header "Learn how to install the Event Kit app using a free [Heroku](https://www.heroku.com/) instance by watching this step-by-step video:" has a weird river in the center of the header.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

