### PR TITLE
Adding back Algolia name and link to seach.

### DIFF
--- a/src/scss/components/_algolia.scss
+++ b/src/scss/components/_algolia.scss
@@ -25,7 +25,21 @@
   }
 
   .algolia-docsearch-footer {
-    display: none;
+    font-size: $scaledown-2 !important;
+    color: $slate-40 !important;
+    width: auto !important;
+    height: auto !important;
+    margin-top: $scaleup-3 !important;
+  }
+
+  .algolia-docsearch-footer--logo {
+    text-indent: 0 !important;
+    background: transparent !important;
+    color: $slate-40 !important;
+    overflow: visible !important;
+    height: auto !important;
+    width: auto !important;
+    display: inline !important;
   }
 
   .algolia-docsearch-suggestion--subcategory-column {


### PR DESCRIPTION
Added back Algolia name and link to search results container. Hid the logo, and made the text small and light color so it's not so noticeable.