### PR TITLE
Update how-to-use-a-transactional-template-with-smtp.md

### DIFF
--- a/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp.md
+++ b/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp.md
@@ -1,9 +1,9 @@
 ---
 seo:
-  title: How to use a Transactional Template with the SMTP API
+  title: How to use a Legacy Template with the SMTP API
   description: Learn how to send a transactional template with the SMTP API.
-  keywords: SMTP, send email, integrate, building, filters, scheduling, substitution, suppression groups, unique arguments, recipients, transactional template
-title: How to use a Transactional Template with the SMTP API
+  keywords: SMTP, send email, integrate, building, filters, scheduling, substitution, suppression groups, unique arguments, recipients, transactional template, legacy template
+title: How to use a Legacy Template with the SMTP API
 group: smtp
 weight: 949
 layout: page
@@ -13,7 +13,11 @@ navigation:
 
 ## 	Enabling a Template
 
-To use a transactional template when you send, enable the `templates`
+{% warning %}
+This method of sending does not support Transactional Templates. For sending Transactional Templates you need to use v3 Mail Send
+{% endwarning %}
+
+To use a legacy template when you send, enable the `templates`
 filter and set the `template_id` to one of your transactional templates.
 
 Example
@@ -33,7 +37,7 @@ Example
 You can use this JSON in the `X-SMTPAPI` header of an SMTP message, or in
 the `x-smtpapi` parameter of a [Web API v2 mail send](https://sendgrid.com/docs/API_Reference/Web_API/mail.html#-send) call.
 
-If you are using the [Web API v3 mail send endpoint](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html), you can specify which transactional template you would like to use simply by setting the template ID in the `template_id` parameter of your JSON payload.
+If you are using the [Web API v3 mail send endpoint](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html), you can specify which legacy template you would like to use simply by setting the template ID in the `template_id` parameter of your JSON payload.
 
 <call-out>
 
@@ -45,7 +49,7 @@ Make sure that the version of the template you want to use is set to active by u
 
 ## 	Body and Subject Tags
 
-Enabling a transactional template means that the `subject` and `body`
+Enabling a legacy template means that the `subject` and `body`
 content of your message will behave differently.
 
 If you want only the message's content to be displayed, populate only the token in the template's field.


### PR DESCRIPTION
I have changed the word "transactional" to "legacy" as transactional templates means something different now. I have also created a warning, but not linked it to anything as of yet since the new dynamic templates have not been fully integrated into the documentation. Not sure if we have a way to change the URL from transactional templates to legacy templates.
