### PR TITLE
Adds documentation on text only replacement

### DIFF
--- a/source/User_Guide/Transactional_Templates/Using_handlebars.md
+++ b/source/User_Guide/Transactional_Templates/Using_handlebars.md
@@ -123,6 +123,7 @@ Substitution
 There are four main types of substitutions:
 
 - [Basic replacement](#-Basic-replacement)
+- [Text only replacement](#-Text-only-replacement)
 - [Deep object replacement](#-Deep-object-replacement)
 - [Object failure](#-Object-failure)
 - [Replacement with HTML](#-Replacement-with-HTML)
@@ -144,6 +145,27 @@ Test Data should contain:
 Resulting replacement:
 {% codeblock %}
 {% raw %}<p>Hello Ben</p>{% endraw %}
+{% endcodeblock %}
+
+{% anchor h4 %}
+Text only replacement
+{% endanchor %}
+
+This is useful for subject line replacement, as the subject line doesn't process HTML encoding (i.e. an apostrophe would encode as &apos;).
+
+Subject line should contain:
+{% codeblock %}
+{% raw %}{{{subject}}}{% endraw %}
+{% endcodeblock %}
+
+Test Data should contain:
+{% codeblock %}
+{"subject":"James' Artisanal \"Cheeses\""}
+{% endcodeblock %}
+
+Resulting subject line replacement:
+{% codeblock %}
+{% raw %}James' Artisanal "Cheeses"{% endraw %}
 {% endcodeblock %}
 
 {% anchor h4 %}


### PR DESCRIPTION
There is no documentation about the triple curly brace that doesn't encode as HTML but instead as raw text. This is necessary for transactional templates with variables in subject lines to avoid improper rendering of special characters.

**Description of the change**:
Adds in information about triple curly brace handlebars variable that renders as text instead of HTML
**Reason for the change**:
I found no reference to it elsewhere, and it is quite useful for subject line variables
**Link to original source**:
https://sendgrid.com/docs/User_Guide/Transactional_Templates/Using_handlebars.html#-Basic-replacement

Also, see Sendgrid support ticket #1601605

