### PR TITLE
Added [unsubscribe] tag placement steps

### DIFF
--- a/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
+++ b/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
@@ -39,7 +39,27 @@ To view the unsubscribe preferences page, select the action menu next to an Unsu
 
 </call-out>
 
+## Adding an Unsubscribe Group to your Email
 
+*Using the Design Editor:*
+
+1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
+1. From the **Build** section you may then drag the **Unsubscribe** module to implement Sender Information and a link to the [unsubscribe] tag.
+1. To manually hyperlink to the [unsubscribe] tag, enter the text you would like to link.
+1. Highlight the text then select the link icon from the top toolbar.
+1. In the URL field enter [unsubscribe], then Save.
+
+[Possible Image for clarity]
+
+*Using the Code Editor:*
+1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
+1. Enter the following code styling to the HTML window where you would like your unsubscribe content placed:
+
+```
+<a href="[unsubscribe]">Click here to unsubscribe.</a>
+```
+
+[Possible Image for clarity]
 
 ## Add recipients to an Unsubscribe Group
 

--- a/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
+++ b/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
@@ -43,13 +43,11 @@ To view the unsubscribe preferences page, select the action menu next to an Unsu
 
 *Using the Design Editor:*
 
-1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
-1. From the **Build** section you may then drag the **Unsubscribe** module to implement Sender Information and a link to the [unsubscribe] tag.
+1. Select your preferred Unsubscribe Group by clicking **Settings** and selecting the group from **Recipients**.
+1. From the **Build** tab, drag the **Unsubscribe** module to insert Sender Information and a link to the [unsubscribe] tag.
 1. To manually hyperlink to the [unsubscribe] tag, enter the text you would like to link.
 1. Highlight the text then select the link icon from the top toolbar.
-1. In the URL field enter [unsubscribe], then Save.
-
-[Possible Image for clarity]
+1. In the URL field enter [unsubscribe], then click **Save**.
 
 *Using the Code Editor:*
 1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
@@ -58,8 +56,6 @@ To view the unsubscribe preferences page, select the action menu next to an Unsu
 ```
 <a href="[unsubscribe]">Click here to unsubscribe.</a>
 ```
-
-[Possible Image for clarity]
 
 ## Add recipients to an Unsubscribe Group
 


### PR DESCRIPTION
Added:

## Adding an Unsubscribe Group to your Email

*Using the Design Editor:*

1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
1. From the **Build** section you may then drag the **Unsubscribe** module to implement Sender Information and a link to the [unsubscribe] tag.
1. To manually hyperlink to the [unsubscribe] tag, enter the text you would like to link.
1. Highlight the text then select the link icon from the top toolbar.
1. In the URL field enter [unsubscribe], then Save.

[Possible Image for clarity]

*Using the Code Editor:*
1. Select your preferred Unsubscribe Group from the **Settings** > **Recipients**.
1. Enter the following code styling to the HTML window where you would like your unsubscribe content placed:

```
<a href="[unsubscribe]">Click here to unsubscribe.</a>
```

[Possible Image for clarity]

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

