### PR TITLE
Clarify tag usage between transactional and MC editor

### DIFF
--- a/content/docs/ui/sending-email/editor.md
+++ b/content/docs/ui/sending-email/editor.md
@@ -169,7 +169,7 @@ Substitution tags allow you to easily generate dynamic content for each recipien
  </tr>
 </table>
 
-&ast; For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Build tab of the Design Editor.
+
 
 <call-out>
 

--- a/content/docs/ui/sending-email/editor.md
+++ b/content/docs/ui/sending-email/editor.md
@@ -439,7 +439,14 @@ You'll also see a number of System Fields that you can place in the body of your
  </tr>
 </table>
 
-&ast; For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Build tab of the Design Editor.
+&ast; For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Tags tab of the Design Editor.
+
+<call-out type="warning">
+
+The %asm_group_unsubscribe_raw_url%>, <%asm_preferences_raw_url%>, and <%asm_global_unsubscribe
+_raw_url%> tags are reserved for use in Transactional Templates and should not be used in Marketing Campaigns.
+
+</call-out>
 
 <call-out>
 


### PR DESCRIPTION
Tags ,%asm_group_unsubscribe_raw_url%>, <%asm_preferences_raw_url%>, and <%asm_global_unsubscribe<br>_raw_url%> are reserved for use in Transactional Template editor not the Code Editor specifically.

If using MC users should still use the [unsubscribe] tag in their HTML when designing their email, this tag is not included in the tags section so customers will need to be guided on using `<a href="[unsubscribe]">Click here to unsubscribe.</a>` format.

The other tags can be used for Transactional Templates as they will pull from an asm group ID specified in the API call for that transactional template.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

