### PR TITLE
updated header X-Message-Id to be case sensitive

### DIFF
--- a/content/docs/glossary/x-message-id.md
+++ b/content/docs/glossary/x-message-id.md
@@ -1,8 +1,8 @@
 ---
 seo:
-  title: X-Message-ID
-  description: The X-Message-ID is a header returned when making a mail send.
-  keywords: X-Message-ID, Track
+  title: X-Message-Id
+  description: The X-Message-Id is a header returned when making a mail send.
+  keywords: X-Message-Id, Track
 title: X-Message-ID
 weight: 0
 layout: page
@@ -14,9 +14,9 @@ The following image depicts a response after the mail is sent.
 
 ![]({{root_url}}/images/example_response.png "Example Response")
 
-The X-Message-ID is a header returned when making a mail send which can be used to track events that the Event Webhook posts.
+The X-Message-Id is a header returned when making a mail send which can be used to track events that the Event Webhook posts.
 
-When using the Event Webhook, it's best practice to store your X-Message-ID. X-Message-ID data helps with deduplications in your webhook data. It can be used to find all corresponding Message-IDs.
+When using the Event Webhook, it's best practice to store your X-Message-Id. X-Message-Id data helps with deduplications in your webhook data. It can be used to find all corresponding Message-Ids.
 
 SendGrid recommends that users store this data to correlate to their Event Webhook data, and this data is very useful for Support troubleshooting.
 


### PR DESCRIPTION
**Description of the change**:
updated header X-Message-Id param in description to show that X-Message-Id is actually with Id and not ID, as it was originally written in this page.

**Reason for the change**:
the param returned is _X-Message-Id_ AND NOT _X-Message-ID_

**Link to original source**:
https://github.com/sendgrid/docs/blob/rc-develop/content/docs/glossary/x-message-id.md
