### PR TITLE
Update getting-started-smtp.md

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-smtp.md
+++ b/content/docs/for-developers/sending-email/getting-started-smtp.md
@@ -64,7 +64,7 @@ Telnet does not register backspaces correctly - so you have to type your command
     <br>The mail server returns `250 Ok: queued as …` - This means the email has been queued to send. This queue moves very quickly.
 1. Exit the Telnet connection with: `quit`.
 
-Now that you've sent a test email, learn to [integrate your servers with our SMTP API]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/).
+Now that you've sent a test email, learn to [integrate your servers with our SMTP service]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/).
 
 <call-out>
 


### PR DESCRIPTION
Changed SMTP API to SMTP service in link as it links to a page that explains how to integrate with SMTP through telnet and not how to integrate with SMTP API. The wording of this link makes sense for the page it directs to.