### PR TITLE
Fixed typo in whitelabel.md.

### DIFF
--- a/source/API_Reference/Web_API/Reseller_API/whitelabel.md
+++ b/source/API_Reference/Web_API/Reseller_API/whitelabel.md
@@ -16,7 +16,7 @@ List
 
 
 {% parameters get %}
- {% parameter 'list' 'Yes' 'Must be set to <em>list</em>' %}
+ {% parameter 'task' 'Yes' 'Must be set to <em>list</em>' %}
  {% parameter 'method' 'Yes' 'Must be set to <em>whitelabel</em>' %}
 {% endparameters %}
 


### PR DESCRIPTION
**Description of the Change**: For this endpoint, the URI parameter should be _task_ (not _list_).
**Reason for the Change**: Typo
**Link to Original Source**: https://sendgrid.com/docs/API_Reference/Web_API/Reseller_API/whitelabel.html
