### PR TITLE
Fix table header in Event Webhook Reference page

### DIFF
--- a/source/API_Reference/Event_Webhook/event.md
+++ b/source/API_Reference/Event_Webhook/event.md
@@ -439,7 +439,7 @@ Event objects
     <th><a href="#spamreport">Spam Report</a></th>
     <th><a href="#unsubscribe">Unsubscribe</a></th>
     <th><a href="#groupunsubscribe">Group Unsubscribe</a></th>
-    <th><a href="#groupresubscribe"Group Resubscribe</a></th>
+    <th><a href="#groupresubscribe">Group Resubscribe</a></th>
   </tr>
   <tr>
     <td><a href="#email">email</a></td>


### PR DESCRIPTION
**Description of the change**:
Fixes the html opening tag of anchor link in the table header.

**Reason for the change**:
Text is missing.

**Link to original source**:
https://sendgrid.com/docs/API_Reference/Event_Webhook/event.html#-Event-objects

<!-- 
If this pull request closes an issue, add in the issue number here 
-->

