### PR TITLE
Broken image links fixed in first-timers.md

### DIFF
--- a/first-timers.md
+++ b/first-timers.md
@@ -7,17 +7,17 @@ To make changes to any page on http://sendgrid.com/docs, follow these steps:
 
 1. Navigate to the page you would like to edit and click **View and Edit** in the upper right-hand corner.
 
-<img src="https://github.com/Whatthefoxsays/docs/blob/github-cheatsheet/source/img/docs_view_and_edit.png" width="800" height="500">
+<img src="https://github.com/sendgrid/docs/blob/develop/source/img/docs_view_and_edit.png" width="800" height="500">
 
 This will take you to the sendgrid.com/docs GitHub repository, or repo. This is where our docs pages are stored.
 
 2. If you do not already have a GitHub account, you will have to create one in order to suggest a change. Click the Sign up link in the upper right-hand corner to create an account. Enter your username, password, and email address. If you are an employee of SendGrid, please use your full name with your GitHub account and enter SendGrid as your company so we can easily identify you.  
 
-<img src="https://github.com/Whatthefoxsays/docs/blob/github-cheatsheet/source/img/docs_signup.png" width="800" height="500">
+<img src="https://github.com/sendgrid/docs/blob/develop/source/img/docs_signup.png" width="800" height="500">
 
 Once you are viewing a Docs page in GitHub, click the pencil icon to begin editing:
 
-<img src="https://github.com/Whatthefoxsays/docs/blob/github-cheatsheet/source/img/docs_edit_github.png" width="800" height="500">
+<img src="https://github.com/sendgrid/docs/blob/develop/source/img/docs_edit_github.png" width="800" height="500">
 
 
 3. Once you have made your changes, you will be given the option of creating a new branch in a Pull Request. This is a request to create a copy, or branch, of the original Docs but with your changes. Once your changes are approved, your branch will then be merged back into the original. 


### PR DESCRIPTION
**Description of the change**: Fix broken image urls in first-timers.md
**Reason for the change**: Image links were broken
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/first-timers.md

Closes #3942 

