### PR TITLE
fix typo errors in C# code example

### DIFF
--- a/content/docs/for-developers/sending-email/v2-csharp-code-example.md
+++ b/content/docs/for-developers/sending-email/v2-csharp-code-example.md
@@ -27,9 +27,9 @@ using System.Net.Mail;
 
 var myMessage = new SendGrid.SendGridMessage();
 myMessage.AddTo("test@sendgrid.com");
-myMessage.From = new MailAddress("you@youremail.com", "First Last");
+myMessage.From = new EmailAddress("you@youremail.com", "First Last");
 myMessage.Subject = "Sending with SendGrid is Fun";
-myMessage.Text = "and easy to do anywhere, even with C#";
+myMessage.PlainTextContent= "and easy to do anywhere, even with C#";
 
 var transportWeb = new SendGrid.Web("SENDGRID_APIKEY");
 transportWeb.DeliverAsync(myMessage);


### PR DESCRIPTION
**Description of the change**: Fix some typo errors in C# example
**Reason for the change**:  Wrong code example
**Link to original source**: https://sendgrid.com/docs/Integrate/Code_Examples/v2_Mail/csharp.html

Closes #3831

