### PR TITLE
add info about godaddy to domain auth docs page

### DIFF
--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2013-2018 SendGrid Inc.
+Copyright © 2013-2017 SendGrid Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Description of the change**: Added info about how to configure DNS for GoDaddy
**Reason for the change**: This is to ensure that there is no ambigutiy while configuring the settings. Also, this would help people if the validation fails.

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3830 

