### PR TITLE
fixing broken link in dynamic templates

### DIFF
--- a/content/docs/ui/sending-email/create-and-edit-transactional-templates.md
+++ b/content/docs/ui/sending-email/create-and-edit-transactional-templates.md
@@ -111,6 +111,6 @@ For more information about unsubscribes, check out our [unsubscribe documentatio
 
 ## Additional Resources
 
-- [Dynamic Templates]({{root_url}}/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-teplates/)
+- [Dynamic Templates]({{root_url}}/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/)
 - [Using Handlebars]({{root_url}}/ui/sending-email/using-handlebars/)
 - [Design & Code Editor]({{root_url}}/ui/sending-email/editor/)


### PR DESCRIPTION
**Description of the change**: fixes a spelling mistake in a url `teplates` -> `templates`, fixes 404
**Reason for the change**: previous url was pointing to a 404
**Link to original source**: https://sendgrid.com/docs/ui/sending-email/create-and-edit-transactional-templates/

Closes #3963 

