### PR TITLE
Noted out of date video and added new instructions

### DIFF
--- a/source/User_Guide/Settings/Sender_authentication/providers.md
+++ b/source/User_Guide/Settings/Sender_authentication/providers.md
@@ -15,8 +15,7 @@ navigation:
 
 #Whitelabeling with GoDaddy
 <p><iframe src="https://player.vimeo.com/video/149805633" width="700" height="400" frameborder="0" allowfullscreen=""></iframe></p>
-
+<p>Please note that the video is slightly out of date. DoDaddy no longer requires you to enter the whole address for the CNAME, just the subdomain is enough.<p>
 
 #Whitelabeling with Hover
 <p><iframe src="https://player.vimeo.com/video/158954155" width="700" height="400" frameborder="0" allowfullscreen=""></iframe></p>
-


### PR DESCRIPTION
**Description of the change** Add a note that GoDaddy no longer require users to enter the whole address for the CNAME, just the subdomain
**Reason for the change**: GoDaddy video out of date
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/dns-providers/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3944 

