### PR TITLE
Add type field for Event Webhook documenation

### DIFF
--- a/source/API_Reference/Event_Webhook/event.md
+++ b/source/API_Reference/Event_Webhook/event.md
@@ -721,6 +721,21 @@ Event objects
     <td></td>
     <td></td>
   </tr>
+  </tr>
+    <tr>
+    <td><a href="#type">type</a></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
 </table>
 
 {% anchor h3 %}
@@ -742,7 +757,7 @@ JSON objects
 - <a name="url"></a>`url` - the URL where the event originates. For click events, this is the URL clicked on by the recipient.
 - <a name="attempt"></a>`attempt` - the number of times SendGrid has attempted to deliver this message.
 - <a name="category"></a>`category` - [Categories]({{root_url}}/Glossary/categories.html) are custom tags that you set for the purpose of organizing your emails. If you send single categories as an array, they will be returned by the webhook as an array. If you send single categories as a string, they will be returned by the webhook as a string.
-
+- <a name="type"></a>`type` - type of bounce [Bounce]({{root_url}}/Glossary/bounces.html)/[Blocked]({{root_url}}/Glossary/blocks.html)/[Expired]({{root_url}}/Glossary/expired.html)
 String categories:
 
 {% codeblock lang:json %}

--- a/source/API_Reference/Event_Webhook/event.md
+++ b/source/API_Reference/Event_Webhook/event.md
@@ -758,6 +758,7 @@ JSON objects
 - <a name="attempt"></a>`attempt` - the number of times SendGrid has attempted to deliver this message.
 - <a name="category"></a>`category` - [Categories]({{root_url}}/Glossary/categories.html) are custom tags that you set for the purpose of organizing your emails. If you send single categories as an array, they will be returned by the webhook as an array. If you send single categories as a string, they will be returned by the webhook as a string.
 - <a name="type"></a>`type` - type of bounce [Bounce]({{root_url}}/Glossary/bounces.html)/[Blocked]({{root_url}}/Glossary/blocks.html)/[Expired]({{root_url}}/Glossary/expired.html)
+
 String categories:
 
 {% codeblock lang:json %}


### PR DESCRIPTION
**Description of the change**: Add type field for Event Webhook documentation
**Reason for the change**: Missing documentation for type field. Close open issue
**Link to original source**: 
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3675

