### PR TITLE
Laravel example is not working correctly #3559

### DIFF
--- a/source/Integrate/Frameworks/laravel.md
+++ b/source/Integrate/Frameworks/laravel.md
@@ -82,7 +82,7 @@ class TestEmail extends Mailable
                     ->bcc($address, $name)
                     ->replyTo($address, $name)
                     ->subject($subject)
-                    ->with([ 'message' => $this->data['message'] ]);
+                    ->with([ 'content' => $this->data['message'] ]);
     }
 }
 {% endcodeblock %}
@@ -97,7 +97,7 @@ In Laravel `Views` are used as 'templates' when sending an email. Let's create a
     	</head>
     	<body>
     		<h2>Test Email</h2>
-    		<p>{{ $message }}</p>
+		<p>{{ $content }}</p>
     	</body>
     </html>
 {% endcodeblock %}


### PR DESCRIPTION
**Issue Reported:**

You cannot use the key **message** along with method

**Description of the change**:
Rename the variable to use it along “with” method

**Reason for the change**:

To send a new message using the view, Laravel uses this method  **Illuminate\Mail\Mailer:: send**

The message is being created and assigned to an array with key **message**. If we use the same variable to assign data to the template, then this get replaced with an instance of **Illuminate\Mail\Message** and rendering the template will cause an error as an object is received in the view


**Link to original source**:
<!-- 
#3559 
-->
Closes #