### PR TITLE
BUGFIX: Update README to remove brew tap homebrew/versions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,11 +178,9 @@ to install client-side dependencies.
 
 	`$ bundle install`
 
-	* If the gem installation fails with a message like "An error occurred while installing libv8 (3.16.14.7), and Bundler cannot continue", a few extra steps will be necessary in order to build and install a version of V8 that can be used by the libv8 and therubyracer gems:
+	* If the gem installation fails with a message like `"An error occurred while installing libv8 (3.16.14.7), and Bundler cannot continue"`, a few extra steps will be necessary in order to build and install a version of V8 that can be used by the libv8 and therubyracer gems:
 
 		`$ gem uninstall libv8`
-	
-		`$ brew tap homebrew/versions`
 	
 		`$ brew install --force v8-315`
 	


### PR DESCRIPTION
**Description of the change**:
README Update:

Since the `homebrew/versions` tap is deprecated and migrated into `homebrew/core`, the step can be skipped.

```
$ brew tap homebrew/versions
```

The PR removes this step from the README [Setup Steps](https://github.com/sendgrid/docs#setup-steps)

**Reason for the change**:
`homebrew/versions` tap is deprecated and migrated into `homebrew/core`

**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3984

