### PR TITLE
Add CakePHP Plugin under PHP libraries

### DIFF
--- a/source/Integrate/libraries.md
+++ b/source/Integrate/libraries.md
@@ -158,6 +158,7 @@ PHP
 -   [sendgrid-component](http://github.com/damusnet/sendgrid-component) *by Damien Varron* - CakePHP component that extends the base email component with SendGrid functionality
 -   [sendgrid-subuser-api](https://github.com/eliksir/sendgrid-subuser-api) *by Eliksir* - Library that makes it easy to work with the SendGrid Subuser API
 -   [sendgrid-webapi-v3-php](https://github.com/idimensionz/sendgrid-webapi-v3-php) *by iDimensionz* - A complete implementation of the V3 WebAPI in PHP. Very structured, OO implementation with excellent test coverage. A repo containing examples showing how simple it is to utilize our implementation is available at [example](https://github.com/idimensionz/sendgrid-webapi-v3-examples).
+-   [cakephp-sendgrid](https://github.com/sprintcube/cakephp-sendgrid) *by SprintCube* - This plugin provides email delivery using SendGrid API in CakePHP applications.
 -   [laravel-sendgrid-driver](https://github.com/s-ichikawa/laravel-sendgrid-driver) *by Shingo Ichikawa* - This liblary can add sendgrid driver into the laravel's mail configure.
 -   [godpod/sendgrid](https://packagist.org/packages/godpod/sendgrid) *by Ravi Rajendra* - This library allows you to quickly and easily send emails or make api calls through SendGrid using PHP.
 -   [fastglass/sendgrid](https://github.com/taz77) *by taz77* - This library allows you to send emails through SendGrid using PHP and Guzzle 6.x.


### PR DESCRIPTION
**Description of the change**: Add a new PHP library (CakePHP Plugin)
**Reason for the change**: It was missing in the list.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

