### PR TITLE
Adding space after comma for consistency

### DIFF
--- a/content/docs/for-developers/sending-email/api-getting-started.md
+++ b/content/docs/for-developers/sending-email/api-getting-started.md
@@ -74,7 +74,7 @@ If you have not yet set up [Sender Authentication]({{root_url}}/ui/account-and-s
 
  ### 	API Response messages
 
-All responses are returned in JSON format. We specify this by sending the ``Content-Type`` header. The Web API v3 provides a selection of [response codes](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#status-codes),[content-type headers](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#content-type-header), and [pagination](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#pagination) options to help you interpret the responses to your API requests.
+All responses are returned in JSON format. We specify this by sending the ``Content-Type`` header. The Web API v3 provides a selection of [response codes](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#status-codes), [content-type headers](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#content-type-header), and [pagination](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-responses#pagination) options to help you interpret the responses to your API requests.
 
 ## 	Next Steps
 


### PR DESCRIPTION
**Description of the change**:
Adding a space after a list of comma separated items. 
**Reason for the change**:
Keep consistency with the rest of the docs
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

