### PR TITLE
Fix uneven padding in Feedback Cards and Tip Callouts

### DIFF
--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -8,6 +8,23 @@
   border-radius: $border-radius;
   box-shadow: 8px 10px 0 0 rgba($sg-blue, 0.1);
 
+  h2,
+  p,
+  .card-icon {
+    flex-basis: 100%;
+  }
+
+  // bump icon font-size if placed inline w/ title
+  h2 .sg-icon {
+    margin-right: 6px;
+    font-size: 27px;
+    vertical-align: text-bottom;
+  }
+
+  p {
+    margin-bottom: 20px;
+  }
+
   &__inner {
     flex: 1 1 auto;
   }
@@ -120,23 +137,6 @@
       font-size: 20px;
       color: $slate-60;
     }
-  }
-
-  h2,
-  p,
-  .card-icon {
-    flex-basis: 100%;
-  }
-
-  // bump icon font-size if placed inline w/ title
-  h2 .sg-icon {
-    margin-right: 6px;
-    font-size: 27px;
-    vertical-align: text-bottom;
-  }
-
-  p {
-    margin-bottom: 20px;
   }
 
   .card-icon {

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -118,15 +118,12 @@ aside a.active {
 
 // custom Markdown components
 .callout {
-  padding: $scaleup-4;
+  padding: $scaleup-3 $scaleup-4;
   margin: $scaleup-4 0;
   position: relative;
 
   &::before {
     display: block;
-    position: absolute;
-    top: $scaleup-1;
-    left: $scaleup-4;
     text-transform: uppercase;
     @include colfax(600);
     font-size: $scaledown-1;
@@ -134,8 +131,12 @@ aside a.active {
   }
 }
 
-.callout > p {
+.callout p {
   margin: $scaledown-3 0;
+}
+
+.callout p:last-child {
+  margin-bottom: 0;
 }
 
 .callout--info {


### PR DESCRIPTION
**Description of the change**: Fixes uneven top/bottom padding in the Feedback Cards and the Tip Callouts
**Reason for the change**: The top and bottom padding were mismatched because of absolute positioning and margins on text elements within the cards and callouts
**Link to original source**: Any page that leverages these components

