### PR TITLE
Fix some line height issues with headlines and card links

### DIFF
--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -150,6 +150,10 @@
     line-height: 30px;
   }
 
+  .card__link {
+    line-height: 20px;
+  }
+
   .badge {
     position: absolute;
     top: 27px;

--- a/src/scss/global/_typography.scss
+++ b/src/scss/global/_typography.scss
@@ -72,7 +72,7 @@ h2,
 .is-size-h2 {
   margin-bottom: 18px;
   font-size: 25px;
-  line-height: 25px;
+  line-height: 30px;
   letter-spacing: -0.5px;
 }
 
@@ -80,7 +80,7 @@ h3,
 .is-size-h3 {
   margin-bottom: 12px;
   font-size: 18px;
-  line-height: 18px;
+  line-height: 25px;
 }
 
 h4,


### PR DESCRIPTION
**Description of the change**: Adjust the line height for some headlines and card links
**Reason for the change**: Some of the headline text and links had a line height that matched their font size, so the line height looked a little tight
**Link to original source**: Global change