### PR TITLE
Update "account settings" link

### DIFF
--- a/content/docs/ui/sending-email/senders.md
+++ b/content/docs/ui/sending-email/senders.md
@@ -14,7 +14,7 @@ seo:
 
 ## 	Before you Begin
 
-Before you begin, go to your SendGrid [account settings](https://app.sendgrid.com/user/account) to verify that your timezone and account email address are correct. Verifying your account information ensures that when you upload contacts, you receive notifications and that we deliver scheduled emails at the correct time.
+Before you begin, go to your SendGrid [account settings](https://app.sendgrid.com/settings/account) to verify that your timezone and account email address are correct. Verifying your account information ensures that when you upload contacts, you receive notifications and that we deliver scheduled emails at the correct time.
 
 ## 	Adding a Sender
 


### PR DESCRIPTION
**Description of the change**: Change "account settings" link on sender identity page
**Reason for the change**: Current link takes you to a broken page "We couldn't find the page you requested."
**Link to original source**: https://sendgrid.com/docs/ui/sending-email/senders/
![sendgrid](https://user-images.githubusercontent.com/30353804/46371447-9f275c00-c645-11e8-9fd8-5e2e4bfb3d35.png)


