### PR TITLE
Fix erroneous adustment to HTML substitution section

### DIFF
--- a/content/docs/ui/sending-email/using-handlebars.md
+++ b/content/docs/ui/sending-email/using-handlebars.md
@@ -175,8 +175,9 @@ If you include the characters `'`, `"` or `&` in a subject line replacement be s
 
 HTML should contain:
 ```
-<p>Hello {{firstName}}</p>
+<p>Hello {{{firstName}}}</p>
 ```
+> Per Handlebars' documentation: If you don't want Handlebars to escape a value, use the "triple-stash", {{{
 
 Test Data should contain:
 ```


### PR DESCRIPTION
Call out the reason for the "triple-stash" in HTML substitution

**Description of the change**:
Call out the reason for the "triple-stash" in HTML substitution

**Reason for the change**:
My previous fix was wrong and so updating the text surrounding it to explain why the "triple-stash"

**Link to original source**:
https://sendgrid.com/docs/ui/sending-email/using-handlebars/#replacement-with-html
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

