### PR TITLE
Fix request headers type in an example

### DIFF
--- a/source/API_Reference/api_getting_started.md
+++ b/source/API_Reference/api_getting_started.md
@@ -57,8 +57,8 @@ _To Send an email using the SendGrid API:_
 {% codeblock %}
 curl --request POST \
 --url https://api.sendgrid.com/v3/mail/send \
---header 'authorization: Bearer <<YOUR_API_KEY>>' \
---header 'content-type: application/json' \
+--header 'Authorization: Bearer <<YOUR_API_KEY>>' \
+--header 'Content-Type: application/json' \
 --data '{"personalizations":[{"to":[{"email":"john.doe@example.com","name":"John Doe"}],"subject":"Hello, World!"}],"from":{"email":"sam.smith@example.com","name":"Sam Smith"},"reply_to":{"email":"sam.smith@example.com","name":"Sam Smith"}}'{% endcodeblock %}
 
 1. Copy the curl example above.


### PR DESCRIPTION


**Description of the change**:
Fix request headers type in an example
**Reason for the change**:
Request headers should be capitalized
https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#General_format


