### PR TITLE
Account Settings: Add Page - 'Verifying Your Account'

### DIFF
--- a/content/docs/ui/account-and-settings/verifying-your-account.md
+++ b/content/docs/ui/account-and-settings/verifying-your-account.md
@@ -11,58 +11,43 @@ navigation:
   show: true
 ---
 
-When you sign up for a SendGrid account, there are a few steps that our users must complete before they can start using their accounts fully.
+When you sign up for a SendGrid account, there are a few steps that our users must complete before they can start using their accounts fully. Even in a pre-verified state, you can send up to 100 emails per day with your SendGrid account. Once you complete the steps presented, your credit usage limits will be unlocked
 
 You will have either one, two, or three seperate steps to complete before you fully unlock the credit limits available to your chosen plan level. We require these steps for your security, as well as to help you get started more quickly!
 
-### How long does the verification process take?
+<call-out>
+
+ If you chose a paid plan during the initial signup form, your credit card is charged and your trial period begins right away. Complete the verification steps presented to you to unlock the full abilities of your paid account.
+
+</call-out>
+
+## Verifying your Account
 
 The time it takes to completely unlock your account can vary based on the number of steps you are required to complete. The faster you complete the steps, the faster you can start sending!
 
-### What steps are required?
+*To verify your account:*
 
-You will either have to verify your email address, set up two-factor authentication, and/or create a domain whitelabel. You may need to complete one or more of these steps to completely verify your account.
+Complete one or more of the following:
 
-### Can I send email right away?
+* Verify your email address
+* Set up [two-factor authentication]({{root_url}}/ui/account-and-settings/two-factor-authentication/#setting-up-two-factor-authentication)
+* Set up [domain authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/)
 
-Yes, you can send up to 100 emails per day even when your account is in a pre-verified state.
+You may need to complete one or more of these steps to completely verify your account. You cannot skip any of the verification steps, or your account won't be completely unlocked. 
 
-### Can I skip a verification step?
 
-Unfortunately you cannot skip a verification step, we require our users to complete the verification steps before their accounts are completely unlocked.
+### Resend the verification email
 
-### Why do I only have 100 credits a day?
+You can resend the verification to the email address you specified during the initial signup form by heading to the [verification guide](https://app.sendgrid.com/guide) and clicking "Resend in the "Confirm your Email Address" step. If you entered your email address incorrectly in the initial signup form, you can correct the email address and resend the verification email to the correct address.
 
-You have either not yet completed the verification steps for your account, or your 30 day trial period has expired. Either complete the verification steps, or [upgrade your account](https://app.sendgrid.com/settings/billing) to send more email.
+## Setting up Two-factor Authentication
 
-### Why don't I have all the credits available on my paid plan?
+Two-factor authenticaiton allows you to make your SendGrid account more secure by requiring authentication beyond a simple username and password when logging in. Learn more about setting up and using [two-factor authentication]({{root_url}}/ui/account-and-settings/two-factor-authentication/#setting-up-two-factor-authentication).
 
-Until you complete the required verification steps, you will only be able to send up to 100 emails per day. Once you complete the steps presented, your credit usage limits will be unlocked
+## Setting up Domain Authentication
 
-### How do I resend the verification email?
+Domain authentication, formally known as domain whitelabel, shows email providers that SendGrid has your permission to send emails on your behalf. For more information, see see [How to set up domain authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/).
 
-You can resend the verification to the email address you specified during the initial signup form by heading to the [verification guide](https://app.sendgrid.com/guide) and clicking "Resend in the "Confirm your Email Address" step.
+## Upgrading your account
 
-### What if I entered my email address incorrectly?
-
-If you entered your email address incorrectly in the initial signup form, you can correct the email address and resend the verification email to the correct address.
-
-### How do I set up two factor authentication?
-
-Learn more about setting up and using [two factor authentication]({{root_url}}/glossary/two-factor-authentication/).
-
-### How do I set up the domain whitelabel?
-
-A domain whitelabel is now called [domain authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/).
-
-### Was my credit card charged even though I only have 100 credits per day?
-
-Yes. If you chose a paid plan during the initial signup form, your credit card is charged and your trial period begins right away. Complete the verification steps presented to you to unlock the full abilities of your paid account.
-
-### When does the trial period begin?
-
-Your 30 day trial starts as soon as you complete the initial sign up form. Not when you complete the final verification step.
-
-### What happens after my 30 day free trial?
-
-After your 30 day trial period expires you will maintain the same level of account functionality, and your settings will remain intact. However, you will only be able to send up to 100 emails per day from that point onwards, unless you choose to [upgrade your account](https://app.sendgrid.com/settings/billing).
+Your 30 day trial starts as soon as you complete the initial sign up form, not when you complete the final verification step. After your 30 day trial period expires you will maintain the same level of account functionality, and your settings will remain intact. However, you will only be able to send up to 100 emails per day from that point onwards, unless you choose to [upgrade your account](https://app.sendgrid.com/settings/billing).

--- a/content/docs/ui/account-and-settings/verifying-your-account.md
+++ b/content/docs/ui/account-and-settings/verifying-your-account.md
@@ -1,0 +1,68 @@
+---
+layout: page
+weight: 0
+group: account-management
+title: Verifying your Account
+seo:
+  title: Verifying your Account
+  description: Signed up with SendGrid? Learn more about the steps to complete first...
+  keywords: sign, up, signup, account, verification, 2fa, mfa, two, factor, authentication, auth, getting, started, paid, credits, unlock, verify, 100
+navigation:
+  show: true
+---
+
+When you sign up for a SendGrid account, there are a few steps that our users must complete before they can start using their accounts fully.
+
+You will have either one, two, or three seperate steps to complete before you fully unlock the credit limits available to your chosen plan level. We require these steps for your security, as well as to help you get started more quickly!
+
+### How long does the verification process take?
+
+The time it takes to completely unlock your account can vary based on the number of steps you are required to complete. The faster you complete the steps, the faster you can start sending!
+
+### What steps are required?
+
+You will either have to verify your email address, set up two-factor authentication, and/or create a domain whitelabel. You may need to complete one or more of these steps to completely verify your account.
+
+### Can I send email right away?
+
+Yes, you can send up to 100 emails per day even when your account is in a pre-verified state.
+
+### Can I skip a verification step?
+
+Unfortunately you cannot skip a verification step, we require our users to complete the verification steps before their accounts are completely unlocked.
+
+### Why do I only have 100 credits a day?
+
+You have either not yet completed the verification steps for your account, or your 30 day trial period has expired. Either complete the verification steps, or [upgrade your account](https://app.sendgrid.com/settings/billing) to send more email.
+
+### Why don't I have all the credits available on my paid plan?
+
+Until you complete the required verification steps, you will only be able to send up to 100 emails per day. Once you complete the steps presented, your credit usage limits will be unlocked
+
+### How do I resend the verification email?
+
+You can resend the verification to the email address you specified during the initial signup form by heading to the [verification guide](https://app.sendgrid.com/guide) and clicking "Resend in the "Confirm your Email Address" step.
+
+### What if I entered my email address incorrectly?
+
+If you entered your email address incorrectly in the initial signup form, you can correct the email address and resend the verification email to the correct address.
+
+### How do I set up two factor authentication?
+
+Learn more about setting up and using [two factor authentication]({{root_url}}/glossary/two-factor-authentication/).
+
+### How do I set up the domain whitelabel?
+
+A domain whitelabel is now called [domain authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/).
+
+### Was my credit card charged even though I only have 100 credits per day?
+
+Yes. If you chose a paid plan during the initial signup form, your credit card is charged and your trial period begins right away. Complete the verification steps presented to you to unlock the full abilities of your paid account.
+
+### When does the trial period begin?
+
+Your 30 day trial starts as soon as you complete the initial sign up form. Not when you complete the final verification step.
+
+### What happens after my 30 day free trial?
+
+After your 30 day trial period expires you will maintain the same level of account functionality, and your settings will remain intact. However, you will only be able to send up to 100 emails per day from that point onwards, unless you choose to [upgrade your account](https://app.sendgrid.com/settings/billing).

--- a/content/docs/ui/account-and-settings/verifying-your-account.md
+++ b/content/docs/ui/account-and-settings/verifying-your-account.md
@@ -35,7 +35,6 @@ Complete one or more of the following:
 
 You may need to complete one or more of these steps to completely verify your account. You cannot skip any of the verification steps, or your account won't be completely unlocked. 
 
-
 ### Resend the verification email
 
 You can resend the verification to the email address you specified during the initial signup form by heading to the [verification guide](https://app.sendgrid.com/guide) and clicking "Resend in the "Confirm your Email Address" step. If you entered your email address incorrectly in the initial signup form, you can correct the email address and resend the verification email to the correct address.


### PR DESCRIPTION
**Description of the change**:
Add Page: Verifying your Account

Navigation will be under: Home > Account And Settings > Verifying Your Account

**Reason for the change**:
Transferring content from FAQ: account_sign_up_faq 

https://github.com/sendgrid/docs/blob/Whatthefoxsays-patch-15/source/Classroom/Basics/Account/account_sign_up_faq.md

**Minor Update:**
I also saw that **domain whitelabel** is now called **domain authentication**, and linked to the corresponding domain authentication page:
http://localhost:8000/ui/account-and-settings/how-to-set-up-domain-authentication/


**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3999 

