### PR TITLE
Updated for TLS 1.1 or higher

### DIFF
--- a/content/docs/ui/sending-email/tls.md
+++ b/content/docs/ui/sending-email/tls.md
@@ -12,6 +12,6 @@ navigation:
   show: true
 ---
 
-By default, our system is designed to opportunistically try outbound TLS v.1.1 when attempting to deliver email. This means that if your recipient's email server accepts an inbound TLS v.1.1 connection, we will deliver the email over a TLS encrypted connection. If the server does not support TLS, we will deliver the message over the default unencrypted connection.
+By default, our system is designed to opportunistically try outbound TLS v1.1 or higher when attempting to deliver email. This means that if your recipient's email server accepts an inbound TLS v1.1 or higher connection, we will deliver the email over a TLS encrypted connection. If the server does not support TLS, we will deliver the message over the default unencrypted connection.
 
-We also offer the ability to _enforce TLS encryption_ when we attempt to deliver email to your recipients. The [Enforced TLS feature]({{root_url}}/API_Reference/Web_API_v3/Settings/enforced_tls.html) specifies whether or not the recipient is required to support TLS v.1.1 or higher or have a valid certificate before we deliver an email to them.
+We also offer the ability to _enforce TLS encryption_ when we attempt to deliver email to your recipients. The [Enforced TLS feature]({{root_url}}/API_Reference/Web_API_v3/Settings/enforced_tls.html) specifies whether or not the recipient is required to support TLS v1.1 or higher or have a valid certificate before we deliver an email to them.


### PR DESCRIPTION
Changed content to mention TLS v1.1 or higher (not just v1.1) to stay in line with other docs. Also removed confusing extra dot from versions, e.g. v1.1 instead of v.1.1 (which could mean 0.1.1).