### PR TITLE
Formatting change for the quoted RFC text

### DIFF
--- a/content/docs/ui/sending-email/email-to-sms.md
+++ b/content/docs/ui/sending-email/email-to-sms.md
@@ -14,20 +14,9 @@ navigation:
 
 SendGrid occasionally gets the question "Why isn't my email to SMS working?"
 
-Basically, SMTP-to-SMS gateways have narrow bandwidth, due to the need for mobile carriers to predict network traffic, as well as a way to prevent spam to their users. Furthermore, mobile carriers are not incentivized to successfully deliver SMTP-to-SMS messages, since they often provide this as a free service. Senders will see deferrals and blocks if they attempt to send high volumes without reaching a payment agreement with mobile carriers ahead of time. 
+Basically, SMTP-to-SMS gateways have narrow bandwidth, due to the need for mobile carriers to predict network traffic, as well as a way to prevent spam to their users. Furthermore, mobile carriers are not incentivized to successfully deliver SMTP-to-SMS messages, since they often provide this as a free service. Senders will see deferrals and blocks if they attempt to send high volumes without reaching a payment agreement with mobile carriers ahead of time.
 
 Here’s a relevant comment about SMS from [RFC 5724](http://www.ietf.org/rfc/rfc5724.txt):  
- > SMS messages very often are delivered almost instantaneously (if the  
-  receiving SMS client is online), but there is no guarantee for when  
-  SMS messages will be delivered. In particular, SMS messages between  
-  different network operators sometimes take a long time to be  
-  delivered (hours or even days) or are not delivered at all, so  
-  applications SHOULD NOT make any assumptions about the reliability  
-  and performance of SMS message transmission.
-  >
+ > "SMS messages very often are delivered almost instantaneously (if the receiving SMS client is online), but there is no guarantee for when SMS messages will be delivered. In particular, SMS messages between different network operators sometimes take a long time to be delivered (hours or even days) or are not delivered at all, so applications SHOULD NOT make any assumptions about the reliability and performance of SMS message transmission."
 
-Essentially, email to SMS may work for occasional messages at low volume, and even then it can be a gamble.  
-
-
- 
-
+Essentially, email to SMS may work for occasional messages at low volume, and even then it can be a gamble.


### PR DESCRIPTION
Minor formatting change for the quoted RFC text to improve readability. Styling on the SendGrid website doesn't indent blockquote tags, so I also added the quotation marks.