### PR TITLE
Unify subuser spelling

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -52,9 +52,9 @@ Sender authentication shows email providers that SendGrid has your permission to
 
 ### Adding Subusers
 
-You can only add Subusers if you are on an AWS Pro plan. To upgrade your plan, see [Upgrading or Downgrading Your Account](#upgrading-or-downgrading-your-account). Subusers are SendGrid accounts that belong to a parent account. They have their permissions and credit limits, which you assign as you create the subusers. Subusers help you segment your email sending and API activity.
+You can only add subusers if you are on an AWS Pro plan. To upgrade your plan, see [Upgrading or Downgrading Your Account](#upgrading-or-downgrading-your-account). Subusers are SendGrid accounts that belong to a parent account. They have their permissions and credit limits, which you assign as you create the subusers. Subusers help you segment your email sending and API activity.
 
-To get started with using Subusers, see the [Subusers overview]({{root_url}}/ui/account-and-settings/subusers/).
+To get started with using subusers, see the [Subusers overview]({{root_url}}/ui/account-and-settings/subusers/).
 
 ### Upgrading or Downgrading Your Account
 

--- a/content/docs/ui/account-and-settings/account-under-review.md
+++ b/content/docs/ui/account-and-settings/account-under-review.md
@@ -19,7 +19,7 @@ Once your account is under review, SendGrid sends a notification to the address 
 
  ### 	Warned
  	
-The account maintains full sending functionality during a warning period. However, if we do not receive a response, your account may be suspended to prevent further risk to your sending reputation. Accounts with a warned status can still upgrade their usage plan, or create new sub-users until the review has concluded to our satisfaction.
+The account maintains full sending functionality during a warning period. However, if we do not receive a response, your account may be suspended to prevent further risk to your sending reputation. Accounts with a warned status can still upgrade their usage plan, or create new subusers until the review has concluded to our satisfaction.
 
  ### 	Suspended
  	
@@ -33,7 +33,7 @@ An account in a suspended state continues to incur auto-renewal billing for your
 
  ### 	Deactivated
  	
-A deactivated SendGrid account cannot accept mail. Upon deactivation, SendGrid deletes any undelivered mail queued on the system. Click and Open tracking links are disabled in the deactivated account.  Deactivated sub-users are not accessible via the ‘log in as’ method available to parent accounts. However, deactivated sub-users can still log in directly.
+A deactivated SendGrid account cannot accept mail. Upon deactivation, SendGrid deletes any undelivered mail queued on the system. Click and Open tracking links are disabled in the deactivated account.  Deactivated subusers are not accessible via the ‘log in as’ method available to parent accounts. However, deactivated subusers can still log in directly.
 
 <call-out>
 
@@ -43,7 +43,7 @@ An account in a deactivated state continues to incur auto-renewal billing for yo
 
  ### 	Banned
  	
-Banned accounts cannot access our system either through SendGrid.com or the API. Our system does not accept email requests from banned accounts. Dedicated IPs assigned to the account are removed.  Related sub-users are unable to send email or access their account.
+Banned accounts cannot access our system either through SendGrid.com or the API. Our system does not accept email requests from banned accounts. Dedicated IPs assigned to the account are removed.  Related subusers are unable to send email or access their account.
 
 <call-out>
 

--- a/content/docs/ui/account-and-settings/troubleshooting-login.md
+++ b/content/docs/ui/account-and-settings/troubleshooting-login.md
@@ -39,6 +39,6 @@ On the last week of each month, we terminate accounts with outstanding unpaid ba
 We will send out several warning emails in the course of a month if an account fails to pay on time, so you should have ample warning before Termination. However, if you believe your account has been terminated due to non-payment, please get in touch with [Support](https://support.sendgrid.com) and we can help get you out of the red and sending again.
 
 ## Account banned
-When an account is banned, it is permanently cancelled. Access to the account is blocked and no further requests to our system will be accepted. A banned account is not allowed back on SendGrid in the future. If the account had dedicated IPs they will be removed. Related sub-users will also be banned.
+When an account is banned, it is permanently cancelled. Access to the account is blocked and no further requests to our system will be accepted. A banned account is not allowed back on SendGrid in the future. If the account had dedicated IPs they will be removed. Related subusers will also be banned.
 
 We don't make a habit of letting banned accounts back on, but if you would like to discuss it, _please respond to the email you received regarding the ban._ **Support cannot assist in reactivation of banned accounts.**


### PR DESCRIPTION
**Description of the change**: Unified the spelling of ``subuser``.
**Reason for the change**: The spelling of ``subuser`` was inconsistent (ex. subuser, sub-user, Subuser)
**Link to original source**:
