### PR TITLE
Inbound Parse Webhook 'attachment-info' is incorrect

### DIFF
--- a/content/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook.md
+++ b/content/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook.md
@@ -173,7 +173,7 @@ Remember to direct your incoming email to your hostname (for example, example@ex
       </tr>
       <tr>
          <th>attachment-info</th>
-         <td>A string containing the attachmentX keys with another JSON string as the value. This string will contain the keys <code>filename</code> and <code>name</code>, which is the name of the file (if it was provided) and <code>type</code>, which is the <a href="http://en.wikipedia.org/wiki/Internet_media_type">media type</a> of the file. X is the total number of attachments. For example, if the number of attachments is 0, there will be no attachment files. If the number of attachments is 3, parameters attachment1, attachment2, and attachment3 will have file uploads. </td>
+         <td>A JSON map where the keys are named attachment{X}. Each attachment key points to a JSON object containing three fields, <code>filename</code>, <code>type</code>, and <code>content-id</code>. The <code>filename</code> field is the name of the file (if it was provided). The <code>type</code> field is the <a href="http://en.wikipedia.org/wiki/Internet_media_type">media type</a> of the file. <code>X</<code> is the total number of attachments. For example, if the number of attachments is 0, there will be no attachment files. If the number of attachments is 3, parameters attachment1, attachment2, and attachment3 will have file uploads. </td>
       </tr>
       <tr>
          <th>charsets</th>
@@ -254,7 +254,7 @@ Content analysis details:   (2.6 points, 5.0 required)
   ["spam_score"]=>
   string(5) "2.597"
   ["attachment-info"]=>
-  string(287) "{"attachment2":{"filename":"DockMcWordface.docx","name":"DockMcWordface.docx","type":"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},"attachment1":{"filename":"MG_2359.jpg","name":"_MG_2359.jpg","type":"image/jpeg","content-id":"ii_1562e2169c132d83"}}"
+  string(287) "{"attachment2":{"filename":"DockMcWordface.docx","type":"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},"attachment1":{"filename":"MG_2359.jpg","type":"image/jpeg","content-id":"ii_1562e2169c132d83"}}"
   ["charsets"]=>
   string(77) "{"to":"UTF-8","html":"UTF-8","subject":"UTF-8","from":"UTF-8","text":"UTF-8"}"
   ["SPF"]=>


### PR DESCRIPTION
**Description of the change**: attachment-info doesn't contain a name field.
**Reason for the change**: See #2017
**Link to original source**: [this file](content/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook.md)
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #2017 

