### PR TITLE
Fix broken domain authentication link

### DIFF
--- a/content/docs/glossary/domain-authentication.md
+++ b/content/docs/glossary/domain-authentication.md
@@ -20,6 +20,6 @@ In an attempt to clarify complex functionality, SendGrid is upgrading the name o
 
 ## 	Additional Resources
 
-- [How to set up domain authentication]({{root_url}}/ui/sending-email/how-to-set-up-domain-authentication/)
+- [How to set up domain authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/)
 - [How to set up link branding]({{root_url}}/ui/account-and-settings/how-to-set-up-link-branding/)
 - [How to set up reverse DNS]({{root_url}}/ui/account-and-settings/how-to-set-up-reverse-dns/)


### PR DESCRIPTION


**Description of the change**:
 Fix broken link at bottom of page 'How to set up domain authentication'. Line 23. Corrected link: https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/

**Reason for the change**:
Fix broken link.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes # 46

