### PR TITLE
fixed GitHub word capitalizing in the footer

### DIFF
--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -62,7 +62,7 @@ class DocTemplate extends React.Component {
             <div className="card__inner">
               <h3 className="card__title" >Feedback</h3>
               <p>If you have a question that needs an answer, please <a href="https://support.sendgrid.com" title="contact support" target="_blank" rel="noopener noreferrer">contact support</a>.
-                Otherwise, please <a href="https://github.com/sendgrid/docs/issues/new" title="open an issue in our github" target="_blank" rel="noopener noreferrer">open an issue in our github</a>!
+                Otherwise, please <a href="https://github.com/sendgrid/docs/issues/new" title="open an issue in our GitHub" target="_blank" rel="noopener noreferrer">open an issue in our GitHub</a>!
                 Thanks for helping us improve our docs!
               </p>
             </div>


### PR DESCRIPTION
**Description of the change**: `github` -> `GitHub`

