### PR TITLE
add swoosh in the list of libraries

### DIFF
--- a/content/docs/for-developers/sending-email/libraries.md
+++ b/content/docs/for-developers/sending-email/libraries.md
@@ -87,6 +87,7 @@ If you create a library, please let us know, by editing this page [in our GitHub
 
 -   [sendgrid_elixir](http://github.com/alexgaribay/sendgrid_elixir) *by Alex Garibay* - Elixir package for sending SendGrid transactional emails
 -   [sendgrid_elixir](https://github.com/thoughtbot/bamboo) *by Thoughtbot* - Elixir emailing package, with SendGrid adapter
+-   [sendgrid_elixir](https://github.com/swoosh/swoosh) - Another Elixir emailing package, with SendGrid adapter
 
  ### 	Groovy
 


### PR DESCRIPTION
**Description of the change**: Add swoosh in the elixir library section
**Reason for the change**: Swoosh is also quite a popular e-mail composing and sending library with sendgrid being one of the available adapters. Just wanted to add it to the list.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->

