### PR TITLE
Fix interspire XML API link

### DIFF
--- a/content/docs/for-developers/sending-email/interspire.md
+++ b/content/docs/for-developers/sending-email/interspire.md
@@ -39,6 +39,6 @@ A bounce event occurs when mail is not able to be handed off to the mail servers
 
 More info on SendGrid's Event API can be found [here]({{root_url}}/API_Reference/Webhooks/event.html)
 
-More info on Interspire's XML API can be found [here](http://www.interspire.com/emailmarketer/pdf/XMLApiDocumentation.pdf)
+More info on Interspire's XML API can be found [here](https://www.interspire.com/xml-api-documentation)
 
 


### PR DESCRIPTION
**Description of the change**: Update Interspire XML API link
**Reason for the change**: Previous link was broken (http://www.interspire.com/emailmarketer/pdf/XMLApiDocumentation.pdf)

Updated to https://www.interspire.com/xml-api-documentation

**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/interspire/