### PR TITLE
Date output was missing a forward slash

### DIFF
--- a/content/docs/ui/sending-email/using-handlebars.md
+++ b/content/docs/ui/sending-email/using-handlebars.md
@@ -340,7 +340,7 @@ Resulting replacement:
 ```
 <ol>
 	<li>You ordered: shoes on: 2/1/2018</li>
-	<li>You ordered: hat on: 1/42017</li>
+	<li>You ordered: hat on: 1/4/2017</li>
 </ol>
 ```
 


### PR DESCRIPTION
See line 343

**Description of the change**:
Just added a forward slash that was missing on line 343.
**Reason for the change**:
Doc was incorrect.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

