### PR TITLE
Clarify test integration in the Mail Settings

### DIFF
--- a/content/docs/for-developers/tracking-events/troubleshooting.md
+++ b/content/docs/for-developers/tracking-events/troubleshooting.md
@@ -18,7 +18,7 @@ navigation:
 - Start by making sure your web server is returning a 2xx response to our servers. Any other response type will result in our server retrying a POST until we receive a 2xx response or the maximum time has expired. All events are retried at increasing intervals for up to 24 hours after the event occurs.
 - Next, make sure you are not blocking our IPs that are trying to POST to your server. Our IPs change often since we constantly add more machines.
 - http://httpresponder.com/ is a helpful tool for debugging webhooks.
-- You can use the **Test Your Integration** button on the [Settings > Mail Settings](https://app.sendgrid.com/settings/mail_settings) page in the [SendGrid UI](https://app.sendgrid.com) to send simulated events to your callback URL. You can also send a POST from a shell using cURL - this will give you the full response your server is returning including the HTTP headers:
+- You can use the **Test Your Integration** feature within the Event Notification Setting on the [Settings > Mail Settings](https://app.sendgrid.com/settings/mail_settings) page in the [SendGrid UI](https://app.sendgrid.com) to send simulated events to your callback URL. You can also send a POST from a shell using cURL - this will give you the full response your server is returning including the HTTP headers:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '[{"email":"john.doe@sendgrid.com","timestamp":1337197600,"smtp-id":"<4FB4041F.6080505@sendgrid.com>","event":"processed"},{"email":"john.doe@sendgrid.com","timestamp":1337966815,"category":"newuser","event":"click","url":"https://sendgrid.com"},{"email":"john.doe@sendgrid.com","timestamp":1337969592,"smtp-id":"<20120525181309.C1A9B40405B3@Example-Mac.local>","event":"processed"}]'


### PR DESCRIPTION
**Description of the change**:
Added detail of where in Settings you find the Test Your Integration

**Reason for the change**:
For users coming from the inbound parse help, it was not clear where the Test Your Integration feature was.

**Link to original source**:
https://sendgrid.com/docs/for-developers/tracking-events/troubleshooting/

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

