### PR TITLE
Update command string for install homebrew for MacOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ SendGrid does not merge a pull request made against a SendGrid open source proje
 
 * Install Homebrew (if you don't have it)
 
-	`$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+	`$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 
 * Install npm
 


### PR DESCRIPTION
**Description of the change**: Update command string for install homebrew for MacOS
**Reason for the change**: commando updated for install  homebrew for MacOS
**Link to original source**: https://brew.sh
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
my issue #4087

