### PR TITLE
Fix link to WordPress Subscription Widget

### DIFF
--- a/content/docs/for-developers/sending-email/wordpress-faq.md
+++ b/content/docs/for-developers/sending-email/wordpress-faq.md
@@ -146,4 +146,4 @@ define('SENDGRID_DISABLE_BUDDYPRESS', '1');
 ## 	Related Content
 
 * [SendGrid’s WordPress Plugin]({{root_url}}/for-developers/sending-email/wordpress-plugin/)
-* [SendGrid’s WordPress Subscription Widget]({{root_url}}/for-developers/managing-contacts/wordpress-subscription-widget/)
+* [SendGrid’s WordPress Subscription Widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/)

--- a/content/docs/for-developers/sending-email/wordpress-plugin.md
+++ b/content/docs/for-developers/sending-email/wordpress-plugin.md
@@ -195,5 +195,5 @@ If you have already installed the SendGrid plugin in a multisite environment and
 
 ## 	Additional Resources
 
-* [SendGrid's WordPress Subscription Widget]({{root_url}}/for-developers/managing-contacts/wordpress-subscription-widget/)
+* [SendGrid's WordPress Subscription Widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/)
 * [SendGrid's WordPress Integration FAQ]({{root_url}}/for-developers/sending-email/wordpress-faq/)


### PR DESCRIPTION
**Description of the change**: Updates the link to the WordPress Subscription Widget
**Reason for the change**: Original link was broken 
(https://sendgrid.com/docs/for-developers/managing-contacts/wordpress-subscription-widget/)

should be (https://sendgrid.com/docs/for-developers/sending-email/wordpress-subscription-widget/)

**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/wordpress-faq/

