### PR TITLE
Updated troubleshooting section of postfix.md

### DIFF
--- a/content/docs/for-developers/sending-email/postfix.md
+++ b/content/docs/for-developers/sending-email/postfix.md
@@ -70,3 +70,7 @@ $ yum install cyrus-sasl-plain
   ## 	Troubleshooting
  	
 If port 587 is not working for you please try 2525 in your postfix config. You may also need to edit /etc/postfix/master.cf to remove # from `tlsmgr unix - - n 1000? 1 tlsmgr`. 
+
+For other potential errors, please navigate to the default maillog file on your server for debugging purposes. For a CentOS server, the file is in path /var/log/maillog by default. 
+
+This file not only reports that the server was unable to use SendGrid to send email but also serves as an excellent debugging tool for new users that catalogues server parameters.


### PR DESCRIPTION
**Description of the change:** Updated documentation for Postfix troubleshooting by including the default maillog file and how to navigate to its filepath in accordance to the comment by kiranshashiny.
**Reason for the change:** New users might need this information for more effective debugging in the case of potential errors with Postfix configuration
**Link to original source:** https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/sending-email/postfix.md

Closes #2861

