### PR TITLE
Added CNAME meaning and grammatical revisions.

### DIFF
--- a/content/docs/glossary/cname.md
+++ b/content/docs/glossary/cname.md
@@ -10,7 +10,7 @@ navigation:
   show: false
 ---
 
-The CNAME record creates an alias for subdomain.yourdomain.com and points to sendgrid.net. The CNAME is needed for our click and open tracking features in order for those statistics to be routed back to your SendGrid account. This will also be what your messages are signed by, so your recipients will be able see what you have chosen for your CNAME.
+The CNAME record (canonical name record) creates an alias for subdomain.yourdomain.com and points to sendgrid.net. The CNAME is needed for our click and open tracking features in order for those statistics to be routed back to your SendGrid account. This is also what your messages will be signed by, so your recipients will be able see your CNAME.
 
 What it should look like:
 
@@ -18,6 +18,6 @@ What it should look like:
 subdomain.yourdomain.com. |  CNAME  |  sendgrid.net.
 ```
 
-If your account has a dedicated IP and you are looking to set up [reverse DNS]({{root_url}}/ui/account-and-settings/how-to-set-up-reverse-dns/) your IP, you will need to add some records to your DNS host. In this group of records you will have 1 CNAME record.
+If your account has a dedicated IP and you are looking to set up [reverse DNS]({{root_url}}/ui/account-and-settings/how-to-set-up-reverse-dns/) for your IP, you will need to add some records to your DNS host. In this group of records you will have 1 CNAME record.
 
 If you are having trouble validating your CNAME record, please see our [sender authentication troubleshooting]({{root_url}}/ui/account-and-settings/troubleshooting-sender-authentication/).


### PR DESCRIPTION
**Description of the change**: Added CNAME meaning and some grammatical revisions.
**Reason for the change**: The a-record.md explicitly says that an A record stands for address record, so I added the same for CNAME (canonical name record) just for consistency. I also revised some of the grammar to communicate the same, but with different or less words. 
**Link to original source**: 
original file: 
https://github.com/sendgrid/docs/blob/develop/content/docs/glossary/cname.md
forked file: 
https://github.com/thisaaronm/docs/blob/am1/content/docs/glossary/cname.md
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

