### PR TITLE
fix small typo in event.md

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -248,7 +248,7 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
       </tr>
       <tr>
          <td><a name="bounce"></a>Bounce</td>
-         <td>Receiving server could not or would not accept the message. If a recipient has previously unsubscribed from your emails, the message is bounced.</td>
+         <td>Receiving server could not or would not accept the message. If a recipient has previously unsubscribed from your emails, the message is dropped.</td>
          <td>
 ```raw
 [


### PR DESCRIPTION
**Description of the change**: change **bounced** to **dropped**
**Reason for the change**: #4109 
**Link to original source**:  https://sendgrid.com/docs/API_Reference/Event_Webhook/event.html#processed

Closes #4109

