### PR TITLE
Update KeyCDN Signup Link

### DIFF
--- a/content/docs/ui/sending-email/content-delivery-networks.md
+++ b/content/docs/ui/sending-email/content-delivery-networks.md
@@ -71,7 +71,7 @@ For more information, please visit [Fastly's documentation](https://docs.fastly.
 
 This section is maintained by KeyCDN, if you have any questions about KeyCDN please [contact their support](https://www.keycdn.com/support/) team.
 
-[Sign up for KeyCDN](https://www.keycdn.com) or login to your
+[Sign up for KeyCDN](https://app.keycdn.com/signup) or login to your
 existing account.
 
 Create a pull zone and point the origin URL to https://sendgrid.net.


### PR DESCRIPTION
The Fastly signup link takes you right to the dedicated Fastly signup page at https://www.fastly.com/signup/
This commit changes the KeyCDN signup link to also go directly to the dedicated KeyCDN signup page at https://app.keycdn.com/signup , instead of the home page.
So, link changed for consistency.
