### PR TITLE
Fix keywords-and-operator-reference link

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
+++ b/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
@@ -100,7 +100,7 @@ Encoded, this query would look like this:
 
 ## 	Creating compound queries
 
-Use [operators and keywords](#keywords-and-Operator-reference) to combine queries for a compound query. For example, you could filter for emails between a date range, or you could filter for when a specific recipients email is bounced. Here are some common use cases:
+Use [operators and keywords](#keywords-and-operator-reference) to combine queries for a compound query. For example, you could filter for emails between a date range, or you could filter for when a specific recipients email is bounced. Here are some common use cases:
 
  ### 	Filter by a recipient email that was bounced
 


### PR DESCRIPTION
**Description of the change**: Update the keywords-and-operator-reference link
**Reason for the change**: Previous link didn't point anywhere because there was a capital O in "operator"
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/sending-email/getting-started-email-activity-api.md