### PR TITLE
Update "Getting Started with the SMTP API" link

### DIFF
--- a/content/docs/for-developers/sending-email/building-an-smtp-email.md
+++ b/content/docs/for-developers/sending-email/building-an-smtp-email.md
@@ -207,5 +207,5 @@ For more information, see our [IP Pools documentation]({{root_url}}/API_Referenc
 - [How to send email]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/)
 - [Getting started with the API]({{root_url}}/api-reference/)
 - [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
-- [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/sending-email-smtp/)
+- [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
 - [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)


### PR DESCRIPTION
**Description of the change**: Update the link to the "Getting Started with the SMTP API" link
**Reason for the change**: Previous link was broken (404) 
https://sendgrid.com/docs/for-developers/sending-email/sending-email-smtp/

New link: https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/
(took the updated link from:
https://github.com/sendgrid/docs/blame/develop/content/docs/for-developers/sending-email/integrating-with-the-smtp-api.md#L43)
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/building-an-smtp-email/
