### PR TITLE
Fix grammar error

### DIFF
--- a/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
+++ b/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
@@ -39,7 +39,7 @@ Sender Policy Framework (SPF) is an email authentication standard developed by A
 
  ### 	CNAME
 
-The CNAME record creates an alias for subdomain.yourdomain.com and points to sendgrid.net. The CNAME is needed for our click and open tracking features in order for those statistics to be routed back to your SendGrid account. This will also be what your messages are signed by, so your recipients will be able see what you have chosen for your CNAME. You set up the CNAME files that SendGrid provides with your DNS host. For more information about CNAME, see our [CNAME glossary page]({{root_url}}/glossary/cname/).
+The CNAME record creates an alias for subdomain.yourdomain.com and points to sendgrid.net. The CNAME is needed for our click and open tracking features in order for those statistics to be routed back to your SendGrid account. This will also be what your messages are signed by, so your recipients will be able to see what you have chosen for your CNAME. You set up the CNAME files that SendGrid provides with your DNS host. For more information about CNAME, see our [CNAME glossary page]({{root_url}}/glossary/cname/).
 
 ## 	Setting up domain authentication
 


### PR DESCRIPTION
**Description of the change**:
The sentence was not grammatically correct. I made it correct.
`...... so your recipients will be able see what you have chosen.........` 
is rectified to:
`....... so your recipients will be able <to> see what you have chosen..........`
**Reason for the change**:
So as to become more readable and understandable
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

