### PR TITLE
Fixed typo

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
+++ b/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
@@ -124,7 +124,7 @@ curl --request GET \
 
  ### 	Filter by a recipient and a date range
 
-Use this query to filter to emails by recipient and between specific dates: (replace `<<your API key>>` with an API key from your account, replace <<start_date>> and <<end_date>> with a URL encoded UTC date string in this format: `YYYY-MM-DD HH:mm:SS`, and and replace <<email>> with the URL encoded recipient's email)
+Use this query to filter to emails by recipient and between specific dates: (replace `<<your API key>>` with an API key from your account, replace <<start_date>> and <<end_date>> with a URL encoded UTC date string in this format: `YYYY-MM-DD HH:mm:SS`, and replace <<email>> with the URL encoded recipient's email)
 
 ```
 curl --request GET \


### PR DESCRIPTION
**Description of the change**:
Changed "and and" to "and".
**Reason for the change**:
It is not proper English and probably a typo.
**Link to original source**: https://sendgrid.com/docs/API_Reference/Web_API_v3/Tutorials/getting_started_email_activity_api.html#-Filter-by-a-recipient-and-a-date-range
<!-- 
If this pull request closes an issue, add in the issue number here 
-->


