### PR TITLE
Made Minor changes

### DIFF
--- a/content/docs/for-developers/sending-email/integrating-with-the-smtp-api.md
+++ b/content/docs/for-developers/sending-email/integrating-with-the-smtp-api.md
@@ -26,8 +26,8 @@ Now that you've integrated, learn to [build SMTP email]({{root_url}}/for-develop
 
  ### 	SMTP Ports
 
-- For an unencrypted or a [TLS connections]({{root_url}}/ui/sending-email/ssl-vs-tls/), use port `25`, `2525`, or `587`.
-- For a [SSL connections]({{root_url}}/ui/sending-email/tls/), use port `465`.
+- For an unencrypted or a [TLS connection]({{root_url}}/ui/sending-email/ssl-vs-tls/), use port `25`, `2525`, or `587`.
+- For a [SSL connection]({{root_url}}/ui/sending-email/tls/), use port `465`.
 
  ### 	Rate limits
 


### PR DESCRIPTION
**Description of the change**:
Changed "a TLS connections" to "a TLS connection" AND "a SSL connections" to "a SSL connection"
**Reason for the change**:
Incorrect use of a with plural.
**Link to original source**: https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html

