### PR TITLE
Update brite-verify.md

### DIFF
--- a/content/docs/for-developers/sending-email/brite-verify.md
+++ b/content/docs/for-developers/sending-email/brite-verify.md
@@ -73,7 +73,7 @@ Once the correct API Key is provided, the applications sync, and you may now ver
 
 <call-out>
 
-For more information or support contact [BriteVerify](http://www.briteverify.com/)
+For more information or support contact [BriteVerify](https://support.briteverify.com/)
 
 </call-out>
  	


### PR DESCRIPTION
Since Validity acquired BriteVerify some months back this year, 
BriteVerify is now a product under the Validity list

Replacing 
http://www.briteverify.com/
with
https://support.briteverify.com/

Info: https://www.businesswire.com/news/home/20180612005375/en/Leading-Data-Integrity-Platform-Validity-Acquires-Industry

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

