### PR TITLE
Update api-getting-started.md

### DIFF
--- a/content/docs/for-developers/sending-email/api-getting-started.md
+++ b/content/docs/for-developers/sending-email/api-getting-started.md
@@ -37,7 +37,7 @@ Your API call must have the following components:
 
 * A Host. The host for Web API v3 requests is always `https://api.sendgrid.com/v3/`
 * An [Authorization Header](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-authentication#authorization-header)
-* An [API Key]({{root_url}}/ui/account-and-settings/api-keys/) within the Authorization Header
+* An [API Key](/content/docs/ui/account-and-settings/api-keys.md) within the Authorization Header
 * A Request. When submitting data to a resource via POST or PUT, you must submit your payload in JSON.
 
 <call-out>


### PR DESCRIPTION
Fixing the API Key url in 'Build your API call'.

**Description of the change**: Fixing the API Key url in 'Build your API call'.
**Reason for the change**: The api-keys.md not opening.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/sending-email/api-getting-started.md

Thank You.
