### PR TITLE
Update jelastic.md

### DIFF
--- a/content/docs/for-developers/partners/jelastic.md
+++ b/content/docs/for-developers/partners/jelastic.md
@@ -16,4 +16,4 @@ Application Examples
 1. [Java with Spring](http://docs.jelastic.com/sendgrid-java)
 2. [PHP](http://docs.jelastic.com/sendgrid-php)
 
-Check out our blog for more information on SendGrid and Jelastic [here]({{site.blog_url}}/?s=jelastic).
+Check out our blog for more information on SendGrid and Jelastic [here](https://sendgrid.com/blog/jelastic-sendgrid-team-power-java-php-applications/).


### PR DESCRIPTION
Fixing the URL from SendGrid and Jelastic Blog.

**Description of the change**: Fixing the URL from SendGrid and Jelastic Blog.
**Reason for the change**: The URL was not working for SendGrid and Jelastic Blog.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/partners/jelastic.md

Thank You.


