### PR TITLE
Update magento.md

### DIFF
--- a/content/docs/for-developers/partners/magento.md
+++ b/content/docs/for-developers/partners/magento.md
@@ -55,7 +55,7 @@ Learn more about your shoppers’ engagement with performance feedback and real-
 * Flexible API and SMTP setup for for easy transactional email Integration.
 * Key email deliverability features including email authentication, reputation monitoring, dedicated IP addresses, and more.
 * Real-time analytics and reporting including opens, clicks, bounces, unsubscribe tracking, and more.
-* Leverage our step-by-step [documentation]({{root_url}}/api-reference/) or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
+* Leverage our step-by-step [documentation](https://sendgrid.com/docs/for-developers/partners/magento/) or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
 * This official extension was built for M2 by SendGrid’s dedicated partner-focused teams for continued management and future development.
 
 ## 	Configuration

--- a/content/docs/for-developers/partners/magento.md
+++ b/content/docs/for-developers/partners/magento.md
@@ -55,7 +55,7 @@ Learn more about your shoppers’ engagement with performance feedback and real-
 * Flexible API and SMTP setup for for easy transactional email Integration.
 * Key email deliverability features including email authentication, reputation monitoring, dedicated IP addresses, and more.
 * Real-time analytics and reporting including opens, clicks, bounces, unsubscribe tracking, and more.
-* Leverage our step-by-step [documentation](https://sendgrid.com/docs/for-developers/partners/magento/) or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
+* Leverage our step-by-step [documentation]({{root_url}}/for-developers/partners/magento/) or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
 * This official extension was built for M2 by SendGrid’s dedicated partner-focused teams for continued management and future development.
 
 ## 	Configuration


### PR DESCRIPTION
Fixing the link for sendGrid and Magento documentation.

**Description of the change**: Fixing the link for sendGrid and Magento documentation.
**Reason for the change**: The link was broken for sendGrid and Magento documentation.
**Link to original source**: https://github.com/sendgrid/docs/edit/develop/content/docs/for-developers/partners/magento.md

Thank You.
