### PR TITLE
Line 26 [SMTP API Link - routes to 404 Error

### DIFF
--- a/content/docs/for-developers/sending-email/categories.md
+++ b/content/docs/for-developers/sending-email/categories.md
@@ -23,7 +23,7 @@ Currently, there is no limit to the number of categories you can track. However,
 
 ## 	Example
 
-You can use SendGrid's [SMTP API]({{root_url}/for-developers/sending-email/getting-started-smtp/) to add these categories to your email. The following should be added to the email's header:
+You can use SendGrid's [SMTP API](https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/) to add these categories to your email. The following should be added to the email's header:
 
 ### Example Category Header
 ```json

--- a/content/docs/for-developers/sending-email/categories.md
+++ b/content/docs/for-developers/sending-email/categories.md
@@ -23,7 +23,7 @@ Currently, there is no limit to the number of categories you can track. However,
 
 ## 	Example
 
-You can use SendGrid's [SMTP API](https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/) to add these categories to your email. The following should be added to the email's header:
+You can use SendGrid's [SMTP API]({{root_url}}/ui/for-developers/sending-email/getting-started-smtp/) to add these categories to your email. The following should be added to the email's header:
 
 ### Example Category Header
 ```json


### PR DESCRIPTION
Line 26 link is not functioning the SMTP API link to https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/ is not working

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

