### PR TITLE
Fix Link for Send Email Using SendGrid on Azure

### DIFF
--- a/content/docs/for-developers/partners/microsoft-azure.md
+++ b/content/docs/for-developers/partners/microsoft-azure.md
@@ -7,7 +7,7 @@ navigation:
   show: true
 ---
 
-If you are using Microsoft’s cloud platform you can easily integrate with SendGrid. Simply navigate to the Azure Marketplace, locate the SendGrid add-on, select the appropriate plan, and get ready to start sending. The following documentation covers signing up, sending an email, adding an attachment, as well as using filters. Click [here](http://azure.microsoft.com/en-us/documentation/articles/sendgrid-dotnet-how-to-send-email-with-marketing-campaigns/) to start learning how Azure and SendGrid can solve your email deliverability problems.
+If you are using Microsoft’s cloud platform you can easily integrate with SendGrid. Simply navigate to the Azure Marketplace, locate the SendGrid add-on, select the appropriate plan, and get ready to start sending. The following documentation covers signing up, sending an email, adding an attachment, as well as using filters. See the below Code Examples to start learning how Azure and SendGrid can solve your email deliverability problems.
 
 ## 	Code Examples
 


### PR DESCRIPTION
**Description of the change**:
Line 10 on the [microsoft-azure.md](https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/partners/microsoft-azure.md) file has a link that states "*Click here to start learning how Azure and SendGrid can solve your email deliverability problems*" and links to: http://azure.microsoft.com/en-us/documentation/articles/sendgrid-dotnet-how-to-send-email-with-marketing-campaigns/

However, clicking that above link redirects users to the main Azure Docs page at: https://docs.microsoft.com/en-us/azure/

Notice how the original (wrong) link contains the phrase "dotnet" ```[...]/articles/sendgrid-dotnet-how[...]```.

The proper Microsoft Azure documentation for sending SendGrid emails utilizing .NET is already listed on Line 16 under the **Code Examples** heading.

**Reason for the change**:
Thus, this removes the incorrect link and redirects users to see the **Code Examples** for how to integrate SendGrid with Azure, which includes .NET, PHP, Node, and others.

**Link to original source**:
https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/partners/microsoft-azure.md


