### PR TITLE
wider search results.

### DIFF
--- a/src/scss/components/_algolia.scss
+++ b/src/scss/components/_algolia.scss
@@ -85,6 +85,18 @@
   .algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
     padding: $scale-0 !important;
   }
+
+  .ds-dropdown-menu {
+    width: 200% !important;
+    max-width: 200% !important;
+    min-width: 200% !important;
+
+    @media (max-width: 610px) {
+      width: 100% !important;
+      max-width: 100% !important;
+      min-width: 100% !important;
+    }
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
**Description of the change**:
On the For Developers page, the search results container is now wider so its easier to read the results.

**Reason for the change**:
Design change. The results were compressed into a narrow container. Closes backlog ticket.


