### PR TITLE
added margin to logged in user name.

### DIFF
--- a/src/components/NavMain/NavMain.scss
+++ b/src/components/NavMain/NavMain.scss
@@ -194,8 +194,9 @@
 }
 
 .nav-secondary__account {
-  position: relative;
   display: inline-block;
+  position: relative;
+  margin-left: $scaleup-2;
 
   span {
     padding-left: 20px;


### PR DESCRIPTION
**Description of the change**:
Added a left margin to the user's name element when a user is logged in.

**Reason for the change**:
Design fix. The user's name was overlapping the SendGrid.com link text.

