### PR TITLE
changed icon color

### DIFF
--- a/src/img/release-note-ui.svg
+++ b/src/img/release-note-ui.svg
@@ -10,8 +10,8 @@
                 <g id="Group-6-Copy-4">
                     <g id="Group-13">
                         <g id="Group-5">
-                            <circle id="Oval-2" fill="#D9FFF8" cx="35" cy="35" r="35"></circle>
-                            <g id="Group-3" transform="translate(17.500000, 18.666667)" stroke="#39DFC1" stroke-width="1.16666667">
+                            <circle id="Oval-2" fill="#d1e6f9" cx="35" cy="35" r="35"></circle>
+                            <g id="Group-3" transform="translate(17.500000, 18.666667)" stroke="#1A82E2" stroke-width="1.16666667">
                                 <g id="Group-941" transform="translate(0.000000, 2.819444)" stroke-linejoin="round">
                                     <path d="M0.7,4.93402778 L34.3,4.93402778" id="Stroke-2829" stroke-linecap="round"></path>
                                     <path d="M7.7,1.40972222 C7.7,1.79880556 7.3864,2.11458333 7,2.11458333 C6.6136,2.11458333 6.3,1.79880556 6.3,1.40972222 C6.3,1.02063889 6.6136,0.704861111 7,0.704861111 C7.3864,0.704861111 7.7,1.02063889 7.7,1.40972222 L7.7,1.40972222 Z" id="Stroke-2830" stroke-linecap="round"></path>


### PR DESCRIPTION
**Description of the change**:
Changed the color of the UI Update icon on the release notes page.

**Reason for the change**:
The UI Update and API Update icons were similar in color and could cause some confusion. Closes a backlog ticket.

