### PR TITLE
closing anchor tag for"Group Resubscribe" is missing

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -431,7 +431,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <th><a href="#spamreport">Spam Report</a></th>
     <th><a href="#unsubscribe">Unsubscribe</a></th>
     <th><a href="#groupunsubscribe">Group Unsubscribe</a></th>
-    <th><a href="#groupresubscribe"Group Resubscribe</a></th>
+    <th><a href="#groupresubscribe">Group Resubscribe</a></th>
   </tr>
   <tr>
     <td><a href="#email">email</a></td>


### PR DESCRIPTION
**Description of the change**:
closing anchor tag symbol is missing

**Reason for the change**:
 Previous
```<th><a href="#groupresubscribe"Group Resubscribe</a></th>```
after
```<th><a href="#groupresubscribe">Group Resubscribe</a></th>```
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Signed-off-by: inyee786 intakhab.cusat@gmail.com

Closes #

