### PR TITLE
Rewrite: Sending a Transactional Template Email over SMTP

### DIFF
--- a/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp.md
+++ b/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp.md
@@ -1,9 +1,9 @@
 ---
 seo:
-  title: How to use a Legacy Template with the SMTP API
-  description: Learn how to send a legacy template with the SMTP API.
-  keywords: SMTP, send email, integrate, building, filters, scheduling, substitution, suppression groups, unique arguments, recipients, legacy template
-title: How to use a legacy Template with the SMTP API
+  title: Sending a Transactional Template Email over SMTP
+  description: Learn how to send a transactional template with the SMTP API.
+  keywords: SMTP, send email, integrate, building, filters, scheduling, substitution, suppression groups, unique arguments, recipients, legacy template, transactional template
+title: Sending a Transactional Template Email over SMTP
 group: smtp
 weight: 949
 layout: page
@@ -11,18 +11,76 @@ navigation:
   show: true
 ---
 
-## 	Enabling a Template
+<call-out>
 
-To use a legacy template when you send, enable the `templates`
-filter and set the `template_id` to one of your transactional templates.
+### Who should consider using the SMTP API?
 
-<call-out type="warning">
-
-This method of sending does not support Transactional Templates. For sending Transactional Templates you need to use v3 Mail Send.
+For customers who are unable to use the Web API, SMTP is a perfectly acceptable option.
 
 </call-out>
 
-Example
+<call-out type="warning">
+
+The SMTP API does not support Dynamic Transactional Templates. For sending Dynamic Transactional Templates you need to use v3 Mail Send.
+
+* [How to send an email with Dynamic Transactional Templates]({{root_url}}/for-developers/sending-email/how-to-send-an-email-with-dynamic-transactional-templates)
+- [Getting Started with the v3 Mail Send API]({{root_url}}/for-developers/sending-email/api-getting-started/)
+  
+</call-out>
+
+## 	Before you begin
+
+Before you create and send a transactional template email over SMTP you need to do the following:
+
+* [Integrate with the SendGrid SMTP API]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
+* [Send a test email over SMTP]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
+* [Build an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)
+* [Create a Legacy Transactional Template](https://sendgrid.com/templates)
+
+## 	Sending a test Email
+
+### Sending a test SMTP email with Telnet
+
+[Sending a test SMTP email with Telnet](/ui/sending-email/getting-started-smtp/#sending-a-test-smtp-email-with-telnet) is one of the most basic tests you can do. This test is useful in checking the connection and determining if the most basic of problems:
+
+* Is the server up?
+* Is there a firewall blocking communication?
+* Does the mail server allow for relaying of a particular domain/email address?
+* What SMTP commands does the mail server support?
+* Does the server respond with the correct hostname?
+* Does the connection work outside any third party software or APIs?
+
+## Sending an Email
+
+### Code Examples with different clients
+
+* [SMTP Go Code Example]({{root_url}}/for-developers/sending-email/smtp-go-code-example/)
+* [SMTP Node.js Code Example]({{root_url}}/for-developers/sending-email/smtp-nodejs-code-example/)
+* [SMTP PHP Code Example]({{root_url}}/for-developers/sending-email/smtp-php-code-example/)
+* [SMTP Perl Code Example]({{root_url}}/for-developers/sending-email/smtp-perl-code-example/)
+* [SMTP Python Code Example]({{root_url}}/for-developers/sending-email/smtp-python-code-example/)
+* [SMTP Ruby Code Example]({{root_url}}/for-developers/sending-email/smtp-ruby-code-example/)
+
+
+### Enabling a Template
+
+<call-out>
+
+Make sure that the version of the template you want to use is set to active by using:
+
+- The [Activate a transactional template version endpoint](https://sendgrid.com/docs/api-reference/)
+  ```/templates/{template_id}/versions/{version_id}/activate```
+  
+- Or by [activating the template version in the UI](https://sendgrid.com/templates)
+
+</call-out>
+
+To use a legacy template when you send, configure the `X-SMTPAPI` header of an SMTP message:
+* Enable the `templates` filter
+* Set the `template_id` to one of your transactional templates
+
+
+**Example**
 ```json
 {
   "filters": {
@@ -36,101 +94,37 @@ Example
 }
 ```
 
-You can use this JSON in the `X-SMTPAPI` header of an SMTP message, or in
-the `x-smtpapi` parameter of a [Web API v2 mail send]({{root_url}}/API_Reference/Web_API/mail.html#-send) call.
+### Set the Body and Subject Tags
 
-If you are using the [Web API v3 mail send endpoint]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html), you can specify which legacy template you would like to use simply by setting the template ID in the `template_id` parameter of your JSON payload.
+The `<%subject%>` property is used for both Text and HTML templates.
 
-<call-out>
+The ```text``` property is substituted into the `<%body%>` of the text template and ```html``` is substituted into the `<%body%>` of the HTML template.
 
-Make sure that the version of the template you want to use is set to active by using the [activate endpoint]({{root_url}}/API_Reference/Web_API_v3/Transactional_Templates/versions.html#-POST) or by activating it in the UI.
-
-</call-out>
-
-
-
-## 	Body and Subject Tags
-
-Enabling a legacy template means that the `subject` and `body`
-content of your message will behave differently.
-
-If you want only the message's content to be displayed, populate only the token in the template's field.
-If you want only the template's content to be displayed, leave the message field (subject or body) empty, and the template will populate.
-
- ### 	Text or HTML Templates?
+**Text or HTML Templates?**
 
 <call-out>
 
 It is best practice to provide content for both the ```html``` and the ```text``` properties in all of your emails.
 
+If the ```text``` property is present, but not ```html```, then the resulting email will only contain the text version of the template, not the HTML version.
+
 </call-out>
 
-The ```text``` property is substituted into the `<%body%>` of the text template and ```html``` is substituted into the `<%body%>` of the HTML template. If the ```text``` property is present, but not ```html```, then the resulting email will only contain the text version of the template, not the HTML version. The `<%subject%>` property is used for both Text and HTML templates.
 
+Enabling a legacy template means that the `subject` and `body`
+content of your message will behave differently.
 
+* If you want only the message's content to be displayed, populate only the token in the template's field.
+* If you want only the template's content to be displayed, leave the message field (subject or body) empty, and the template will populate.
 
-## 	Substitutions and Sections
+## Advanced options
 
-You can use SMTP API
-[substitution]({{root_url}}/for-developers/sending-email/substitution-tags/)
-and [section]({{root_url}}/for-developers/sending-email/section-tags/)
-tags in your template's subject and body content, and they will be replaced with the values
-specified when you send the message.
+You can use SMTP API [substitution]({{root_url}}/for-developers/sending-email/substitution-tags/) and [section]({{root_url}}/for-developers/sending-email/section-tags/) tags in your template's subject and body content, and they will be replaced with the values specified when you send the message.
 
-For example, consider a template with a subject of `Dear :name, big sale on <%subject%>!` and following text content:
+### Substitution Tags
 
-```html
-<%body%>
+[Substitution tags]({{root_url}}/for-developers/sending-email/substitution-tags/) allow you to generate dynamic content for each recipient on your list. When you send to a list of recipients over SMTP API, you can specify substitution tags specific to each recipient.
 
-Hello there :name!
+### Section Tags
 
-You can buy it for only :price! Yay!
-```
-
-Now let's specify what to replace the `:name` and `:price` tags with,
-using the SMTP API header:
-
-```json
-{
-  "to": [
-    "example@example.com",
-    "bob@sendgrid.com"
-  ],
-  "sub": {
-    ":name": [
-      "Alice",
-      "Bob"
-    ],
-    ":price": [
-      "$4",
-      "$4"
-    ]
-  },
-  "category": [
-    "Promotions"
-  ],
-  "filters": {
-    "templates": {
-      "settings": {
-        "enable": 1,
-        "template_id": "60414495-6787-441b-8b08-3979499bba7a"
-      }
-    }
-  }
-}
-```
-
-This combination of template and substitutions, when used with a message
-that has a subject of `bacon` and a body of `Big news from Good Food
-Company!` will produce the following email to Alice, and a separate
-customized email for Bob.
-
-```
-Subject: Dear Alice, big sale on bacon!
-
-Big news from Good Food Company!
-
-Hello there Alice!
-
-You can buy it for only $4! Yay!
-```
+[Section tags]({{root_url}}/for-developers/sending-email/section-tags/) allow you to substitute in content in an SMTP message. Section tags are similar to substitution tags but are specific to the message, and not the recipient. Section tags have to be contained within a Substitution tag since SendGrid needs to know which data to populate for the recipient.


### PR DESCRIPTION
**Description of the change**:
Purpose: Rewrite the [Using Transactional Templates With the SMTP API](https://sendgrid.com/docs/API_Reference/SMTP_API/how_to_use_a_transactional_template_with_smtp.html).

**Reason for the change**:
Clarifying using the Transactional Templates with the SMTP API

**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #1755 
