### PR TITLE
Added a note to AWS page

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -20,6 +20,12 @@ Once you have an AWS account, you can to [subscribe to SendGrid](https://aws.ama
 
 <call-out>
 
+If you are using SendGrid through AWS, you cannot change your SendGrid username.
+
+</call-out>
+
+<call-out>
+
 **Warmup your sending** - Since ISP spam filters look at volume as a significant factor when determining whether or not you are sending spam, we recommend that you begin sending a low to moderate volume, eventually working your way up to larger volumes. This gives the receiving email providers a chance to closely observe your sending habits and the way your customers treat the emails they receive from you.
 
 </call-out>


### PR DESCRIPTION
**Description of the change**: Added call out about inability to change sendgrid username on aws signup
**Reason for the change**: https://github.com/sendgrid/docs/issues/4236 inform users
**Link to original source**: https://sendgrid.com/docs/for-developers/partners/amazon-marketplace/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #4236 

