### PR TITLE
Use secure "https" link in CURL example

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
+++ b/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
@@ -24,7 +24,7 @@ Start with this basic query to the Email Activity Feed API (replace `<<your API 
 
 ```
 curl --request GET \
- --url 'http://api.sendgrid.com/v3/messages?limit=10' \
+ --url 'https://api.sendgrid.com/v3/messages?limit=10' \
  --header 'authorization: Bearer <<your API key>>'
 ```
 


### PR DESCRIPTION
This example makes it easy for developers to accidentally expose API keys as
part of an insecure request body.