### PR TITLE
Corrected URL for Java web page example on Azure docs

### DIFF
--- a/content/docs/for-developers/partners/microsoft-azure.md
+++ b/content/docs/for-developers/partners/microsoft-azure.md
@@ -15,7 +15,7 @@ If you are using Microsoft’s cloud platform you can easily integrate with Send
 2. [Node.js](https://docs.microsoft.com/en-us/azure/store-sendgrid-nodejs-how-to-send-email)
 3. [.NET](https://docs.microsoft.com/en-us/azure/sendgrid-dotnet-how-to-send-email)
 4. [Java](https://docs.microsoft.com/en-us/azure/store-sendgrid-java-how-to-send-email)
-5. [Java]({{root_url}}/for-developers/partners/azure/) via an Azure webpage
+5. [Java](https://docs.microsoft.com/en-us/azure/store-sendgrid-java-how-to-send-email-example) via an Azure webpage
 6. [Mobile Services](https://docs.microsoft.com/en-us/azure/sendgrid-dotnet-how-to-send-email)
 
 ## 	Still have questions?


### PR DESCRIPTION
**Description of the change**:

Changed an invalid URL for the Java with web page example on the Azure docs to the correct example URL.


**Reason for the change**:

Old URL pointed to an invalid link.

**Link to original source**:

https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/partners/microsoft-azure.md

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes # (N/A)

