### PR TITLE
Removed broken link

### DIFF
--- a/content/docs/for-developers/partners/google.md
+++ b/content/docs/for-developers/partners/google.md
@@ -20,4 +20,4 @@ Using Google’s App Engine or Compute Engine? Here are a few examples of how to
 
 If you're using Google's Compute Engine, click [here](https://cloud.google.com/compute/docs/tutorials/sending-mail/using-sendgrid)
 
-Check out our blog for more information on how to make Google and SendGrid work together [here]({{site.blog_url}}/?s=google+app+engine). 
+Check out our blog for more information on how to make Google and SendGrid work together.


### PR DESCRIPTION
Removed link that was broken and was giving 404 page error.

**Description of the change**: Removed link that was broken and was giving 404 page error.
**Reason for the change**: Link was broken and it was directing to 404 error page.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

