### PR TITLE
Fixed broken image in styleguide.md

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -73,7 +73,7 @@ navigation:
 
 The sections in **Bold** are the categories. The "group" field in the head matter pertains to the different headers article residing under a specific category. The group designation is after the colon of the "group" field.
 
-src="https://github.com/sendgrid/docs/blob/develop/static/img/docs-architecture-group.png" width="676" height="386">
+![Document architecture schematic.](https://github.com/sendgrid/docs/blob/develop/static/img/docs-architecture-group.png)
  
 #### UI
 


### PR DESCRIPTION
**Description of the change**: Fixed broken image embed in styleguide.md
**Reason for the change**: Image didn't show. instead there was a broken `<src  ... />` tag
**Link to original source**: [styleguide.md] (https://github.com/sendgrid/docs/blob/develop/styleguide.md)
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes ##4303

