### PR TITLE
Delete Call Change

### DIFF
--- a/source/API_Reference/Web_API_v3/blocks.apiblueprint
+++ b/source/API_Reference/Web_API_v3/blocks.apiblueprint
@@ -50,6 +50,9 @@ There are two options for deleting blocked emails:
 
 ### Delete blocks [DELETE]
 
+{% info %} Please note, when you are completing the following requests they should not be combined. For example, if requesting to delete one address, it is not necessary to add the "delete_all=false" parameter in an effort to prevent deletion of further blocks, it is assumed. {% endinfo %}
+
+
 + Request (application/json)
 
     + Body


### PR DESCRIPTION
Under Delete Blocks I added the following information:
{% info %} Please note, when you are completing the following requests they should not be combined. For example, if requesting to delete one address, it is not necessary to add the "delete_all=false" parameter in an effort to prevent deletion of further blocks, it is assumed. {% endinfo %}

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

