### PR TITLE
Updated dev link to use secure url.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 This is a Gatsby site.
 
-The develop branch is continuously deployed to a preview site. [View dev site](http://d2w67tjf43xwdp.cloudfront.net/)
+The develop branch is continuously deployed to a preview site. [View dev site](https://d2w67tjf43xwdp.cloudfront.net/)
 
 The develop branch is merged to production weekly (unless we need to do a release sooner than that).
 


### PR DESCRIPTION
**Description of the change**: Changed "View dev site" link to use secure url.
**Reason for the change**: "View dev site" using nonsecure url.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

