### PR TITLE
Line 35 - Took out unnecessary comma

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -32,7 +32,7 @@ If you are using SendGrid through AWS, you cannot change your SendGrid username.
 
 ### Pricing
 
-There are two plans: AWS Basic, and AWS Pro. For more information, check out our[ AWS Marketplace page](https://aws.amazon.com/marketplace/pp/B074CQY6KB). Here's a monthly view of cost:
+There are two plans: AWS Basic and AWS Pro. For more information, check out our[ AWS Marketplace page](https://aws.amazon.com/marketplace/pp/B074CQY6KB). Here's a monthly view of cost:
 
 ![]({{root_url}}/images/aws_pricing.png "AWS pricing")
 


### PR DESCRIPTION
Used to say -- There are two plans: AWS Basic, and AWS Pro

**Took out extra comma in pricing section**:
**Didn't need it :) **:
**Lhttps://sendgrid.com/docs/for-developers/partners/amazon-marketplace/**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

