### PR TITLE
Missing word (added "on")

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -54,7 +54,7 @@ You can only add a Dedicated IP Address if you are on an AWS Pro plan. To upgrad
 
 ### Adding domain authentication and link branding
 
-Sender authentication shows email providers that SendGrid has your permission to send emails on your behalf. Domain authentication works by pointing DNS entries from your domain registrar to SendGrid, which drastically increases your ability to deliver email and allows you to begin building a sender reputation for your domain and for your IP addresses. For more information domain authentication, see [How to Set Up Domain Authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/).
+Sender authentication shows email providers that SendGrid has your permission to send emails on your behalf. Domain authentication works by pointing DNS entries from your domain registrar to SendGrid, which drastically increases your ability to deliver email and allows you to begin building a sender reputation for your domain and for your IP addresses. For more information on domain authentication, see [How to Set Up Domain Authentication]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/).
 
 ### Adding Subusers
 


### PR DESCRIPTION
Line 57, used to read: For more information domain authentication, see How to Set Up Domain Authentication

**Added a word**:
**It was missing**:
**https://sendgrid.com/docs/for-developers/partners/amazon-marketplace/**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

