### PR TITLE
Update subuser.md

### DIFF
--- a/content/docs/ui/analytics-and-reporting/subuser.md
+++ b/content/docs/ui/analytics-and-reporting/subuser.md
@@ -27,6 +27,6 @@ This table will refresh with new or adjusted data based on the various filters a
 
 ## 	Additional Resources
 
-- [Subuser Statistics]({{root_url}}/API_Reference/Web_API_v3/Stats/subusers/)
+- [Subuser Statistics Comparison]({{root_url}}/ui/analytics-and-reporting/subuser-comparison/)
 - [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/)
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)


### PR DESCRIPTION
Fixing broken link and updating link name

currently: Subuser Statistics
https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/subusers/ (404 error)

should be: Subuser Statistics Comparison
https://sendgrid.com/docs/ui/analytics-and-reporting/subuser-comparison/

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

