### PR TITLE
Removed unnecessary hyperlink

### DIFF
--- a/content/docs/ui/analytics-and-reporting/marketing-campaigns-stats.md
+++ b/content/docs/ui/analytics-and-reporting/marketing-campaigns-stats.md
@@ -70,7 +70,7 @@ Marketing Campaigns makes it very easy to view recipients who have either opened
 1. From the Campaigns page or the individual campaign statistics page, hover over the **Unique Opens** or **Unique Clicks** stats.
 1. Click **View Details** and then select **Create Segment**.
 
-   A window opens with segmentation options. By default, the segment will contain the conditions to capture all recipients who either opened your campaign or clicked within your campaign. The segment will be given the name _“Contacts who [clicked/opened] [your campaign name]”_. You can rename this segment or modify the conditions of the segment as you wish directly in this window. For more information on segmentation, [click here]({{root_url}}/ui/managing-contacts/segmenting-your-contacts/#creating-a-segment).
+   A window opens with segmentation options. By default, the segment will contain the conditions to capture all recipients who either opened your campaign or clicked within your campaign. The segment will be given the name _“Contacts who clicked/opened [your campaign name]”_. You can rename this segment or modify the conditions of the segment as you wish directly in this window. For more information on segmentation, [click here]({{root_url}}/ui/managing-contacts/segmenting-your-contacts/#creating-a-segment).
 
 1. Click **Save**.
 <br>You now have a dynamic segment that will continuously update as recipients engage with this campaign.


### PR DESCRIPTION
The hyperlink for "clicked/opened" was redirecting to the same page the user was already on so removed the hyperlink, which should also allow "[your campaign name]" to display (was not showing up before then).

**Description of the change**: Removed the hyperlink for "clicked/opened".
**Reason for the change**: The hyperlink for "clicked/opened" was redirecting to the same page the user was already on, and also keeping "[your campaign name]" from displaying.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/ui/analytics-and-reporting/marketing-campaigns-stats.md 
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

