### PR TITLE
Fixed Video Markdown in "event-kit.md"

### DIFF
--- a/content/docs/for-developers/tracking-events/event-kit.md
+++ b/content/docs/for-developers/tracking-events/event-kit.md
@@ -23,9 +23,8 @@ Our open source EventKit app alleviates the hassle of needing to set up an endpo
 
 ## Learn how to install the Event Kit app using a free [Heroku](https://www.heroku.com/) instance by watching this step-by-step video:
 
-<iframe src="https://player.vimeo.com/video/167121552" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
+[![Click to Watch](https://i.imgur.com/Oj57LEh.png=600x400)](https://vimeo.com/167121552 "Click to Watch")
 
 ## Once you have EventKit set up, watch this video to learn more about the features within as well as how to navigate the user interface.
 
-<iframe src="https://player.vimeo.com/video/179804115" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+[![Click to Watch](https://i.imgur.com/JyWwmZH.png=600x400)](https://vimeo.com/179804115 "Click to Watch")


### PR DESCRIPTION
**Description of the change**:
In "content/docs/for-developers/tracking-events/event-kit.md", iFrame was originally used to embed the videos, but it didn't compile correctly. This is a screenshot before the change:

<img width="800" alt="screen shot 2018-10-23 at 1 28 29 pm" src="https://user-images.githubusercontent.com/22715360/47379219-4ab55080-d6c8-11e8-962f-8076561d3e20.png">

I fixed it by using linked images. The reader can click on the image to be redirected to the video. These are screenshots after the change: 

<img width="800" alt="screen shot 2018-10-23 at 1 35 21 pm" src="https://user-images.githubusercontent.com/22715360/47379358-b0094180-d6c8-11e8-9c49-73265046ec63.png">

<img width="800" alt="screen shot 2018-10-23 at 1 35 28 pm" src="https://user-images.githubusercontent.com/22715360/47379374-bd263080-d6c8-11e8-9535-78e9cc5830c5.png">

**Reason for the change**:
To improve the format/look of the document.

**Link to original source**:
I did not find any issues related to this pull request.

