### PR TITLE
Fixed Typo

### DIFF
--- a/content/docs/for-developers/sending-email/building-an-smtp-email.md
+++ b/content/docs/for-developers/sending-email/building-an-smtp-email.md
@@ -10,7 +10,7 @@ layout: page
 navigation:
   show: true
 ---
-Now that you've sent a [sent a test SMTP email with Telnet]({{root_url}}/for-developers/sending-email/getting-started-smtp/), and [integrated with SendGrid]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/), it's time to build content.
+Now that you've [sent a test SMTP email with Telnet]({{root_url}}/for-developers/sending-email/getting-started-smtp/), and [integrated with SendGrid]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/), it's time to build content.
 
 ## 	Getting started building
 


### PR DESCRIPTION
**Description of the change**: Fixed duplicate word typo
**Reason for the change**: didn't make sense when read
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/building-an-smtp-email/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

