### PR TITLE
Removed Unnecessary Comma

### DIFF
--- a/content/docs/for-developers/sending-email/smtp-filters.md
+++ b/content/docs/for-developers/sending-email/smtp-filters.md
@@ -23,7 +23,7 @@ For more information on the utility of these settings, please check out the [Set
 
 <call-out>
 
-Some Settings are not listed here, because they cannot be defined on a per-message basis. To update these other Settings, please refer to the
+Some Settings are not listed here because they cannot be defined on a per-message basis. To update these other Settings, please refer to the
 [Web API Filter Settings]({{root_url}}/API_Reference/Web_API/filter_settings.html) commands.
 
 </call-out>


### PR DESCRIPTION
**Description of the change**: Removed Unnecessary Comma
**Reason for the change**: Reading experience
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/smtp-filters/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

