### PR TITLE
Fixed & Symbol to Be Consistent

### DIFF
--- a/content/docs/for-developers/sending-email/section-tags.md
+++ b/content/docs/for-developers/sending-email/section-tags.md
@@ -14,7 +14,7 @@ navigation:
 Section tags allow you to substitute in content in an SMTP message. Section tags are similar to [substitution tags]({{root_url}}/for-developers/sending-email/substitution-tags/) but are specific to the message, and not the recipient. You have to have a substitution tag value for **each** recipient, but you can have any number of section tags. Section tags can then contain Substitution tags for the recipient if needed. Section tags have to be contained within a Substitution tag since SendGrid needs to know which data to populate for the recipient.
 See the [Section Tag Example Walkthrough](#section-tag-example-walkthrough) below.
 
-It's possible & acceptable to use only Substitution tags. However, that method is not [DRY](http://en.wikipedia.org/wiki/Don%27t_repeat_yourself), and you may come against [message size limitations]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/).
+It's possible and acceptable to use only Substitution tags. However, that method is not [DRY](http://en.wikipedia.org/wiki/Don%27t_repeat_yourself), and you may come against [message size limitations]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/).
 
 The format of the SMTP API section tag has the form:
 ```json


### PR DESCRIPTION
**Description of the change**: Replaced & with and to be consistent
**Reason for the change**: Consistency with grammar
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/section-tags/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

