### PR TITLE
Fixed Typo

### DIFF
--- a/content/docs/for-developers/sending-email/substitution-tags.md
+++ b/content/docs/for-developers/sending-email/substitution-tags.md
@@ -145,7 +145,7 @@ In contrast, the resulting email for Jane will look like the following, with her
 ```
 
 ## 	SendGrid Defined Substitution Tags
- 	While the tags above are tags that you define at the time of your send in the SMTPAPI headers, SendGrid also offers [Unsubscribe Groups tags]({{root_url}}/ui/sending-email/create-and-edit-transactional-templates/) that have been pre-defined for you. You can use these tags within the content of your email, and you do not have to and should not, define them.
+ 	While the tags above are tags that you define at the time of your send in the SMTP API headers, SendGrid also offers [Unsubscribe Groups tags]({{root_url}}/ui/sending-email/create-and-edit-transactional-templates/) that have been pre-defined for you. You can use these tags within the content of your email, and you do not have to and should not, define them.
 
 ## 	Additional Resources
 


### PR DESCRIPTION
**Description of the change**: Put Space between SMTP and API
**Reason for the change**: Typo
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/substitution-tags/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

