### PR TITLE
Fixed Typo

### DIFF
--- a/content/docs/for-developers/sending-email/api-getting-started.md
+++ b/content/docs/for-developers/sending-email/api-getting-started.md
@@ -15,7 +15,7 @@ There are several ways you can get started with the SendGrid API
 
 ## 	Prerequisites
 
-These instructions describe how to send your first email using cURL calls. This is one of many ways to send email with the SendGrid - we also have [PHP](https://github.com/sendgrid/sendgrid-php), [Python](https://github.com/sendgrid/sendgrid-python), [Node.js](https://github.com/sendgrid/sendgrid-nodejs), [Java](https://github.com/sendgrid/sendgrid-java), [C#](https://github.com/sendgrid/sendgrid-csharp), [Go](https://github.com/sendgrid/sendgrid-go), and [Ruby](https://github.com/sendgrid/sendgrid-ruby) libraries.
+These instructions describe how to send your first email using cURL calls. This is one of many ways to send email with the SendGrid API - we also have [PHP](https://github.com/sendgrid/sendgrid-php), [Python](https://github.com/sendgrid/sendgrid-python), [Node.js](https://github.com/sendgrid/sendgrid-nodejs), [Java](https://github.com/sendgrid/sendgrid-java), [C#](https://github.com/sendgrid/sendgrid-csharp), [Go](https://github.com/sendgrid/sendgrid-go), and [Ruby](https://github.com/sendgrid/sendgrid-ruby) libraries.
 
 Before you can start using the API, you need to do the following:
 


### PR DESCRIPTION
**Description of the change**: Just added API after SendGrid to complete the sentence...unless it's meant to read "the SendGrid"
**Reason for the change**: to make sense 
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/api-getting-started/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

