### PR TITLE
added line to styleguide to follow US english spelling

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -20,6 +20,7 @@ We strive to make our documentation concise, clear, organized, and scannable.
 * Use conversational language and industry-standard terms when possible.
 * Contractions are OK and preferred.
 * Use bulleted lists and numbered steps where applicable.
+* Use US English spellling.  
 
 When documenting a UI action, make it **bold**. Avoid using the word "button" in the step and simply refer to the name on the UI element.
     For example, "Enter your username and password, and then click **login**."


### PR DESCRIPTION
**Description of the change**:
I have added the line as per #4422 .
Added a sentence to the styleguide saying to use US English spelling.
**Reason for the change**: 
issue #4422 
**Link to original source**:
https://github.com/sendgrid/docs/issues/4422

Closes #4422 

