### PR TITLE
Adding Missing Period + Reformatted Sentence

### DIFF
--- a/content/docs/ui/managing-contacts/formatting-a-csv.md
+++ b/content/docs/ui/managing-contacts/formatting-a-csv.md
@@ -63,7 +63,7 @@ Properly format any dates in your CSV. If you created your CSV with Excel and it
 
 Marketing Campaigns uses email as the unique identifier for each contact. So, if you upload the same email address multiple times, the [custom field]({{root_url}}/ui/managing-contacts/custom-fields/) data associated with that email will be updated with each upload to the most recently uploaded/updated information. This feature helps prevent you from accidentally emailing the user after they have unsubscribed.
 
-If it's necessary to have a duplicate entry in your contacts database, what you may want to do is add logic to set a custom field—based on the reason why you have duplicate emails in your system (for example multiple product lines)—and then [segment]({{root_url}}/ui/managing-contacts/managing-contact-list/) your user to be in lists based on those custom fields.
+If it's necessary to have a duplicate entry in your contacts database, you may want to add a custom field based on the reason why you have duplicate emails in your system (for example multiple product lines). Then, [segment]({{root_url}}/ui/managing-contacts/managing-contact-list/) your user to be in lists based on those custom fields.
 
 ## 	Troubleshooting
 

--- a/content/docs/ui/managing-contacts/formatting-a-csv.md
+++ b/content/docs/ui/managing-contacts/formatting-a-csv.md
@@ -30,7 +30,7 @@ You can also include [custom fields]({{root_url}}/ui/managing-contacts/custom-fi
 
 ### Header Row
 
-The first row of your CSV must be a header row containing labels identifying each column. Headers must only use letters, numbers, and underscores. **You cannot use spaces** If you add custom field data to your CSV, you can save some time when uploading by naming the columns the same as the custom fields you have previously defined.
+The first row of your CSV must be a header row containing labels identifying each column. Headers must only use letters, numbers, and underscores. **You cannot use spaces**. If you add custom field data to your CSV, you can save some time when uploading by naming the columns the same as the custom fields you have previously defined.
 
 SendGrid identifies individual contacts by their email address, so "email" must be one of the CSV headers. If you do not include the email column, SendGrid will not add any information to your contact database or list. Rows in your CSV without an email address in the email column will automatically fail, but will not cause the entire upload to fail.
 
@@ -63,7 +63,7 @@ Properly format any dates in your CSV. If you created your CSV with Excel and it
 
 Marketing Campaigns uses email as the unique identifier for each contact. So, if you upload the same email address multiple times, the [custom field]({{root_url}}/ui/managing-contacts/custom-fields/) data associated with that email will be updated with each upload to the most recently uploaded/updated information. This feature helps prevent you from accidentally emailing the user after they have unsubscribed.
 
-If it's necessary to have a duplicate entry in your contacts database What you may want to do is add logic to set a custom field, based on the reason why you have duplicate emails in your system (for example multiple product lines) and then [segment]({{root_url}}/ui/managing-contacts/managing-contact-list/) your user to be in lists based on those custom fields.
+If it's necessary to have a duplicate entry in your contacts database, what you may want to do is add logic to set a custom field—based on the reason why you have duplicate emails in your system (for example multiple product lines)—and then [segment]({{root_url}}/ui/managing-contacts/managing-contact-list/) your user to be in lists based on those custom fields.
 
 ## 	Troubleshooting
 


### PR DESCRIPTION
**Description of the change**: Added missing period. Another sentence was missing a comma, so I added and then included some additional punctuation to attempt to make the sentence easier to read (don't want too many commas).
**Reason for the change**: reading experience
**Link to original source**: https://sendgrid.com/docs/ui/managing-contacts/formatting-a-csv/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

