### PR TITLE
Reworded Typo + Deleted Unnecessary Comma

### DIFF
--- a/content/docs/ui/analytics-and-reporting/browser-comparison.md
+++ b/content/docs/ui/analytics-and-reporting/browser-comparison.md
@@ -17,7 +17,7 @@ Parent accounts will see aggregated statistics for their account and all subuser
 
 </call-out>
 
-Browser information can help optimize your email sending by showing you how different browser usage affects how your recipients interact with your email. As a result, you may want to compare one browser’s statistics to another to see differences or to see if a recent change has made an improvement. The browser comparison tool allows you to do this. You can change which metrics, date, or grouping by adjusting the [statistics filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters).
+Browser information can help optimize your email sending by showing you how different browser usage affects how your recipients interact with your email. As a result, you may want to compare one browser’s statistics to another to see differences or to see if a recent change has made an improvement. The browser comparison tool allows you to do this. You can change the metrics, date, or grouping by adjusting the [statistics filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters).
 
 ## 	Comparison Overview
 
@@ -33,7 +33,7 @@ You can remove individual browsers from the graph by clicking the button above a
 
 This table is titled “Figures for Delivered” and shows you the actual delivery numbers over time for each of the compared browsers.
 
-You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+You can also choose to show actual counts or percentages by clicking the corresponding button above and to the right of the table.
 
 ## 	Additional Resources
 


### PR DESCRIPTION
**Description of the change**: Reworded Typo + Deleted Unnecessary Comma (1) first change was changing the word "which" for "the" to make the sentence make sense. Then removed an unnecessary comma.
**Reason for the change**: reading experience
**Link to original source**: https://sendgrid.com/docs/ui/analytics-and-reporting/browser-comparison/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

