### PR TITLE
Fixed Typo, reword sentence, fixed numeral, comma

### DIFF
--- a/content/docs/ui/analytics-and-reporting/browser.md
+++ b/content/docs/ui/analytics-and-reporting/browser.md
@@ -17,11 +17,11 @@ Parent accounts will see aggregated statistics for their account and all subuser
 
 </call-out>
 
-The browser statistics report you which browsers, such as Safari, Firefox, and Chrome, that your recipients use to view your email.
+The browser statistics report which browsers (such as Safari, Firefox, and Chrome) your recipients use to view your email.
 
 <call-out>
 
-There are similarities between Device and Browser statistics and we are working on ways to consolidate the data. The current reasoning for two separate reports is that in some cases an open from a device can result with a click from a browser that represents the device (e.g. Open on an Iphone -> Click on an Iphone), in other cases an open from one device can result in a click from a different browser (e.g. an Open on a desktop computer -> Click on FireFox).
+There are similarities between Device and Browser statistics and we are working on ways to consolidate the data. The current reasoning for 2 separate reports is that in some cases an open from a device can result with a click from a browser that represents the device (e.g. Open on an Iphone -> Click on an Iphone), in other cases an open from one device can result in a click from a different browser (e.g. an Open on a desktop computer -> Click on FireFox).
 
 </call-out>
 
@@ -33,9 +33,9 @@ You can change which metrics, date, or grouping by adjusting the [statistics fil
 
 ## 	Figures
 
-The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your statistics (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April based on the browser, this is a great place to look.
+The figures table gives you all of the specific counts or percentages of each event according to how you’ve grouped your statistics (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April based on the browser, this is a great place to look.
 
-This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
+This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages by clicking the corresponding button above and to the right of the table.
 
 ## 	Additional Resources
 


### PR DESCRIPTION
**Description of the change**: Fixed a typo and then decided to reword the rest of the sentence to make it flow a bit smoother. Replaced "two" with the numeral "2." Removed unnecessary commas.
**Reason for the change**: reading experience. 
**Link to original source**: https://sendgrid.com/docs/ui/analytics-and-reporting/browser/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

