### PR TITLE
404 Not Found link

### DIFF
--- a/content/docs/ui/managing-contacts/custom-fields.md
+++ b/content/docs/ui/managing-contacts/custom-fields.md
@@ -97,4 +97,4 @@ If you do find that the custom field has an associated value on the contact’s 
 
 - [Substitution Tags]({{root_url}}/ui/sending-email/editor/#using-substitution-tags)
 - [Contacts]({{root_url}}/ui/managing-contacts/adding-contacts/)
-- [Creating and exporting segments]({{root_url}}/ui/manging-contacts/segmenting-your-contacts/)
+- [Segmenting your Contacts]({{root_url}}/ui/managing-contacts/segmenting-your-contacts/)


### PR DESCRIPTION
Previous link redirects to a 404 Not Found. Changed link to point to current "Segmenting your Contacts" doc, which contains info for creating and exporting a segment.

**Description of the change**: Changed link to point to current "Segmenting your Contacts" doc, which contains info for creating and exporting a segment.

**Reason for the change**: Previous link redirects to a 404 Not Found.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/ui/managing-contacts/custom-fields.md
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

