### PR TITLE
chore: fixed typos, converted stateful components to functional and made few code formatting

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import './About.scss'
+import React from 'react';
+import './About.scss';
 
 function About() {
     return (
@@ -8,7 +8,7 @@ function About() {
           Edit About component or pages/about.jsx to include your information.
         </h1>
       </div>
-    )
+    );
 }
 
-export default About
+export default About;

--- a/src/components/AsideMenu/index.jsx
+++ b/src/components/AsideMenu/index.jsx
@@ -57,7 +57,7 @@ class AsideMenu extends Component {
     return (
       <aside className="aside-nav">
         <div className="aside-nav__title is-size-h5">In the article</div>
-        {navItems.map((el) => {
+        {navItems.map(el => {
             const {
               id,
               textNode,

--- a/src/components/BreadCrumbs/index.jsx
+++ b/src/components/BreadCrumbs/index.jsx
@@ -95,7 +95,7 @@ class BreadCrumbs extends Component {
     return (
       <div>
         <ul className="breadcrumb">
-          {this.state.items.map((item) => {
+          {this.state.items.map(item => {
             const classes = `breadcrumb-item-${item.textNode.replace(' ', '-').toLowerCase()}`;
             return (
               <li key={item.textNode} className={classes} ><Link to={item.to}>{item.textNode}</Link></li>

--- a/src/components/NavMain/index.jsx
+++ b/src/components/NavMain/index.jsx
@@ -27,7 +27,7 @@ class NavMain extends Component {
         'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
         Authorization: `token ${token}`,
       },
-    }).then((response) => {
+    }).then(response => {
       if (!response.ok) {
         return false;
       }
@@ -37,7 +37,7 @@ class NavMain extends Component {
   }
 
   toggleMenu() {
-    this.setState({ showMenu: !this.state.showMenu });
+    this.setState(prevState => ({ showMenu: !prevState.showMenu }));
   }
 
   closeMenu() {

--- a/src/components/StatusPage/index.jsx
+++ b/src/components/StatusPage/index.jsx
@@ -12,7 +12,7 @@ class MainLayout extends Component {
 
   componentWillMount() {
     axios.get('https://3tgl2vf85cht.statuspage.io/api/v2/status.json')
-      .then((res) => {
+      .then(res => {
         this.setState({
           status: res.data,
         });

--- a/src/componentsMarkdown/Callout.jsx
+++ b/src/componentsMarkdown/Callout.jsx
@@ -1,19 +1,18 @@
 import React from 'react';
 
-export default class Callout extends React.Component {
-  render() {
-    // check for emplty callout
-    if (!this.props.children) {
+export default function Callout(props) {
+    // check for empty callout
+    if (!props.children) {
       return null;
     }
 
-    const classes = `callout callout--${this.props.type}`;
+    const classes = `callout callout--${props.type}`;
+  
     return (
       <div className={classes}>
-        {this.props.children.map(el => el)}
+        {props.children.map(el => el)}
       </div>
     );
-  }
 }
 
 Callout.defaultProps = {

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -4,12 +4,11 @@ import StatusPage from '../components/StatusPage';
 import Footer from '../components/Footer';
 import '../scss/style-guide.scss';
 
-export default class MainLayout extends React.Component {
-  render() {
+export default function MainLayout(props) {
     const {
       children,
       location,
-    } = this.props;
+    } = props;
 
     const pathClass = location.pathname.replace(/\/docs\\|\//g, '');
     const classNames = `docSearch-content docs-wrap ${pathClass}`;
@@ -23,5 +22,4 @@ export default class MainLayout extends React.Component {
         {renderFooter}
       </div>
     );
-  }
 }

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -2,22 +2,20 @@ import React from 'react';
 import Link from 'gatsby-link';
 import './404.scss';
 
-class NotFound extends React.Component {
-  render() {
-    return (
-      <div className="puppy-wrap">
-        <div className="container ta-center">
-          <div className="row not-found-content">
-            <div className="col-lg-8 col-offset-lg-2 col-md-8 col-offset-md-2 col-sm-12">
-              <h1>404 not found</h1>
-              <div className="m-bottom-8">Looks like you’ve fallen off the grid.</div>
-              <Link className="btn btn-secondary" to="/">Return to Knowledge Center</Link>
-            </div>
+function NotFound() {
+  return (
+    <div className="puppy-wrap">
+      <div className="container ta-center">
+        <div className="row not-found-content">
+          <div className="col-lg-8 col-offset-lg-2 col-md-8 col-offset-md-2 col-sm-12">
+            <h1>404 not found</h1>
+            <div className="m-bottom-8">Looks like you’ve fallen off the grid.</div>
+            <Link className="btn btn-secondary" to="/">Return to Knowledge Center</Link>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export default NotFound;

--- a/src/pages/api-reference.jsx
+++ b/src/pages/api-reference.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import './api-reference.scss';
 
-class stopLight extends React.Component {
-  render() {
-    return (
-      <div className="container container-stoplight">
-        <div className="iframe-container">
-          <iframe width="1500" height="1000" title="SendGrid V3 API" src="https://sendgrid.api-docs.io/v3.0/mail-send/v3-mail-send" frameBorder="0" />
-        </div>
+function stopLight() {
+  return (
+    <div className="container container-stoplight">
+      <div className="iframe-container">
+        <iframe width="1500" height="1000" title="SendGrid V3 API" src="https://sendgrid.api-docs.io/v3.0/mail-send/v3-mail-send" frameBorder="0" />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export default stopLight;


### PR DESCRIPTION
**Description of the change**:
Fixed Typo.
Converted stateful components to Functional components.

**Reason for the change**:
React 16.6 was just released, introducing React.memo. Quoting from the Motivation section of the RFC:

> Today in React, function components and PureComponent provide two different kinds of optimizations that can't be unified.
> 
> Function components let us avoid constructing a class instance. This benefits the initial render. Function components also tend to minify better than classes, which helps reduce the bundle size.
> 
> ⋮
> 
> By having memo as a first-class API in React itself, we can remove the need to make a choice between these optimizations. It makes it easy to memoize the output of function components without introducing other extra costs.
> 

Now by using React.memo(), functional components can be optimized.