### PR TITLE
Fixed broken link - unsubscribe groups was a 404

### DIFF
--- a/content/docs/ui/managing-contacts/building-your-contact-list.md
+++ b/content/docs/ui/managing-contacts/building-your-contact-list.md
@@ -53,5 +53,5 @@ SendGrid strongly recommends:
  ### 	Additional Resources
 
 - [Lists and Segmentation]({{root_url}}/ui/managing-contacts/segmenting-your-contacts/)
-- [Unsubscribe Groups]({{root_url}}/docs/ui/sending-email/index-suppressions/)
+- [Unsubscribe Groups]({{root_url}}/docs/ui/sending-email/unsubscribe-groups/) 
 - [Custom Fields]({{root_url}}/ui/managing-contacts/custom-fields/)


### PR DESCRIPTION
**Fixed broken link**:
**Unsuscribe groups page was giving 404**:
**https://sendgrid.com/docs/ui/managing-contacts/building-your-contact-list/**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

