### PR TITLE
Adding IP Warmup Doc in the tips

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -26,7 +26,7 @@ If you are using SendGrid through AWS, you cannot change your SendGrid username.
 
 <call-out>
 
-**Warm up your sending** - Since ISP spam filters look at volume as a significant factor when determining whether or not you are sending spam, we recommend that you begin sending a low to moderate volume, eventually working your way up to larger volumes. This gives the receiving email providers a chance to closely observe your sending habits and the way your customers treat the emails they receive from you.
+**Warm up your sending** - Since ISP spam filters look at volume as a significant factor when determining whether or not you are sending spam, we recommend that you begin sending a low to moderate volume, eventually working your way up to larger volumes. This gives the receiving email providers a chance to closely observe your sending habits and the way your customers treat the emails they receive from you. For more information, see [IP Warmup](https://sendgrid.com/docs/glossary/ip-warmup/).
 
 </call-out>
 


### PR DESCRIPTION
**Want to add a link to the IP Warmup Doc in the tip that talks about warmup**:
**Give more information to customers**:
**https://sendgrid.com/docs/glossary/ip-warmup/**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

