### PR TITLE
Typo Fix + Deleted Duplicate Tip

### DIFF
--- a/content/docs/ui/account-and-settings/teammates.md
+++ b/content/docs/ui/account-and-settings/teammates.md
@@ -10,7 +10,7 @@ layout: page
 navigation:
   show: true
 ---
-Teammates allows multiple users, or teammates, to send email from a single SendGrid account. It enables groups of users to with different roles and responsibilities to share one account, where each of these users has access to varying SendGrid features depending on their needs. By only giving your individual team members access to the features that they need to do their jobs, you can limit access to sensitive areas of your account. Teammates makes it incredibly easy to add, remove, and manage different users. Free and Essentials customers can create 1 teammate per account, and Pro customers or higher packages up to 1000 teammates.
+Teammates allows multiple users, or teammates, to send email from a single SendGrid account. It enables groups of users with different roles and responsibilities to share one account, where each of these users has access to varying SendGrid features depending on their needs. By only giving your individual team members access to the features that they need to do their jobs, you can limit access to sensitive areas of your account. Teammates makes it incredibly easy to add, remove, and manage different users. Free and Essentials customers can create 1 teammate per account, and Pro customers or higher packages up to 1000 teammates.
 
 ## 	Adding Teammates
 
@@ -43,12 +43,6 @@ Only administrator teammates may impersonate subusers.
 </call-out>
 
 ## 	Managing Teammates
-
-<call-out>
-
-Only administrator teammates may impersonate subusers.
-
-</call-out>
 
  ### 	Configuring permissions
 


### PR DESCRIPTION
**Description of the change**: Typo Fix + Deleted Duplicate Tip (1) in the first fix, I deleted the word "to" in the second sentence to fix the typo. (2) two tips were exactly the same. Deleted one.
**Reason for the change**: reading experience.
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/teammates/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

