### PR TITLE
callout for email insight & kotlin code sample

### DIFF
--- a/content/docs/for-developers/sending-email/v3-kotlin-code-example.md
+++ b/content/docs/for-developers/sending-email/v3-kotlin-code-example.md
@@ -1,0 +1,42 @@
+---
+layout: page
+weight: 0
+title: v3 API Kotlin Code Example
+group: api-v3
+navigation:
+  show: true
+---
+<call-out>
+
+We recommend using SendGrid Java, our client library, [available on GitHub](https://github.com/sendgrid/sendgrid-java), with full documentation.
+
+</call-out>
+
+<call-out>
+
+Do you have an [API Key](https://app.sendgrid.com/settings/api_keys) yet? If not, go get one. You're going to need it to integrate!
+
+</call-out>
+
+## Using SendGrid's Java Library
+```kotlin
+// using SendGrid's Java Library
+// https://github.com/sendgrid/sendgrid-java
+import com.sendgrid.*;
+import java.io.IOException;
+
+class Example {
+  private fun sendEmail() {
+
+        val sendgrid = SendGrid("SENDGRID_APIKEY")
+        val email = SendGrid.Email()
+
+        email.addTo("test@sendgrid.com")
+        email.setFrom("you@youremail.com")
+        email.setSubject("Sending with SendGrid is Fun")
+        email.setHtml("and easy to do anywhere, even with Kotlin")
+
+        val response = sendgrid.send(email)
+  }
+}
+```

--- a/content/docs/ui/analytics-and-reporting/categories.md
+++ b/content/docs/ui/analytics-and-reporting/categories.md
@@ -35,6 +35,12 @@ This table will refresh with new or adjusted data based on the various filters a
 
 [Using Categories with the SMTP API]({{root_url}}/for-developers/sending-email/categories/))
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/)

--- a/content/docs/ui/analytics-and-reporting/device.md
+++ b/content/docs/ui/analytics-and-reporting/device.md
@@ -69,6 +69,12 @@ You can remove individual devices from the list of devices at the top of this pa
 
 You can also choose to show actual counts or percentages by clicking the corresponding button above and to the right of the table.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)

--- a/content/docs/ui/analytics-and-reporting/geographic.md
+++ b/content/docs/ui/analytics-and-reporting/geographic.md
@@ -35,6 +35,12 @@ This table will refresh with new or adjusted data based on the various filters a
 
 To see only the figures from a specific geographic area, change the Activity Map to be either the world view or a specific country, then select the countries or states you want to see in the figures table using the buttons just above and to the right of the figures data.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)

--- a/content/docs/ui/analytics-and-reporting/global.md
+++ b/content/docs/ui/analytics-and-reporting/global.md
@@ -26,6 +26,12 @@ The figures table gives you all of the specific counts or percentages of each ev
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages by clicking the corresponding button above and to the right of the table.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)

--- a/content/docs/ui/analytics-and-reporting/google-analytics.md
+++ b/content/docs/ui/analytics-and-reporting/google-analytics.md
@@ -34,3 +34,9 @@ A few scenarios:
 - You link to your Facebook profile in your email. A recipient clicks the link, which will result in 1 SG **Click** , but no GA **Visits**.
 - A recipient clicks a link in your message, forwards it to their friend who also clicks a link, or they re-open it in a new browser/device. This will log 1 **Unique Click** , 2 **Clicks** , 2 **Visitors** , and 2 **Visits**.
 - A recipient clicks a link in your message, comes back an hour later, and clicks the same or a different link in the message to get back to your site. This will log 1 **Unique Click** , 2 **Clicks** , 1 **Visitor** , and 2 **Visits**.
+
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>

--- a/content/docs/ui/analytics-and-reporting/mailbox-provider-comparison.md
+++ b/content/docs/ui/analytics-and-reporting/mailbox-provider-comparison.md
@@ -36,6 +36,12 @@ This table will be titled “Figures for Delivered” and will show you the actu
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Mailbox Provider Stats](https://app.sendgrid.com/statistics/mailbox_provider)


### PR DESCRIPTION
**Description of the change**: Add Kotlin sample code to documentation with Java Library. Add callout about Email Insight Service.
**Reason for the change**: Kotlin is alternative of Java. Send grid also has Email Insight Service.
**Link to original source**: https://github.com/sendgrid/docs/issues/4577

- [x] Geographic Statistics
- [x] Global Statistics 
- [x] Google Analytics and SendGrid Statistics 
- [x] Mailbox Provider Comparison
- [x] Category Statistics
- [x] Device Statistics

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

