### PR TITLE
Add Email Activity Feed callout

### DIFF
--- a/content/docs/ui/analytics-and-reporting/email-activity-feed.md
+++ b/content/docs/ui/analytics-and-reporting/email-activity-feed.md
@@ -165,6 +165,12 @@ In addition to viewing the email activity associated with your account by recipi
    This triggers an email to the email address associated with your SendGrid account.
 1. Open the email and then click **Download**.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Email Activity API](https://sendgrid.api-docs.io/v3.0/email-activity/filter-all-messages)


### PR DESCRIPTION
Signed-off-by: Arthur Novaes <arthurnovaes9@gmail.com>

**Description of the change**: Add a new Email Insights Service to Email Activity Feed doc.
**Reason for the change**: We need to add this callout to these pages.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/ui/analytics-and-reporting/email-activity-feed.md
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Don't close yet, but is for #4577 issue

- [x] Email Activity Feed

