### PR TITLE
Add category-comparision and marketing-campaigns-stats callout for em…

### DIFF
--- a/content/docs/ui/analytics-and-reporting/category-comparison.md
+++ b/content/docs/ui/analytics-and-reporting/category-comparison.md
@@ -51,6 +51,12 @@ To change this graph to see another metric, click the button inline with the gra
 
 You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Subusers]({{root_url}}/ui/account-and-settings/subusers/)

--- a/content/docs/ui/analytics-and-reporting/marketing-campaigns-stats.md
+++ b/content/docs/ui/analytics-and-reporting/marketing-campaigns-stats.md
@@ -86,6 +86,12 @@ In addition to creating a dynamic segment based on campaign engagement as descri
 <br>A real-time list of all recipients who either opened your campaign, or clicked a link within your campaign appears.
 1. Click **Export CSV**.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Sending a Campaign]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/)


### PR DESCRIPTION
**Description of the change**: Add category-comparision and marketing-campaigns-stats callout for email insight
**Reason for the change**: We need to add this callout to these pages.
**Link to original source**: https://github.com/sendgrid/docs/tree/develop/content/docs/ui/analytics-and-reporting
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Don't close yet, but is for #4577 issue

- [x]  Category Comparison Statistics
- [x]  Marketing Campaigns Statistics

Signed-off-by: Arthur Novaes <arthurnovaes9@gmail.com>
