### PR TITLE
Add device statistics callout

### DIFF
--- a/content/docs/ui/analytics-and-reporting/device.md
+++ b/content/docs/ui/analytics-and-reporting/device.md
@@ -69,6 +69,12 @@ You can remove individual devices from the list of devices at the top of this pa
 
 You can also choose to show actual counts or percentages by clicking the corresponding button above and to the right of the table.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)

--- a/content/docs/ui/analytics-and-reporting/email-activity-feed.md
+++ b/content/docs/ui/analytics-and-reporting/email-activity-feed.md
@@ -165,12 +165,6 @@ In addition to viewing the email activity associated with your account by recipi
    This triggers an email to the email address associated with your SendGrid account.
 1. Open the email and then click **Download**.
 
-<call-out>
-
-Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
-
-</call-out>
-
 ## 	Additional Resources
 
 - [Email Activity API](https://sendgrid.api-docs.io/v3.0/email-activity/filter-all-messages)

--- a/content/docs/ui/analytics-and-reporting/email-activity-feed.md
+++ b/content/docs/ui/analytics-and-reporting/email-activity-feed.md
@@ -165,6 +165,12 @@ In addition to viewing the email activity associated with your account by recipi
    This triggers an email to the email address associated with your SendGrid account.
 1. Open the email and then click **Download**.
 
+<call-out>
+
+Want deeper data and insights? With [SendGrid Email Insights Reports](https://go.sendgrid.com/Email-Insights-Reports.html?utm_source=docs), you’ll get access to more data about your email performance plus customized insights from a deliverability consultant.
+
+</call-out>
+
 ## 	Additional Resources
 
 - [Email Activity API](https://sendgrid.api-docs.io/v3.0/email-activity/filter-all-messages)


### PR DESCRIPTION
Description of the change: Add device-statistics callout for email insight
Reason for the change: We need to add this callout to these pages.
Link to original source: https://github.com/sendgrid/docs/tree/develop/content/docs/ui/analytics-and-reporting

Don't close yet, but is for #4577 issue

- [x] Device Statistics


Signed-off-by: Arthur Novaes arthurnovaes9@gmail.com

