### PR TITLE
Fix markdown syntax error

### DIFF
--- a/content/docs/ui/account-and-settings/yahoo-dmarc.md
+++ b/content/docs/ui/account-and-settings/yahoo-dmarc.md
@@ -14,7 +14,7 @@ navigation:
 
 Yahoo mail domains are starting to embrace [DMARC](http://sendgrid.com/blog/dmarc-domain-based-message-authentication-reporting-conformance/) more explicitly. You may have seen an increase in bounce messages with the following explanation:
 
-**"554 5.7.9 Message not accepted for policy reasons. See http://postmaster.yahoo.com/errors/postmaster-28.html"  **
+**"554 5.7.9 Message not accepted for policy reasons. See http://postmaster.yahoo.com/errors/postmaster-28.html"**
 
 This is because Yahoo no longer accepts messages where the From domain is a Yahoo mail domain, and the message originates from a non-approved Yahoo mail domain server/service. This is a security measure they have implemented to help reduce potential address spoofing of their mail domains. 
 


### PR DESCRIPTION
**Description of the change**: Corrects the use of markup asterisks in the yahoo-dmarc file.
**Reason for the change**: Existing markup does not make the text bold.
**Link to original source**: https://github.com/sendgrid/docs/blob/develop/content/docs/ui/account-and-settings/yahoo-dmarc.md