### PR TITLE
Fix typo

### DIFF
--- a/content/docs/glossary/fqdn
+++ b/content/docs/glossary/fqdn
@@ -11,7 +11,7 @@ navigation:
   show: true
 ---
 
-A Fully Qualified Domain Name (FQDN) is the complete domain name for a specific location in the Domain Name System (DNS) heirarchy. This is sometimes referred to as the absolute domain name.
+A Fully Qualified Domain Name (FQDN) is the complete domain name for a specific location in the Domain Name System (DNS) hierarchy. This is sometimes referred to as the absolute domain name.
 
 The hierarchy can be broken down into a few parts:
 


### PR DESCRIPTION
**Description of the change**:

Fix typo in `content/docs/glossary/fqdn`.
I did before, but missed one more typo.
