### PR TITLE
Updated link

### DIFF
--- a/content/docs/ui/account-and-settings/subusers.md
+++ b/content/docs/ui/account-and-settings/subusers.md
@@ -154,5 +154,5 @@ Deleting a Subuser account cannot be undone. Please make sure that you are ready
 
 ## 	Additional Resources
 
-- [Assigning a Domain Whitelabel to a subuser]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/#assigning-a-subuser/)
+- [Assigning a Domain Whitelabel to a subuser]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/#assigning-a-subuser)
 - [Teammates]({{root_url}}/ui/account-and-settings/teammates/)


### PR DESCRIPTION
Updated link to redirect to "Assigning a subuser" section of doc.

**Description of the change**: Updated link to redirect to "Assigning a subuser" section of doc
**Reason for the change**: Previous link was redirecting to "How to set up domain authentication" doc
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/subusers/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

