### PR TITLE
Unsubscribe module for dynamic trans template

### DIFF
--- a/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
+++ b/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
@@ -29,7 +29,7 @@ Before you create and send an email using a dynamic transactional template you n
 
 ##  Unsubscribe modules for dynamic transactional templates
 
-If you want to create a static unsubscribe module for a dynamic transactional template, please review the following:
+If you want to create a static unsubscribe module for a dynamic transactional template, you can copy the contents of an unsubscribe module into a text module and then replace the sender name and address substitution tags with the desired information as shown below.
 
 ![]({{root_url}}/img/dynamic-transactional-template-unsubscribe.gif "Create a static unsubscribe module for dynamic transactional templates")
 

--- a/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
+++ b/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
@@ -29,7 +29,7 @@ Before you create and send an email using a dynamic transactional template you n
 
 ##  Unsubscribe modules for dynamic transactional templates
 
-If you want to create a static unsubscribe module for a dynamic transactional template, you can copy the contents of an unsubscribe module into a text module and then replace the sender name and address substitution tags with the desired information as shown below.
+If you want to create a static unsubscribe module for a dynamic transactional template, you can copy the contents of an unsubscribe module into a text module and then replace the sender name and address substitution tags with the desired information or handlebars syntax as shown below.  
 
 ![]({{root_url}}/img/dynamic-transactional-template-unsubscribe.gif "Create a static unsubscribe module for dynamic transactional templates")
 

--- a/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
+++ b/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
@@ -27,6 +27,12 @@ Before you create and send an email using a dynamic transactional template you n
 4. Select an editor and click **Continue**.
 5. Design your template. For more information on using Handlebars, see [Using handlebars]({{root_url}}/ui/sending-email/using-handlebars/).
 
+##  Unsubscribe modules for dynamic transactional templates
+
+If you want to create a static unsubscribe module for a dynamic transactional template, please review the following:
+
+![]({{root_url}}/img/dynamic-transactional-template-unsubscribe.gif "Create a static unsubscribe module for dynamic transactional templates")
+
 For sample templates that that include examples of receipts, password resets, account activations, newsletters, and sale notifications, check out the [dynamic-template section of our email template's GitHub repo](https://github.com/sendgrid/email-templates/tree/master/dynamic-templates).
 
 The cURL calls on this page use the [receipt example template](https://github.com/sendgrid/email-templates/tree/master/dynamic-templates/receipt).


### PR DESCRIPTION
**Description of the change**: To help users create a static unsubscribe module when working with dynamic transactional templates
**Reason for the change**: Documentation is unclear - investigation by the customer may lead them to improperly add a sender under Marketing Campaigns per the design editor docs
**Link to original source**:https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

