### PR TITLE
Updated text

### DIFF
--- a/content/docs/ui/sending-email/warming-up-an-ip-address.md
+++ b/content/docs/ui/sending-email/warming-up-an-ip-address.md
@@ -419,5 +419,5 @@ Having a dedicated IP allows you to control your own reputation completely, and 
 ## 	Additional Resources
 
 - [Adding a dedicated IP]({{root_url}}/ui/account-and-settings/dedicated-ip-addresses/)
-- [API IP Access Management]({{root_url}}/ui/account-and-settings/ip-access-management/)
+- [IP Access Management]({{root_url}}/ui/account-and-settings/ip-access-management/)
 - [SendGrid billing information]({{root_url}}/ui/account-and-settings/billing/)


### PR DESCRIPTION
Updated text to reflect the link it's redirecting to. There is an "API IP Access Management" doc but it makes more sense to have it point to "IP Access Management" doc instead.

**Description of the change**: Updated text to reflect the link it's redirecting to.
**Reason for the change**: There is an "API IP Access Management" doc but it makes more sense to have it point to "IP Access Management" doc instead.
**Link to original source**: https://sendgrid.com/docs/ui/sending-email/warming-up-an-ip-address/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

