### PR TITLE
added link to Events doc

### DIFF
--- a/content/docs/glossary/reconfirmation.md
+++ b/content/docs/glossary/reconfirmation.md
@@ -22,7 +22,7 @@ important and those that aren't. This is almost entirely determined by whether o
 or even better, if they reply. This increases the ante for senders to send content that recipients will engage with.
 
 Thankfully, SendGrid provides a window into the problem. Senders are able to make use of
-the Event API which allows senders to know if recipients have opened and/or clicked on their emails. Lower tier plans
+the [Event API]({{root_url}}/for-developers/tracking-events/event/) which allows senders to know if recipients have opened and/or clicked on their emails. Lower tier plans
 can view this information under the Email Activity tab. With these tools, a sender can ensure that they are not sending
 to 2 major pitfalls: [spam traps]({{root_url}}/docs/glossary/spam-traps) or recipients that are likely to acknowledge the email as [spam]({{root_url}}/docs/glossary/spam/). Sending to either of
 these recipients, results in the receiving mailbox to believe that they are uninterested and therefore, leads to diversion of emails to the unimportant or spam folders.
@@ -58,7 +58,7 @@ These emails remind your recipients of your services they once opted
 in, and politely ask for the recipient's permission to continue sending
 emails.
 
-## 	How to Reconfirm
+## 	How to Reconfirm?
  	
 Send an email with two links: one link to re-opt in the recipient,
 and the other link to opt-out the recipient. If they do not

--- a/content/docs/glossary/reconfirmation.md
+++ b/content/docs/glossary/reconfirmation.md
@@ -58,7 +58,7 @@ These emails remind your recipients of your services they once opted
 in, and politely ask for the recipient's permission to continue sending
 emails.
 
-## 	How to Reconfirm?
+## 	How do I Reconfirm?
  	
 Send an email with two links: one link to re-opt in the recipient,
 and the other link to opt-out the recipient. If they do not


### PR DESCRIPTION
**Description of the change**: linked Events API doc, added missing `?`
**Reason for the change**:
**Link to original source**: [Reconfirmation](https://sendgrid.com/docs/glossary/reconfirmation/)
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

