### PR TITLE
removed quotes around UNIX_timestamp

### DIFF
--- a/content/docs/for-developers/sending-email/curl-examples.md
+++ b/content/docs/for-developers/sending-email/curl-examples.md
@@ -50,7 +50,7 @@ curl --request POST \
   --url https://api.sendgrid.com/v3/mail/send \
   --header 'authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
-  --data '{"personalizations": [{"to": [{"email": "recipient@example.com"}]}],"from": {"email": "sendeexampexample@example.com"},"subject":"Hello, World!","content": [{"type": "text/plain","value": "Heya!"}], "send_at" : "UNIX_TIMESTAMP_HERE"}'
+  --data '{"personalizations": [{"to": [{"email": "recipient@example.com"}]}],"from": {"email": "sendeexampexample@example.com"},"subject":"Hello, World!","content": [{"type": "text/plain","value": "Heya!"}], "send_at" : UNIX_TIMESTAMP_HERE}'
 ```
 
 ## 	Scheduling and Cancelling an Email
@@ -71,7 +71,7 @@ curl --request POST \
   --url https://api.sendgrid.com/v3/mail/send \
   --header 'authorization: Bearer YOUR_API_KEY' \
   --header 'Content-Type: application/json' \
-  --data '{"personalizations": [{"to": [{"email": "recipient@example.com"}]}],"from": {"email": "sendeexampexample@example.com"},"subject":"Hello, World!","content": [{"type": "text/plain","value": "Heya!"}], "send_at" : "UNIX_TIMESTAMP_HERE", "batch_id" : "YOUR_BATCH_ID"}'
+  --data '{"personalizations": [{"to": [{"email": "recipient@example.com"}]}],"from": {"email": "sendeexampexample@example.com"},"subject":"Hello, World!","content": [{"type": "text/plain","value": "Heya!"}], "send_at" : UNIX_TIMESTAMP_HERE, "batch_id" : "YOUR_BATCH_ID"}'
 ```
 
 **Step 3: Cancel the scheduled email**


### PR DESCRIPTION
value should be passed as integer rather than string

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

