### PR TITLE
Plain Content Verbiage

### DIFF
--- a/content/docs/ui/account-and-settings/mail.md
+++ b/content/docs/ui/account-and-settings/mail.md
@@ -136,7 +136,9 @@ This setting wraps an HTML template around your email content. This can be usefu
 
 ## 	Plain Content
 
-The Plain Content setting will automatically convert any plain text emails that you send to HTML before sending.
+The Plain Content setting will automatically convert any plain text emails that you send to HTML before sending (if disabled).
+
+Turn *on* if you don't want to convert your plain text email to HTML.
 
 <call-out>
 


### PR DESCRIPTION
Within Mail Settings > Plain Content the messaging states "Turn on if you don't want to convert your plain text email to HTML" however our docs state "The Plain Content setting will automatically convert any plain text emails that you send to HTML before sending."

**Description of the change**: See above
**Reason for the change**: Confusing verbiage
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/mail/#plain-content
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

