### PR TITLE
Parse events in Activity Feed

### DIFF
--- a/content/docs/ui/analytics-and-reporting/email-activity-feed.md
+++ b/content/docs/ui/analytics-and-reporting/email-activity-feed.md
@@ -93,6 +93,12 @@ The Email Activity feed allows you to view specific information about messages s
   </tr>
 </table>
 
+<call-out>
+  
+  Warning: Parse events are not available within the Activity Feed. Please utilize your parse endpoint to determine whether or not these events are posting properly. 
+  
+</call-out>
+
 ## 	Filtering email activity
 
 The Email Activity feed lists each email sent. Click on each email to view the current list of triggered events for that email. Use our basic or advanced search to filter by email subject, recipients, or event types.


### PR DESCRIPTION
Parse events no longer available in new activity feed. Check parse endpoint for posted events.

**Description of the change**: ^^
**Reason for the change**: Old activity feed showed parse events. Customers with new feed are expecting this same behavior and reach out confused when they cannot find them.
**Link to original source**: https://sendgrid.com/docs/ui/analytics-and-reporting/email-activity-feed/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

