### PR TITLE
curl command will include content to avoid error

### DIFF
--- a/content/docs/for-developers/sending-email/api-getting-started.md
+++ b/content/docs/for-developers/sending-email/api-getting-started.md
@@ -55,7 +55,7 @@ curl --request POST \
 --url https://api.sendgrid.com/v3/mail/send \
 --header 'authorization: Bearer <<YOUR_API_KEY>>' \
 --header 'content-type: application/json' \
---data '{"personalizations":[{"to":[{"email":"john.doe@example.com","name":"John Doe"}],"subject":"Hello, World!"}],"from":{"email":"sam.smith@example.com","name":"Sam Smith"},"reply_to":{"email":"sam.smith@example.com","name":"Sam Smith"}}'
+--data '{"personalizations":[{"to":[{"email":"john.doe@example.com","name":"John Doe"}],"subject":"Hello, World!"}],"content": [{"type": "text/plain", "value": "Heya!"}],"from":{"email":"sam.smith@example.com","name":"Sam Smith"},"reply_to":{"email":"sam.smith@example.com","name":"Sam Smith"}}'
 ```
 
 1. Copy the curl example above.


### PR DESCRIPTION
**Description of the change**: Sample curl command failed with an error that a content block is missing - fixed.
**Reason for the change**: Curl command on the current page results in an error
```
{"errors":[{"message":"Unless a valid template_id is provided, the content parameter is required. There must be at least one defined content block. We typically suggest both text/plain and text/html blocks are included, but only one block is required.","field":"content","help":"http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.content"}]}
```
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

