### PR TITLE
Remove Inaccuracy Related to Parent/Subuser Stats

### DIFF
--- a/content/docs/ui/analytics-and-reporting/stats-overview.md
+++ b/content/docs/ui/analytics-and-reporting/stats-overview.md
@@ -11,12 +11,6 @@ navigation:
   show: true
 ---
 
-<call-out>
-
-Parent accounts will see aggregated statistics for their account and all subuser accounts. Subuser accounts will only see their own statistics.
-
-</call-out>
-
 <p>
 Tracking your emails is an important part of being a good sender and learning about how your users interact with your email. This includes everything from basics of clicks and opens to looking at which browsers and mailbox providers your customers use.
 </p>


### PR DESCRIPTION
Lines starting at 14 were removed due to inaccuracy of statement claiming that parent statistics will show aggregated numbers of the parent as well as all of the sub users.  At this time, the parent account will only display its own statistics and the sub users have the same.

**Description of the change**:  See above.
**Reason for the change**: Inaccuracies in docs information.
**Link to original source**: https://sendgrid.com/docs/ui/analytics-and-reporting/stats-overview/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

