### PR TITLE
Remove Inaccuracy Related to Parent/Subuser Stats

### DIFF
--- a/content/docs/ui/analytics-and-reporting/categories.md
+++ b/content/docs/ui/analytics-and-reporting/categories.md
@@ -11,12 +11,6 @@ navigation:
   show: true
 ---
 
-<call-out>
-
-Parent accounts will see aggregated statistics for their account and all subuser accounts. Subuser accounts will only see their own statistics.
-
-</call-out>
-
 Categories can help organize your email analytics by enabling you to “tag” emails by type. Just as you can view the statistics on all your [email activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/), you can go a step further and view the statistics broken down to a particular category.
 
 The actual statistics included vary depending upon your [account settings]({{root_url}}/ui/account-and-settings/account/). Emails sent, bounces, and spam reports will always get tracked. Unsubscribes, clicks, and opens require that the associated settings are enabled.


### PR DESCRIPTION
Lines starting at 14 were removed due to inaccuracy of statement claiming that parent statistics will show aggregated numbers of the parent as well as all of the sub users.  At this time, the parent account will only display its own statistics and the sub users have the same.

**Description of the change**: See above.
**Reason for the change**: Inaccuracies in docs information.
**Link to original source**: https://sendgrid.com/docs/ui/analytics-and-reporting/categories/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

