### PR TITLE
Change `email_activity.read` to `message.read`

### DIFF
--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -134,7 +134,7 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 ]
 {% endcodeblock %}
 
-{% info %}A fewof our larger customers still use the older `email_activity.read` scope instead of `message.read`. If you get an error with `message.read`, try `email_activity.read` instead.{% endinfo %}
+{% info %}If you get an error with `message.read`, try `email_activity.read` instead.{% endinfo %}
 
 {% anchor h2 %}IPs{% endanchor %}
 {% codeblock %}

--- a/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
+++ b/source/API_Reference/Web_API_v3/API_Keys/api_key_permissions_list.html
@@ -119,7 +119,7 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
 {% anchor h2 %}Stats{% endanchor %}
 {% codeblock %}
 "scopes": [
-  "email_activity.read",
+  "message.read",
   "stats.read",
   "stats.global.read",
   "browsers.stats.read",
@@ -133,6 +133,8 @@ As explained in the <a href="{{root_url}}/Classroom/Basics/API/api_key_permissio
   "clients.webmail.stats.read"
 ]
 {% endcodeblock %}
+
+{% info %}A fewof our larger customers still use the older `email_activity.read` scope instead of `message.read`. If you get an error with `message.read`, try `email_activity.read` instead.{% endinfo %}
 
 {% anchor h2 %}IPs{% endanchor %}
 {% codeblock %}


### PR DESCRIPTION
Most users have EASE, so we should be providing the most-appropriate scope for this. `email_activity.read` is outdated, and using it throws an obscure error, making a really really terrible UX.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

