### PR TITLE
Turn # of teammates into a Tip

### DIFF
--- a/content/docs/ui/account-and-settings/teammates.md
+++ b/content/docs/ui/account-and-settings/teammates.md
@@ -12,6 +12,12 @@ navigation:
 ---
 Teammates allows multiple users, or teammates, to send email from a single SendGrid account. It enables groups of users with different roles and responsibilities to share one account, where each of these users has access to varying SendGrid features depending on their needs. By only giving your individual team members access to the features that they need to do their jobs, you can limit access to sensitive areas of your account. Teammates makes it incredibly easy to add, remove, and manage different users. Free and Essentials customers can create 1 teammate per account, and Pro customers or higher packages up to 1000 teammates.
 
+<call-out>
+
+Free and Essentials customers can create 1 teammate per account, and Pro customers or higher packages up to 1000 teammates.
+
+</callout>
+
 ## 	Adding Teammates
 
 _To invite a Teammate to your account:_


### PR DESCRIPTION
Pulled the last sentence "Free and Essentials customers can create 1 teammate per account, and Pro customers or higher packages up to 1000 teammates." from the first paragraph and turned it into a Tip callout to make more visible for customers.

**Description of the change**: See above
**Reason for the change**: More visible for users, to avoid getting lost in paragraph.
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/teammates/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

