### PR TITLE
Add Event Tracking to Academy Callouts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -74,12 +74,6 @@ module.exports = {
       },
     },
     {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        trackingId: config.googleAnalyticsID,
-      },
-    },
-    {
       resolve: 'gatsby-plugin-nprogress',
       options: {
         color: config.themeColor,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,7 +47,7 @@ module.exports = {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: 'GTM-PQC59L',
-        includeInDevelopment: true,
+        includeInDevelopment: false,
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,7 +47,7 @@ module.exports = {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: 'GTM-PQC59L',
-        includeInDevelopment: false,
+        includeInDevelopment: true,
       },
     },
     {

--- a/src/componentsMarkdown/AcademyLink.jsx
+++ b/src/componentsMarkdown/AcademyLink.jsx
@@ -3,20 +3,20 @@ import config from '../../data/SiteConfig';
 
 const dataLayer = window.dataLayer || [];
 
-function handleClick() {
-  dataLayer.push({
-    event: 'Event',
-    eventCategory: 'Academy Callout',
-    eventAction: 'Click',
-    eventLabel: 'CTA Click',
-    eventValue: 'test',
-  });
-}
-
 export default function AcademyLink(props) {
   // check for empty AcademyLink
   if (!props.children) {
     return null;
+  }
+
+  function handleClick() {
+    dataLayer.push({
+      event: 'customEvent',
+      eventCategory: 'Academy Callout',
+      eventAction: 'Click',
+      eventLabel: 'Go to Course',
+      eventValue: `${props.courselink}`,
+    });
   }
 
   return (

--- a/src/componentsMarkdown/AcademyLink.jsx
+++ b/src/componentsMarkdown/AcademyLink.jsx
@@ -1,6 +1,18 @@
 import React from 'react';
 import config from '../../data/SiteConfig';
 
+const dataLayer = window.dataLayer || [];
+
+function handleClick() {
+  dataLayer.push({
+    event: 'Event',
+    eventCategory: 'Academy Callout',
+    eventAction: 'Click',
+    eventLabel: 'CTA Click',
+    eventValue: 'test',
+  });
+}
+
 export default function AcademyLink(props) {
   // check for empty AcademyLink
   if (!props.children) {
@@ -11,7 +23,12 @@ export default function AcademyLink(props) {
     <div className="academy-callout">
       <div className="academy-callout__copy">
         {props.children.map(el => el)}
-        <a href={props.courselink}>GO TO COURSE →</a>
+        <a
+          href={props.courselink}
+          onClick={handleClick}
+        >
+          GO TO COURSE →
+        </a>
       </div>
       <div className="academy-callout__img" style={{ backgroundImage: `url(${config.envPrefix + props.img})` }} />
     </div>

--- a/src/componentsMarkdown/AcademyLink.jsx
+++ b/src/componentsMarkdown/AcademyLink.jsx
@@ -1,36 +1,42 @@
 import React from 'react';
 import config from '../../data/SiteConfig';
 
-const dataLayer = window.dataLayer || [];
-
-export default function AcademyLink(props) {
-  // check for empty AcademyLink
-  if (!props.children) {
-    return null;
+class AcademyLink extends React.Component {
+  componentDidMount() {
+    this.dataLayer = window.dataLayer || [];
   }
 
-  function handleClick() {
-    dataLayer.push({
+  handleClick = () => {
+    this.dataLayer.push({
       event: 'customEvent',
       eventCategory: 'Academy Callout',
       eventAction: 'Click',
       eventLabel: 'Go to Course',
-      eventValue: `${props.courselink}`,
+      eventValue: `${this.props.courselink}`,
     });
   }
 
-  return (
-    <div className="academy-callout">
-      <div className="academy-callout__copy">
-        {props.children.map(el => el)}
-        <a
-          href={props.courselink}
-          onClick={handleClick}
-        >
-          GO TO COURSE →
-        </a>
+  render() {
+    // check for empty AcademyLink
+    if (!this.props.children) {
+      return null;
+    }
+
+    return (
+      <div className="academy-callout">
+        <div className="academy-callout__copy">
+          {this.props.children.map(el => el)}
+          <a
+            href={this.props.courselink}
+            onClick={this.handleClick}
+          >
+            GO TO COURSE →
+          </a>
+        </div>
+        <div className="academy-callout__img" style={{ backgroundImage: `url(${config.envPrefix + this.props.img})` }} />
       </div>
-      <div className="academy-callout__img" style={{ backgroundImage: `url(${config.envPrefix + props.img})` }} />
-    </div>
-  );
+    );
+  }
 }
+
+export default AcademyLink;


### PR DESCRIPTION
**Description of the change**:
I've set up a dataLayer function that fires when the Go to Course link is clicked. This sends Google Analytics event tracking information to the datalayer which gets sent to Google Tag Manager. So we should start seeing events in GA.

The event is structured in the following format:

event: 'customEvent',
eventCategory: 'Academy Callout',
eventAction: 'Click',
eventLabel: 'Go to Course',
eventValue: RISE URL 

We were also double counting Google Analytics traffic since that is being loaded on the docs site twice. I've removed the hard-coded GA number so it is only being loaded via Google Tag Manager now.

**Reason for the change**:
Request from LX team, and also to fix the double GA counting.

Closes: https://app.asana.com/0/959084297721550/947351594969261
