### PR TITLE
Update unique-arguments.md

### DIFF
--- a/content/docs/for-developers/sending-email/unique-arguments.md
+++ b/content/docs/for-developers/sending-email/unique-arguments.md
@@ -13,6 +13,12 @@ navigation:
 
 The SMTP API JSON string allows you to attach an unlimited number of unique arguments to your email **up to 10,000 bytes**. The arguments are used only for tracking. They can be retrieved through the [Event API]({{root_url}}/for-developers/tracking-events/event/) or the [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/) page.
 
+<call-out type="warning">
+
+When passing args please make sure to only use strings as shown in our examples.
+
+</call-out>
+
 These arguments can be added using a JSON string like this:
 
 ```json


### PR DESCRIPTION
Needed to add a warning about only passing args as strings.