### PR TITLE
Update how-to-send-an-email-with-dynamic-transactional-templates.md

### DIFF
--- a/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
+++ b/content/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates.md
@@ -25,7 +25,7 @@ Before you create and send an email using a dynamic transactional template you n
 2. Add a unique template name and then click **Save**.
 3. To begin editing your new template, click **Add Version**.
 4. Select an editor and click **Continue**.
-5. Design your template. For more information on using Handlebars, see [Using Handlebars]({{root_url}}/docs/ui/sending-email/using-handlebars/).
+5. Design your template. For more information on using Handlebars, see [Using Handlebars]({{root_url}}/ui/sending-email/using-handlebars/).
 
 ##  Unsubscribe modules for dynamic transactional templates
 


### PR DESCRIPTION
**Description of the change**:  Removed "docs/" from link to handlebars redirect link because when the {{root_url}} value gets input, it already contains that and it ends up making the link "...docs/docs/ui...", breaking the link.
**Reason for the change**:  Links failed to work.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

