### PR TITLE
451 second error

### DIFF
--- a/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
+++ b/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
@@ -52,6 +52,11 @@ Each SMTP call you make returns a response. `200` responses are usually success 
     <td>The message simply failed, usually due to a far-end server error. We continue to retry messages for up to 72 hours.</td>
   </tr>
   <tr>
+    <td>451</td>
+    <td>`Authentication failed: Maximum credits exceeded`</td>
+    <td>There is a credit limit of emails per day enforced in error. Contact support to remove that limit.</td>
+  </tr>
+  <tr>
     <td>452</td>
     <td>`Too many recipients received this hour (throttled)`</td>
     <td>The message has been deferred due to insufficient system storage. We continue to retry messages for up to 72 hours.</td>

--- a/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
+++ b/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
@@ -54,7 +54,7 @@ Each SMTP call you make returns a response. `200` responses are usually success 
   <tr>
     <td>451</td>
     <td>`Authentication failed: Maximum credits exceeded`</td>
-    <td>There is a credit limit of emails per day enforced in error. Contact support to remove that limit.</td>
+    <td>There is a credit limit of emails per day enforced in error. [Contact support](https://support.sendgrid.com/hc/en-us) to remove that limit.</td>
   </tr>
   <tr>
     <td>452</td>


### PR DESCRIPTION
**Description of the change**: An error message is missing.
**Reason for the change**: Add the missing message error (that have the same error code as an actual error)
**Link to original source**: No link availabe. One of our customer get that error and had to ask support to get it fixed.
