### PR TITLE
I changed setup into set up

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-with-transactional-emails.md
+++ b/content/docs/for-developers/sending-email/getting-started-with-transactional-emails.md
@@ -29,7 +29,7 @@ Read more about Transactional Email in the [SendGrid Guide]({{root_url}}/glossar
 
 ## 	How to send an Transactional Email
 
-Once your SendGrid account is setup, you have choices on how to send the emails to your users.
+Once your SendGrid account is set up, you have choices on how to send the emails to your users.
 
 1. Send [via SMTP]({{root_url}}/sending-email/getting-started-smtp/)
 2. Send [via API]({{root_url}}/api-reference)


### PR DESCRIPTION
**Description of the change**: changing setup to set up
**Reason for the change**: it's the wrong form of the word
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/getting-started-with-transactional-emails/


