### PR TITLE
added a "the" before creation in line 24

### DIFF
--- a/content/docs/for-developers/sending-email/getting-started-with-transactional-emails.md
+++ b/content/docs/for-developers/sending-email/getting-started-with-transactional-emails.md
@@ -21,7 +21,7 @@ These emails typically contain information a user wants or needs. They have the 
 
 <call-out>
 
-Well designed and useful emails help keep open rates high. Use ([SendGrid’s Dynamic Transactional Email Templates]({{root_url}}/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/)) to help with creation of responsive transactional email templates.
+Well designed and useful emails help keep open rates high. Use ([SendGrid’s Dynamic Transactional Email Templates]({{root_url}}/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/)) to help with the creation of responsive transactional email templates.
 
 </call-out>
 


### PR DESCRIPTION
**Description of the change**: added 'the' before creation
**Reason for the change**: Not correct grammar
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/getting-started-with-transactional-emails/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

