### PR TITLE
Changed Cancelled to Canceled

### DIFF
--- a/content/docs/for-developers/sending-email/stopping-a-scheduled-send.md
+++ b/content/docs/for-developers/sending-email/stopping-a-scheduled-send.md
@@ -91,7 +91,7 @@ Now that your email has been scheduled and has a batch ID assigned, you can [pau
 
 <call-out type="warning">
 
-Scheduled sends cancelled less than 10 minutes before the scheduled time are not guaranteed to be cancelled.
+Scheduled sends canceled less than 10 minutes before the scheduled time are not guaranteed to be canceled.
 
 </call-out>
 


### PR DESCRIPTION
Spelling errors with the use of word "Canceled" which was fixed to the correct spelling application. It was in the British formatting of Canceled.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

