### PR TITLE
Removing 'simply', making it 'set the status'

### DIFF
--- a/content/docs/for-developers/sending-email/stopping-a-scheduled-send.md
+++ b/content/docs/for-developers/sending-email/stopping-a-scheduled-send.md
@@ -95,7 +95,7 @@ Scheduled sends cancelled less than 10 minutes before the scheduled time are not
 
 </call-out>
 
-To only pause your scheduled send, simply set the `status` parameter in your request to "pause". To completely cancel your request, set `status` to "cancel".
+To only pause your scheduled send, set the `status` parameter in your request to "pause". To completely cancel your request, set `status` to "cancel".
 
 When a Batch is **cancelled**, all messages associated with that batch will stay in your sending queue, but when their `send_at` value is reached, they will be discarded instead of attempting delivery.
 


### PR DESCRIPTION
**Description of the change**: I just removed 'simply' from line 98
**Reason for the change**: seemed unnecessary
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/stopping-a-scheduled-send/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

