### PR TITLE
I added a comma after "when definineing a parameter list,"

### DIFF
--- a/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
+++ b/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
@@ -38,7 +38,7 @@ Now that you have created the new subuser account, you will need to [add an IP](
 https://api.sendgrid.com/apiv2/customer.ip.xml?api_user=ryan.burrer@sendgrid.com&api_key=xxxxxx&list=all
 ```
 
-When defining the parameter 'list' there are a few options you can choose:
+When defining the parameter 'list', there are a few options you can choose:
 
 - **All** - Will list all of the IPs on your account, taken or available.
 - **Free** - Will list all the free IPs on your account. For instance, if an IP is in use by a subuser or parent account then that IP will not be listed.


### PR DESCRIPTION
**Description of the change**: I added a comma
**Reason for the change**: It needed it 
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

