### PR TITLE
change "and/or" to just "and"

### DIFF
--- a/content/docs/for-developers/sending-email/personalizations.md
+++ b/content/docs/for-developers/sending-email/personalizations.md
@@ -154,7 +154,7 @@ The following shows how to send 1 email to 3 different recipients: recipient1&#0
 
 ## 	Sending a Single Email to a Single Recipient With Multiple CCs/BCCs
  	
-The following shows what personalizations are required to send the same email to one recipient, with multiple CCs and/or BCCs.
+The following shows what personalizations are required to send the same email to one recipient, with multiple CCs and BCCs.
 
 ```json
 {


### PR DESCRIPTION
**Description of the change**: 
change "and/or" to just "and" on line 157
**Reason for the change**: 
Unnecessary wording
**Link to original source**:
https://sendgrid.com/docs/for-developers/sending-email/personalizations/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

