### PR TITLE
Update personalizations.md

### DIFF
--- a/content/docs/for-developers/sending-email/personalizations.md
+++ b/content/docs/for-developers/sending-email/personalizations.md
@@ -12,7 +12,7 @@ navigation:
 ---
 
 
-When sending email via the v3 Mail Send endpoint, the various metadata about the message (such as the recipients, subject line, headers, substitutions, and custom arguments) are contained within an array called personalizations.
+When sending an email with the v3 Mail Send endpoint, the various metadata about the message (such as the recipients, subject line, headers, substitutions, and custom arguments) are contained within an array called personalizations.
 
 Think of the personalizations section of the request body like the envelope of a letter: the fields defined within personalizations apply to each individual email, not the recipient. Like an envelope, personalizations are used to identify who should receive the email as well as specifics about how you would like the email to be handled. For example, you can define when you would like it to be sent, what headers you would like to include, and any substitutions or custom arguments you would like to be included with the email.
 


### PR DESCRIPTION
Line #15 corrections -  added "an" before email, changed "via" to "with"

**Description of the change**: Line # 15 corrections -  added "an" before email, changed "via" to "with"
**Reason for the change**: improper grammar/school assignment
**Link to original source**: https://docs.google.com/spreadsheets/d/15cVnU07Z-bbW7hBVX98W1JdWKyBf3E3pTIRegUa716A/edit#gid=0 (row 10)
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

