### PR TITLE
Removing Simply

### DIFF
--- a/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
+++ b/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
@@ -102,7 +102,7 @@ https://api.sendgrid.com/apiv2/customer.whitelabel.json?api_user=ryan.burrer@sen
 
 ## Authenticating the Subuser to Have Website/SMTP Access (required)
 
-The final step in creating your new subuser requires you to simply [activate the subuser]({{root_url}}/API_Reference/Customer_Subuser_API/authenticate_a_subuser.html) account so that they have a website and SMTP access.
+The final step in creating your new subuser requires you to [activate the subuser]({{root_url}}/API_Reference/Customer_Subuser_API/authenticate_a_subuser.html) account so that they have a website and SMTP access.
 
 #### Call Example
 ```


### PR DESCRIPTION
Removing Simply from Line 105

**Description of the change**: Removed the word simply from line 105
**Reason for the change**: Simply is a little condescending
**Link to original source**:  https://docs.google.com/spreadsheets/d/15cVnU07Z-bbW7hBVX98W1JdWKyBf3E3pTIRegUa716A/edit#gid=0
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

