### PR TITLE
Simplified "each individual" to "each"

### DIFF
--- a/content/docs/for-developers/sending-email/personalizations.md
+++ b/content/docs/for-developers/sending-email/personalizations.md
@@ -14,7 +14,7 @@ navigation:
 
 When sending email via the v3 Mail Send endpoint, the various metadata about the message (such as the recipients, subject line, headers, substitutions, and custom arguments) are contained within an array called personalizations.
 
-Think of the personalizations section of the request body like the envelope of a letter: the fields defined within personalizations apply to each individual email, not the recipient. Like an envelope, personalizations are used to identify who should receive the email as well as specifics about how you would like the email to be handled. For example, you can define when you would like it to be sent, what headers you would like to include, and any substitutions or custom arguments you would like to be included with the email.
+Think of the personalizations section of the request body like the envelope of a letter: the fields defined within personalizations apply to each email, not the recipient. Like an envelope, personalizations are used to identify who should receive the email as well as specifics about how you would like the email to be handled. For example, you can define when you would like it to be sent, what headers you would like to include, and any substitutions or custom arguments you would like to be included with the email.
 
 Personalizations allow you to define:
 


### PR DESCRIPTION
Simplified "each individual" to "each" for line 17.

**Simplified "each individual" to "each"**:
**Too complex**:
**https://sendgrid.com/docs/for-developers/sending-email/personalizations/**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

