### PR TITLE
Update scheduling-parameters.md

### DIFF
--- a/content/docs/for-developers/sending-email/scheduling-parameters.md
+++ b/content/docs/for-developers/sending-email/scheduling-parameters.md
@@ -35,6 +35,12 @@ Cancel Scheduled sends by including a batch ID with your send. For more informat
 
 <call-out type="warning">
 
+When passing ``send_at`` or ``send_each_at`` please make sure to only use UNIX timestamps passed as integers, as shown in our examples. Any other type could result in unintended behavior.
+
+</call-out>
+
+<call-out type="warning">
+
 Using both `send_at` and `send_each_at` is not valid. Setting both causes your request to be dropped.
 
 </call-out>


### PR DESCRIPTION
**Description of the change**: Adding clarity that send_at & send_each_at should be passed as a UNIX timestamp in integer format.
**Reason for the change**: we will send the message immediately if the timestamp is passed as a string
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

