### PR TITLE
Update unique-arguments.md

### DIFF
--- a/content/docs/for-developers/sending-email/unique-arguments.md
+++ b/content/docs/for-developers/sending-email/unique-arguments.md
@@ -15,7 +15,7 @@ The SMTP API JSON string allows you to attach an unlimited number of unique argu
 
 <call-out type="warning">
 
-When passing args please make sure to only use strings as shown in our examples.
+When passing ``unique_args`` please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
 
 </call-out>
 

--- a/content/docs/for-developers/sending-email/unique-arguments.md
+++ b/content/docs/for-developers/sending-email/unique-arguments.md
@@ -15,7 +15,7 @@ The SMTP API JSON string allows you to attach an unlimited number of unique argu
 
 <call-out type="warning">
 
-When passing ``unique_args`` please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
+When passing `unique_args` please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
 
 </call-out>
 


### PR DESCRIPTION
**Description of the change**: Adding clarification that passing unique args as anything other than a string will cause unintended behavior
**Reason for the change**: unique args must be passed as strings not integers, clarification needed in the docs
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

