### PR TITLE
Update suppressions.md

### DIFF
--- a/content/docs/for-developers/sending-email/suppressions.md
+++ b/content/docs/for-developers/sending-email/suppressions.md
@@ -27,7 +27,7 @@ You may only specify one group per send, and you should wait one minute after cr
 
 <call-out type="warning">
 
-When passing ``asm_group_id`` please make sure to only use integers as shown in our examples. Any other type could result in unintended behavior.
+When passing `asm_group_id` please make sure to only use integers as shown in our examples. Any other type could result in unintended behavior.
 
 </call-out>
 

--- a/content/docs/for-developers/sending-email/suppressions.md
+++ b/content/docs/for-developers/sending-email/suppressions.md
@@ -25,6 +25,12 @@ You may only specify one group per send, and you should wait one minute after cr
 
 </call-out>
 
+<call-out type="warning">
+
+When passing ``asm_group_id`` please make sure to only use integers as shown in our examples. Any other type could result in unintended behavior.
+
+</call-out>
+
 ```json
 {
   "asm_group_id": 1


### PR DESCRIPTION
**Description of the change**: Adding clarification that asm_group_id should only be passed as integers
**Reason for the change**: asm groups should not be passed as strings, only integers for us to be able to correctly process the message
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

