### PR TITLE
Update substitution_tags.md

### DIFF
--- a/source/API_Reference/SMTP_API/substitution_tags.md
+++ b/source/API_Reference/SMTP_API/substitution_tags.md
@@ -31,6 +31,10 @@ Substitution tags will work in the Subject line, body of the email and in [Uniqu
 Substitutions are limited to 10000 bytes per personalization block.
 {% endinfo %}
 
+{% warning %}
+When passing substitutions please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
+{% endwarning %}
+
 {% info %}
 How you format your substitution tags may depend on the library you use to create your SMTP connection, the language you are writing your code in, or any intermediate mail servers that your servers will send mail through. In some cases -subVal- may be the best choice while in other %subVal% or #subVal# may make more sense. It is best to avoid characters that have special meaning in HTML, such as <,>, and &. These might end up encoded and will not be properly substituted.
 {% endinfo %}


### PR DESCRIPTION
**Description of the change**: Adding clarification that substitution tags should only be passed as strings
**Reason for the change**: substitution tags should only be passed as strings
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

