### PR TITLE
Update scheduling_parameters.md

### DIFF
--- a/source/API_Reference/SMTP_API/scheduling_parameters.md
+++ b/source/API_Reference/SMTP_API/scheduling_parameters.md
@@ -29,6 +29,10 @@ Cancel Scheduled sends by including a batch ID with your send. For more informat
 {% endinfo %}
 
 {% warning %}
+When passing `send_at` or `send_each_at` please make sure to only use UNIX timestamps passed as integers, as shown in our examples. Any other type could result in unintended behavior.
+{% endwarning %}
+
+{% warning %}
 Using both `send_at` and `send_each_at` is not valid. Setting both causes your request to be dropped.
 {% endwarning %}
 


### PR DESCRIPTION
**Description of the change**: adding clarity that send_at & send_each_at should not be passed as strings but as integers
**Reason for the change**: we'll send the message right away if the timestamp is passed as a string
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

