### PR TITLE
Update unique_arguments.md

### DIFF
--- a/source/API_Reference/SMTP_API/unique_arguments.md
+++ b/source/API_Reference/SMTP_API/unique_arguments.md
@@ -10,6 +10,10 @@ navigation:
   show: true
 ---
 
+{% warning %}
+When passing `unique_args` please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
+{% endwarning %}
+
 The SMTP API JSON string allows you to attach an unlimited number of unique arguments to your email **up to 10,000 bytes**. The arguments are used only for tracking. They can be retrieved through the [Event API]({{root_url}}/API_Reference/Webhooks/event.html) or the [Email Activity]({{root_url}}/User_Guide/Delivery_Metrics/email_activity.html) page.
 
 These arguments can be added using a JSON string like this:


### PR DESCRIPTION
**Description of the change**: adding clarification that unique args must be passed as strings
**Reason for the change**:  unique args must be passed as strings not integers
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

