### PR TITLE
Update categories.md

### DIFF
--- a/source/API_Reference/SMTP_API/categories.md
+++ b/source/API_Reference/SMTP_API/categories.md
@@ -26,6 +26,10 @@ Example
 
 You can use SendGrid's [SMTP API]({{root_url}}/API_Reference/SMTP_API/building_an_smtp_email.html) to add these categories to your email. The following should be added to the email's header:
 
+{% warning %}
+When passing `category` please make sure to only use strings as shown in our examples. Any other type could result in unintended behavior.
+{% endwarning %}
+
 <h4>Example Category Header</h4>
 {% codeblock lang:json %}
 {


### PR DESCRIPTION
**Description of the change**: clarity around only using strings for categories, not integers
**Reason for the change**: categories should only be passed as strings
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

