### PR TITLE
Update suppressions.md

### DIFF
--- a/source/API_Reference/SMTP_API/suppressions.md
+++ b/source/API_Reference/SMTP_API/suppressions.md
@@ -21,6 +21,10 @@ The method used to specify an unsubscribe group for an email depends on how you 
 * When sending an email via the [Web API v3]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html), define the group's ID in the `asm.group_id` parameter.
 
 {% warning %}
+When passing `asm_group_id` please make sure to only use integers as shown in our examples. Any other type could result in unintended behavior.
+{% endwarning %}
+
+{% warning %}
 You may only specify one group per send, and you should wait one minute after creating the group before sending with it.
 {% endwarning %}
 


### PR DESCRIPTION
**Description of the change**: clarity around only passing asm groups as integers and not strings
**Reason for the change**: asm_group_ids should only be passed as integers
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

