### PR TITLE
Push PageCategory as 'docs' to dataLayer

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,3 +8,13 @@ exports.onClientEntry = () => {
     document.head.appendChild(link);
   }());
 };
+
+/**
+ * Push PageCategory as 'docs' to dataLayer
+ */
+exports.onRouteUpdate = () => {
+  window.dataLayer = [
+    { PageCategory: 'docs' },
+    ...window.dataLayer,
+  ];
+};


### PR DESCRIPTION
**Description of the change**:
Push `PageCategory` to GA dataLayer

**Reason for the change**:
Per Adrian in BizOps


