### PR TITLE
Update authentication.md

### DIFF
--- a/content/docs/for-developers/sending-email/authentication.md
+++ b/content/docs/for-developers/sending-email/authentication.md
@@ -61,5 +61,5 @@ You have to use basic authentication if you are using v2 of the API.
 
 ## Two-factor authentication
 
-SendGrid recommends enabling two-factor authentication (2FA) for all users. For more information about setting up 2FA, see [Two-factor authentication](https:/sendgrid.com/docs/ui/account-and-settings/two-factor-authentication/). 
+SendGrid recommends enabling two-factor authentication (2FA) for all users. For more information about setting up 2FA, see [Two-factor authentication](https://sendgrid.com/docs/ui/account-and-settings/two-factor-authentication/). 
 


### PR DESCRIPTION
Fix broken link to 2FA

**Description of the change**: 
2FA page link at the bottom of https://sendgrid.com/docs/for-developers/sending-email/authentication/ was missing a second forward slash after https causing it to attempt to navigate to `https://sendgrid.com/sendgrid.com/docs/ui/account-and-settings/two-factor-authentication/`

**Reason for the change**:
Broken link
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

