### PR TITLE
fix github link edge case

### DIFF
--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -37,7 +37,6 @@ class DocTemplate extends React.Component {
   getRepoLink() {
     const {
       permalink,
-      slug,
     } = this.props.data.doc.fields;
 
     const absPath = this.props.data.doc.fileAbsolutePath;

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -39,10 +39,13 @@ class DocTemplate extends React.Component {
       permalink,
       slug,
     } = this.props.data.doc.fields;
-    const path = permalink.replace(`${slug}/`, '');
+
     const absPath = this.props.data.doc.fileAbsolutePath;
     const filename = absPath.substring(absPath.lastIndexOf('/') + 1);
+    const fileSlug = filename.replace('.md', '');
+    const path = permalink.replace(`${fileSlug}/`, '');
     const gitHubURL = config.gitHubMarkdownPath + path + filename;
+
     return gitHubURL;
   }
 


### PR DESCRIPTION
**Description of the change**:
Fixes edge case for "edit this doc" on GitHub

**Reason for the change**:
This link was 404ing for one doc


