### PR TITLE
Update Line 18 (wrong link)

### DIFF
--- a/content/docs/for-developers/sending-email/wordpress-plugin.md
+++ b/content/docs/for-developers/sending-email/wordpress-plugin.md
@@ -15,7 +15,7 @@ navigation:
 ---
 SendGrid's cloud-based email infrastructure relieves businesses of the cost and complexity of maintaining custom email systems. SendGrid provides reliable deliverability, scalability, and real-time analytics along with flexible APIs that make custom integration with your application a breeze.
 
-SendGrid’s [WordPress plugin](https://wordpress.org/plugins/sendgrid-email-delivery-simplified/) replaces WordPress’s default **wp_mail()** function by using either an SMTP or API integration with SendGrid to send outgoing email from your WordPress installation. It also allows you to upload contacts directly to your SendGrid Marketing Campaigns account via a [subscription widget]({{root_url}}/for-developers/managing-contacts/wordpress-subscription-widget/).
+SendGrid’s [WordPress plugin](https://wordpress.org/plugins/sendgrid-email-delivery-simplified/) replaces WordPress’s default **wp_mail()** function by using either an SMTP or API integration with SendGrid to send outgoing email from your WordPress installation. It also allows you to upload contacts directly to your SendGrid Marketing Campaigns account via a [subscription widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/).
 
 By using the SendGrid plugin, you will be able to take advantage of improved deliverability and an expanded feature set, including tracking and analytics, to enhance user engagement on your WordPress installation. SendGrid also provides world class customer support, should you run into any issues.
 


### PR DESCRIPTION
Line 18 resolves to a 404 destination:

https://sendgrid.com/docs/for-developers/sending-email/wordpress-subscription-widget/ (correct location and works)

https://sendgrid.com/docs/for-developers/managing-contacts/wordpress-subscription-widget/ (current and fails)

**Description of the change**: line 18 has the wrong link and results in 404 error
**Reason for the change**: correction of link
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

