### PR TITLE
advise on double CNAME domain entry on DigitalOcean. Fixes #5111

### DIFF
--- a/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
+++ b/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
@@ -59,7 +59,9 @@ To set up domain authentication, you must submit the DNS records provided by Sen
 
 A recent change with how GoDaddy handles new DNS record values automatically adds your domain, resulting in a CNAME entry with too much information and a failure when trying to complete domain authentication. An example of this would be **em123.yourdomain.com.yourdomain.com**.
 
-Below is an example of the CNAME values under the HOST column as they are displayed in step 5 and how you will need to enter into your GoDaddy DNS Management:
+DigitalOcean has this same behaviour in their Networking - Manage Domain - Create new record section.
+
+Below is an example of the CNAME values under the HOST column as they are displayed and how you will need to enter them into your GoDaddy/DigitalOcean DNS Management:
 
 * HOST/NAME **em123.yourdomain.com** . ENTER CNAME RECORD HOST/NAME AS: **em123**
 * HOST/NAME **s1._domainkey.yourdomain.com**  ENTER CNAME RECORD HOST/NAME AS: **s1._domainkey**


### PR DESCRIPTION
Adds a reference to DigitalOcean exhibiting the same behaviour as is
already noted for GoDaddy. Includes minor rewording to accommodate this
dual company reference.

Ready for review.

Closes #5111 

