### PR TITLE
Change expert services icon class.

### DIFF
--- a/src/components/ReleaseNotes/ReleaseKey.jsx
+++ b/src/components/ReleaseNotes/ReleaseKey.jsx
@@ -20,7 +20,7 @@ function ReleaseKey() {
         Price Update
       </div>
       <div className="release-notes-key__icon">
-        <div className="icon-expert" />
+        <div className="icon-expert-services" />
         Expert Services
       </div>
     </div>

--- a/src/pages/release-notes.scss
+++ b/src/pages/release-notes.scss
@@ -103,7 +103,7 @@
   background-size: 60px;
 }
 
-.icon-expert {
+.icon-expert-services {
   background: url('../img/release-note-expert-services.svg') no-repeat;
   background-position: center 14px;
   background-size: 60px;


### PR DESCRIPTION
**Description of the change**:
Changed the expert services icon class to `icon-expert-services` from `icon-expert`

**Reason for the change**:
The icon was broken.


