### PR TITLE
Added back 2FA warning to the end of this page

### DIFF
--- a/content/docs/for-developers/sending-email/authentication.md
+++ b/content/docs/for-developers/sending-email/authentication.md
@@ -63,3 +63,7 @@ You have to use basic authentication if you are using v2 of the API.
 
 SendGrid recommends enabling two-factor authentication (2FA) for all users. For more information about setting up 2FA, see [Two-factor authentication]({{root_url}}/ui/account-and-settings/two-factor-authentication/).
 
+<call-out type="warning">
+
+It is not possible to use basic authentication for users, subusers, or teammates that enable 2FA.
+


### PR DESCRIPTION
 It is not possible to use basic authentication for users, subusers, or teammates that enable 2FA.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

