### PR TITLE
added basic auth warning

### DIFF
--- a/content/docs/glossary/two-factor-authentication.md
+++ b/content/docs/glossary/two-factor-authentication.md
@@ -10,7 +10,7 @@ navigation:
   show: false
 ---
 
-Two-Factor Authentication (also known as Multi-factor authentication, 2FA, two step verification, or TFA) is an extra layer of security enforced during authentication that requires not only a password and username but also something that only that user has on them, that is a piece of information only they should know or have immediately at hand such as a physical token, a phone application, or a device.
+Two-Factor Authentication (also known as Multi-factor authentication, 2FA, two step verification, or TFA) is an extra layer of security enforced during authentication that requires not only a password and username but also something that only that user has on them, that is a piece of information only they should know or have immediately at hand such as a physical token, a phone application, or a device. Please note: it is not possible to use basic authentication for users, subusers, or teammates that enable 2FA.
 
 With SendGrid, you can turn this security feature on in your [Account Settings]({{root_url}}/ui/account-and-settings/two-factor-authentication/).
 


### PR DESCRIPTION
Please note: it is not possible to use basic authentication for users, subusers, or teammates that enable 2FA.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

