### PR TITLE
Added Help Article for rails 5.2+

### DIFF
--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -102,6 +102,6 @@ As a best practice, you should not store your credentials directly in
 the source but should instead store them in configuration files or
 environment variables. See this tutorial on <a
   href='http://railsapps.github.io/rails-environment-variables.html'>environment
-  variables in Rails</a>.
+  variables in Rails</a>. And for Rails Versions 5.2+ see <a href='https://guides.rubyonrails.org/security.html#custom-credentials'>Securely storing custom credentials in Rails.</a>
 
 </call-out>


### PR DESCRIPTION
Added a link to the Offical Rails Guides that outlines how to store custom credentials for Rails version 5.2+



Rails has moved on from using the environmental variables stored in previously mentioned way. 
**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #
