### PR TITLE
Update click-tracking-html-best-practices.md

### DIFF
--- a/content/docs/ui/analytics-and-reporting/click-tracking-html-best-practices.md
+++ b/content/docs/ui/analytics-and-reporting/click-tracking-html-best-practices.md
@@ -12,12 +12,15 @@ navigation:
   show: true
 ---
 
-If you are experiencing issues with the click tracking setting not replacing your original links, please take a look at your link formatting. Links must be in the proper format in order for our click tracking setting to find and replace them. Links must be within an HTML `<a>` tag with the `href` argument as the first argument in the tag. There must not be spaces around the `=` in the `href` attribute, the URI must be quoted, and must be proceeded by **`"http://`** or **`"https://`**.
+If you are experiencing issues with the click tracking setting not replacing your original links, please take a look at your link formatting. Links must be in the proper format in order for our click tracking setting to find and replace them: 
+Links must be within an HTML `<a>` tag with the `href` argument within the tag. There must not be spaces around the `=` in the `href` attribute, the URI must be quoted, and must be proceeded by **`"http://`** or **`"https://`**.
 Here are some example links that will be properly replaced by our click tracking app:
 
 `<a href="http://www.sendgrid.com">SendGrid</a>`
 
 `<a href="https://sendgrid.com">SendGrid</a>`
+
+`<a target="_blank" href="https://sendgrid.com">SendGrid</a>`
 
 The following links, even though they may still resolve, will not be captured or replaced by our click tracking system:
 
@@ -28,9 +31,6 @@ The following links, even though they may still resolve, will not be captured or
 `<a href= http://www.sendgrid.com>SendGrid</a>`
 
 `<a href = "https://sendgrid.com">SendGrid</a>`
-
-`<a target="_blank" href="https://sendgrid.com">SendGrid</a>`
-
 
 <call-out>
 


### PR DESCRIPTION
`href` doesn't have to be the first argument within the tag. Talking to MP team about `gofilterd` & re-reading the regex in `filterd` cleared that up.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

