### PR TITLE
Add step to account cancellation process

### DIFF
--- a/content/docs/ui/account-and-settings/cancel-your-account.md
+++ b/content/docs/ui/account-and-settings/cancel-your-account.md
@@ -14,7 +14,7 @@ seo:
 *To cancel your SendGrid account:*
 
 1. Log into the SendGrid UI.
-1. Select **Settings** and then click **Plan & Billing Details**.
+1. Select **Settings** and then click **Account Details**, followed by **Plan & Billing**.
 1. At the bottom of the page, click **Cancel Account**.
 
 <call-out>


### PR DESCRIPTION
Added the step of clicking on **Account Details**. Plan & Billing is no longer is own tab directly under Settings.

**Description of the change**: Add **Account Details** to the cancellation workflow
**Reason for the change**: **Plan & Billing* is no longer a tab within Settings in the UI. It follows clicking on Account Details.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

