### PR TITLE
Remove Contradictory statement.

### DIFF
--- a/source/API_Reference/SMTP_API/apps.html
+++ b/source/API_Reference/SMTP_API/apps.html
@@ -11,7 +11,6 @@ navigation:
 {% info %}
 <ul>
   <li>If you're enabling a Setting, also called a filter, via SMTPAPI, you are required to define all of the parameters for that Setting.</li>
-  <li>Setting enabled status will always default to your settings on the website, unless otherwise defined in your X-SMTPAPI header</li>
   <li>If you enable a disabled setting, our system will not pull your settings for the disabled setting. You will need to define the settings in your X-SMTPAPI header <em>Example:</em> If you have a footer designed but disabled, you can't just enable it via the API; you need to define the footer in the API call itself.</li>
   <li>All filter names and setting names must be lowercase.</li>
 </ul>


### PR DESCRIPTION
The statement "setting enabled status will apply settings from website" is both untrue, and directly contradicted by the following statement. If the filter is referenced _at all_ in the API string, the full state needs to be defined. As soon as we're looking to the API string for the settings, we don't look at the database. It's PUT-style, not PATCH.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

