### PR TITLE
Correct email limit on Basic 100K

### DIFF
--- a/content/docs/ui/account-and-settings/billing.md
+++ b/content/docs/ui/account-and-settings/billing.md
@@ -251,7 +251,7 @@ Upgrading your account does NOT absorb already incurred overage charges, so make
  </tr>
  <tr>
    <td>Basic 100K</td>
-   <td>100,000 contacts and 200,000 emails</td>
+   <td>100,000 contacts and 300,000 emails</td>
    <td>$0.0023</td>
  </tr>
  <tr>


### PR DESCRIPTION
**Description of the change**: Changed email limit from 200,000 to 300,000 for Basic 100K
**Reason for the change**: Typo on the email limit for that plan
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/billing/#limits-and-overage-rates
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

