### PR TITLE
microsoft-azure.md

### DIFF
--- a/content/docs/for-developers/partners/microsoft-azure.md
+++ b/content/docs/for-developers/partners/microsoft-azure.md
@@ -23,7 +23,7 @@ The following documentation covers signing up, sending an email, adding an attac
 
 ## 	Still have questions?
 
-Wondering how to make the most of your SendGrid/Azure integration? Check out our [Azure related blog entries](https://sendgrid.com/blog/?s=Azure).
+Wondering how to make the most of your SendGrid/Azure integration? Check out our [Azure related blog entries](https://sendgrid.com/?s=Azure).
 
 You are limited to 2 SendGrid accounts per Azure subscription. This limit exists for security and compliance reasons to prevent abuse.
 


### PR DESCRIPTION
Corrects broken link on [Azure related blog entries]

**Description of the change**:
Changed link originally directing to https://sendgrid.com/blog/?s=Azure to instead direct to https://sendgrid.com/?s=Azure.

**Reason for the change**:
The search param only works if it's given on the top level of the domain. This also resolves an SEO issue with unintended URLs being crawled.

**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

