### PR TITLE
Update rubyonrails.md

### DIFF
--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -94,7 +94,7 @@ ActionMailer::Base.smtp_settings = {
   :password => 'your_sendgrid_password',
   :domain => 'yourdomain.com',
   :address => 'smtp.sendgrid.net',
-  :port => 587,
+  :port => 465,
   :authentication => :plain,
   :enable_starttls_auto => true
 }


### PR DESCRIPTION
So it uses 465 in docs instead of unencrypted 587

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

