### PR TITLE
Lines 465 - 508

### DIFF
--- a/content/docs/ui/sending-email/editor.md
+++ b/content/docs/ui/sending-email/editor.md
@@ -507,6 +507,7 @@ You'll also see a number of System Fields that you can place in the body of your
  </tr>
 </table>
 
+
 &ast; For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Tags tab of the Design Editor.
 
 <call-out type="warning">


### PR DESCRIPTION
`<{{sender_name}}>*` should be changed to `{{sender_name}}`
`<{{sender_city}}>*` should be changed to `{{sender_city}}`
`{{sender_state}}>*` should be changed to `{{sender_state}}`
`<{{sender_zip}}>*` should be changed to `{{sender_zip}}`

I am *not* familiar with the HTML to make that change based on the above, so my edits are not complete.

**Description of the change**:  see above
**Reason for the change**:  Incorrect tags given
