### PR TITLE
Correct cancel-your-account.md

### DIFF
--- a/content/docs/ui/account-and-settings/cancel-your-account.md
+++ b/content/docs/ui/account-and-settings/cancel-your-account.md
@@ -15,7 +15,7 @@ seo:
 
 1. Log into the SendGrid UI.
 1. Select **Settings** and then click **Account Details**, followed by **Plan & Billing**.
-1. At the bottom of the page, click **Cancel Account**.
+1. At the bottom of the page, click **Your Products**.
 
 <call-out>
 


### PR DESCRIPTION
The cancellation button has been moved to the "Your Products" tab under "Account Details"

 - Kenneth Wilson
Twilio SendGrid Support Supervisor

**Description of the change**: Changing the path from "Plan & Billing" to "Your Products" in order to cancel account
**Reason for the change**: Current path is incorrect
**Link to original source**:https://sendgrid.com/docs/ui/account-and-settings/cancel-your-account/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

