### PR TITLE
Fix a typo

### DIFF
--- a/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
+++ b/content/docs/ui/account-and-settings/how-to-set-up-domain-authentication.md
@@ -15,7 +15,7 @@ seo:
 
 ## 	What is domain authentication?
 
-Domain authentication, formally known as domain whitelabel, shows email providers that SendGrid has your permission to send emails on your behalf. To give SendGrid permission, you point DNS entries from your DNS provider (like GoDaddy, Rackspace, or Cloudflare) to SendGrid. Your recipients will no longer see the “via sendgrid.net” message on your emails.
+Domain authentication, formerly known as domain whitelabel, shows email providers that SendGrid has your permission to send emails on your behalf. To give SendGrid permission, you point DNS entries from your DNS provider (like GoDaddy, Rackspace, or Cloudflare) to SendGrid. Your recipients will no longer see the “via sendgrid.net” message on your emails.
 
 Even though this is a small change from your recipient's perspective, this change has a huge positive impact on your reputation as a sender and your email deliverability. Email service providers distrust messages that don't have domain authentication set up because they can not be sure that the message comes from you. Explicitly stating that it comes from you increases your reputation with email service providers which makes it much less likely that they will filter your mail and not allow it get to your recipient's inbox, which increases your deliverability. You are also explicitly showing your recipients that this email comes from you, so they are less likely to mark your mail as spam.
 


### PR DESCRIPTION
**Description of the change**: Fixes a typo.
**Reason for the change**: "formally" should be "formerly"
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/

