### PR TITLE
Fix contacts and email limits on Free MC

### DIFF
--- a/content/docs/ui/account-and-settings/billing.md
+++ b/content/docs/ui/account-and-settings/billing.md
@@ -246,7 +246,7 @@ Upgrading your account does NOT absorb already incurred overage charges, so make
  </tr>
  <tr>
    <td>Free</td>
-   <td>6,000 contacts and 2,000 emails</td>
+   <td>2,000 contacts and 6,000 emails</td>
    <td>-</td>
  </tr>
  <tr>


### PR DESCRIPTION
**Description of the change**: Fixed the contacts and email limits on the Free Marketing Campaigns plan
**Reason for the change**: It was incorrect - it said 6,000 contacts and 2,000 emails, and those numbers needed to be switched
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/billing/#marketing-campaigns-contacts
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

