### PR TITLE
Comply with markdown lint (MD039)

### DIFF
--- a/content/docs/for-developers/partners/amazon-marketplace.md
+++ b/content/docs/for-developers/partners/amazon-marketplace.md
@@ -32,7 +32,7 @@ If you are using SendGrid through AWS, you cannot change your SendGrid username.
 
 ### Pricing
 
-There are two plans: AWS Basic and AWS Pro. These plans are billed on your AWS invoice. For more information, check out our[ AWS Marketplace page](https://aws.amazon.com/marketplace/pp/B074CQY6KB). Here's a monthly view of cost:
+There are two plans: AWS Basic and AWS Pro. These plans are billed on your AWS invoice. For more information, check out our [AWS Marketplace page](https://aws.amazon.com/marketplace/pp/B074CQY6KB). Here's a monthly view of cost:
 
 ![]({{root_url}}/images/aws_pricing.png "AWS pricing")
 


### PR DESCRIPTION
**Description of the change**:
Move space outside of link to comply with lint.

**Reason for the change**:
Markdown lint: `MD039/no-space-in-links: Spaces inside link textmarkdownlint(MD039)`
