### PR TITLE
Close the same tag as we open

### DIFF
--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -34,7 +34,7 @@ Montes sociis turpis egestas fermentum tempus lectus cubilia vulputate justo, pl
 
 Montes sociis turpis egestas fermentum tempus lectus cubilia vulputate justo, placerat suscipit mollis nostra mauris at sed adipiscing, enim pharetra laoreet ridiculus litora nunc.
 
-</callout>
+</call-out>
 ```
 
 <call-out>
@@ -50,8 +50,9 @@ Montes sociis turpis egestas fermentum tempus lectus cubilia vulputate justo, pl
 
 Montes sociis turpis egestas fermentum tempus lectus cubilia vulputate justo, placerat suscipit mollis nostra mauris at sed adipiscing, enim pharetra laoreet ridiculus litora nunc.
 
-</callout>
+</call-out>
 ```
+
 <call-out type="warning">
 
 Montes sociis turpis egestas fermentum tempus lectus cubilia vulputate justo, placerat suscipit mollis nostra mauris at sed adipiscing, enim pharetra laoreet ridiculus litora nunc.


### PR DESCRIPTION
**Description of the change**:
1. Close the same tag as we opened.
2. Add newline on L#55 for lint: `MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank linesmarkdownlint(MD031)`

**Reason for the change**:
Make example less confusing and comply with MD031 lint

