### PR TITLE
Update validation_results spelling

### DIFF
--- a/content/docs/for-developers/sending-email/automating-subusers.md
+++ b/content/docs/for-developers/sending-email/automating-subusers.md
@@ -44,6 +44,7 @@ curl -X POST -H "Authorization: Basic XXXXXXXXXXXXXX" -H "Content-Type: applicat
   ]
 }' 'https://api.sendgrid.com/v3/subusers'
 ```
+
 The successful Response looks like this:
 
 ```bash
@@ -284,6 +285,7 @@ Response:
 }
 }
 ```
+
 After creating DNS records then wait for them to propagate and validate records.
 
 
@@ -353,7 +355,7 @@ Response:
 
 ```bash
 => 2xx
-{ "id”: 50784, "valid": true, "validation_resuts": { "mail_cname": { "valid": false, "reason": "Expected your MX record to be "mx.sendgrid.net" but found "example.com"." },"dkim1": { "valid": true, "reason": null }, "dkim2": { "valid": true, "reason": null }, "spf": { "valid": true, "reason": null } } }
+{ "id”: 50784, "valid": true, "validation_results": { "mail_cname": { "valid": false, "reason": "Expected your MX record to be "mx.sendgrid.net" but found "example.com"." },"dkim1": { "valid": true, "reason": null }, "dkim2": { "valid": true, "reason": null }, "spf": { "valid": true, "reason": null } } }
 ```
 
 


### PR DESCRIPTION
**Description of the change**:
There was a spelling error on one of the fields, this was fixed [here](https://github.com/sendgrid/sendgrid-oai/issues/67)

While I was in the file I also fixed markdown lint `MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank linesmarkdownlint(MD031)`

**Reason for the change**:
The issue with the fieldname has been fixed in issue linked above.

