### PR TITLE
Lint fixes

### DIFF
--- a/content/docs/for-developers/sending-email/cakephp.md
+++ b/content/docs/for-developers/sending-email/cakephp.md
@@ -12,7 +12,7 @@ navigation:
 
 CakePHP comes with an email library that already supports SMTP. [For more information check out the CakePHP documentation page](http://book.cakephp.org/2.0/en/core-utility-libraries/email.html#configuration). This example shows how to send an email with both HTML and text bodies.
 
-In **app/views/layouts/** you need to define the layout of your text and HTML emails: 
+In **app/views/layouts/** you need to define the layout of your text and HTML emails:
 
 ```
 email/
@@ -21,13 +21,14 @@ default.ctp
 text/
 default.ctp
 ```
+
 In **app/views/layouts/email/text/default.ctp** add:
 
 ``` php
 <!--?php echo $content_for_layout; ?-->
 ```
 
- and in **app/views/layouts/email/html/default.ctp** add: 
+ and in **app/views/layouts/email/html/default.ctp** add:
 
 ``` php
 <!--?php echo $content_for_layout; ?-->
@@ -45,6 +46,7 @@ registration.ctp
 html/
 registration.ctp
 ```
+
 In **app/views/elements/email/text/registration.ctp** add:
 
 ``` php
@@ -52,20 +54,17 @@ Dear <!--?php echo $name ?-->,
 Thank you for registering. Please go to http://domain.com to finish your registration.
 ```
 
- and in **app/views/layouts/email/html/default.ctp** add: 
+ and in **app/views/layouts/email/html/default.ctp** add:
 
 ``` php
 Dear <!--?php echo $name ?-->,
 Thank you for registering. Please go to <a href="http://domain.com">here</a> to finish your registration.
 ```
 
- In your controller enable the email component:  
-  
- 
+ In your controller enable the email component:
 
 ``` php
-<!--?php var $components = array('Email'); ?--> 
-
+<!--?php var $components = array('Email'); ?-->
 ```
 
  Then anywhere in your controller you can do something like the following to send an email: 


### PR DESCRIPTION
**Description of the change**:
Fix lint warnings

**Reason for the change**:
Lint checks were giving errors for:
```
MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank linesmarkdownlint(MD031)
MD009/no-trailing-spaces: Trailing spaces [Expected: 0 or 2; Actual: 1]markdownlint(MD009)
```

