### PR TITLE
Fix some lint warnings in docs

### DIFF
--- a/content/docs/for-developers/partners/azure.md
+++ b/content/docs/for-developers/partners/azure.md
@@ -197,6 +197,7 @@ In your `index.html` file add the following code near the closing body tag to ad
 ``` html
 <script src="https://website.azure-mobile.net/client/MobileServices.Web-1.0.0.min.js"></script>
 ```
+
 ![Mobile Services]({{root_url}}/images/azure_13.png)
 
 In the `js/app.js` file, after the `$("#queue").append…` line, add the following code:
@@ -250,6 +251,7 @@ items = [results mutableCopy];
 completion();
 }];
 ```
+
 ![Code]({{root_url}}/images/azure_18.png)
 4.	Now, go to the file QSToDoListViewController.m, and replace the onAdd function’s contents with:
 
@@ -294,6 +296,7 @@ UIAlertView *message = [[UIAlertView alloc] initWithTitle:@"Error"
 }
 itemText.text = @"";
 ```
+
 5.	In the same file, replace this line:
 ```label.text = [item objectForKey:@"text"];```
 with this line:

--- a/content/docs/for-developers/sending-email/cloud-rail.md
+++ b/content/docs/for-developers/sending-email/cloud-rail.md
@@ -27,7 +27,7 @@ dependencies {
 ```
 
 ## 	Send a simple email
- 	
+
 After setup, sending an email with SendGrid is a breeze.
 Just add code like the one below:
 
@@ -51,7 +51,7 @@ new Thread() {
 ```
 
 ## 	Send a personalized email
- 	
+
 Since you've already integrated CloudRail SI, why not make use of some of the other APIs that come with it?
 Let's use Facebook to get a user's info to personalize the email:
 

--- a/content/docs/for-developers/sending-email/codeigniter.md
+++ b/content/docs/for-developers/sending-email/codeigniter.md
@@ -14,7 +14,7 @@ CodeIgniter comes with an email sending library built in. See more information o
 
 <call-out>
 
-It is important to use the correct end of lines using "crlf" =\> "\\r\\n" and "newline" =\> "\\r\\n". 
+It is important to use the correct end of lines using "crlf" =\> "\\r\\n" and "newline" =\> "\\r\\n".
 
 </call-out>
 

--- a/content/docs/for-developers/sending-email/django.md
+++ b/content/docs/for-developers/sending-email/django.md
@@ -12,7 +12,7 @@ navigation:
 
 There is more detailed information about sending email over SMTP with Django on the [Django project website](https://docs.djangoproject.com/en/dev/topics/email/).
 
-First start by adding the following to **settings.py:** 
+First start by adding the following to **settings.py:**
 
 ``` python
 SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
@@ -23,15 +23,16 @@ EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 ```
- Then to send email you can do the following: 
+
+Then to send email you can do the following:
 
 ``` python
 from django.core.mail import send_mail
 send_mail('Subject here', 'Here is the message.', 'from@example.com', ['to@example.com'], fail_silently=False)
 ```
+
 <call-out>
 
 You may also send emails with Django by using the [django-sendgrid-v5](https://github.com/sklarsa/django-sendgrid-v5) library, which utilizes the [Web API]({{%20root_url%20}}/API_Reference/Web_API/index.html) instead of SMTP as the transport mechanism.
 
 </call-out>
- 

--- a/content/docs/for-developers/sending-email/exim.md
+++ b/content/docs/for-developers/sending-email/exim.md
@@ -36,8 +36,6 @@ dc_mailname_in_oh='true'
 
 Enable TLS support in **/etc/exim4/exim4.conf.localmacros**.
 
-
-
 <call-out>
 
 If this file does not exist, you will need to create it:
@@ -74,7 +72,6 @@ sendgrid_login:
   client_send = : YourSendGridUsername : YourSendGridPassword
 ```
 
-
 <call-out>
 
 Only include "begin authenticators" if it's not already in the configuration.
@@ -110,4 +107,5 @@ $ /etc/init.d/exim4 restart
 ```
 
 ## 	Exim Documentation
- 	If your version of Exim does not match the version above or you are not finding the answer you need, please check out the Official [Exim Documentation](http://www.exim.org/docs.html) for more information.
+
+If your version of Exim does not match the version above or you are not finding the answer you need, please check out the Official [Exim Documentation](http://www.exim.org/docs.html) for more information.

--- a/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
+++ b/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
@@ -18,11 +18,11 @@ In order to gain access to the Email Activity Feed API, you must purchase [addit
 
 The API gives you access to query all of your stored messages, to query individual messages, and to download a CSV with data about the stored messages.
 
-## 	Getting started
+## Getting started
 
 Start with this basic query to the Email Activity Feed API (replace `<<your API key>>` with an API key from your account):
 
-```
+```bash
 curl --request GET \
  --url 'https://api.sendgrid.com/v3/messages?limit=10' \
  --header 'authorization: Bearer <<your API key>>'
@@ -30,7 +30,7 @@ curl --request GET \
 
 This returns a list of the 10 most recent emails you've sent. Next, check out some of the common use cases to narrow down your search.
 
- ### 	Encoding queries
+### Encoding queries
 
 All queries need to be [URL encoded](https://meyerweb.com/eric/tools/dencoder/) and have this format:
 
@@ -40,15 +40,15 @@ Encoded, this query would look like this:
 
 `query=query_type%3D%22query_content%22`
 
-## 	Queries for common use cases
+## Queries for common use cases
 
 Here are some queries for common use cases. For a full list of possible query types, see the [query reference](#query-reference).
 
- ### 	Filter by subject
+### Filter by subject
 
 Use this query to filter by email subject (replace `<<your API key>>` with an API key from your account, and replace <<subject>> with the subject you want to search):
 
-```
+```bash
 curl --request GET \
  --url 'https://api.sendgrid.com/v3/messages?limit=10&query=subject%3D<<subject>>' \
  --header 'authorization: Bearer <<your API key>>'
@@ -62,11 +62,11 @@ Encoded, this query would look like this:
 
 `subject%3D%22This%20is%20a%20subject%20test%22`
 
- ### 	Filter by recipient email
+### Filter by recipient email
 
 Use this query to filter by a recipient's email: (replace `<<your API key>>` with an API key from your account, and replace <<email>> with the URL encoded recipients email):
 
-```
+```bash
 curl --request GET \
  --url 'https://api.sendgrid.com/v3/messages?limit=10&query=to_email%3D%22<<email>>%22' \
  --header 'authorization: Bearer <<your API key>>'
@@ -80,7 +80,7 @@ Encoded, this query would look like this:
 
 `to_email%3D%22example%40example.com%22`
 
- ### 	Filter by bounced emails
+### Filter by bounced emails
 
 Use this query to filter by all bounced emails: (replace `<<your API key>>` with an API key from your account):
 
@@ -98,11 +98,11 @@ Encoded, this query would look like this:
 
 `status%3D%22bounced%22`
 
-## 	Creating compound queries
+## Creating compound queries
 
 Use [operators and keywords](#keywords-and-operator-reference) to combine queries for a compound query. For example, you could filter for emails between a date range or you could filter for when a specific recipients email is bounced. Here are some common use cases:
 
- ### 	Filter by a recipient email that was bounced
+### Filter by a recipient email that was bounced
 
 Use this query to filter by a recipient's email and by emails that are bounced: (replace `<<your API key>>` with an API key from your account, and replace <<email>> with the URL encoded recipients email):
 
@@ -112,7 +112,7 @@ curl --request GET \
  --header 'authorization: Bearer <<your API key>>'
 ```
 
- ### 	Filter by date range
+### Filter by date range
 
 Use this query to filter to emails between specific dates: (replace `<<your API key>>` with an API key from your account, and replace {start_date} and {end_date} with a URL encoded UTC date string in this format: `YYYY-MM-DD HH:mm:SS`. Encoded, this looks like this: `2018-02-01T00%3A00%3A00.000Z`)
 
@@ -122,7 +122,7 @@ curl --request GET \
  --header 'authorization: Bearer <<your API key>>'
 ```
 
- ### 	Filter by a recipient and a date range
+### Filter by a recipient and a date range
 
 Use this query to filter to emails by recipient and between specific dates: (replace `<<your API key>>` with an API key from your account, replace <<start_date>> and <<end_date>> with a URL encoded UTC date string in this format: `YYYY-MM-DD HH:mm:SS`, and replace <<email>> with the URL encoded recipient's email)
 
@@ -132,7 +132,7 @@ curl --request GET \
  --header 'authorization: Bearer <<your API key>>'
 ```
 
-## 	Keywords and Operator reference
+## Keywords and Operator reference
 
 There are several operators and keywords that you can use to build [Compound queries](#creating-compound-queries). Use these operators between query statements. If the character used as the delimiter is found within the string. The escape character is `\`, which must be escaped with a preceding `\`. All queries need to be URL encoded.
 
@@ -173,8 +173,7 @@ There are several operators and keywords that you can use to build [Compound que
 - TRUE
 - YEAR
 
-
-## 	Query reference
+## Query reference
 
 This is a full list of basic query types and examples: (replace the data in quotes with the information you want to query, and then URL encode it)
 
@@ -260,7 +259,7 @@ This is a full list of basic query types and examples: (replace the data in quot
  </tr>
 </table>
 
-## 	Additional Resources
+## Additional Resources
 
 - [Email Activity Feed API Reference](https://sendgrid.api-docs.io/v3.0/email-activity/filter-all-messages)
 - [Email Activity Feed UI]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/)

--- a/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
+++ b/content/docs/for-developers/sending-email/how-to-create-a-subuser-with-the-api.md
@@ -34,6 +34,7 @@ https://api.sendgrid.com/apiv2/customer.add.json?api_user=ryan.burrer@sendgrid.c
 Now that you have created the new subuser account, you will need to [add an IP](http://sendgrid.com/docs/API_Reference/Customer_Subuser_API/ip_management.html#subuser-ip-assignment) so that it can send emails. We advise that you first find an available IP for this subuser. You can do so by using the following call:
 
 #### Call Example
+
 ```
 https://api.sendgrid.com/apiv2/customer.ip.xml?api_user=ryan.burrer@sendgrid.com&api_key=xxxxxx&list=all
 ```
@@ -51,6 +52,7 @@ When defining the parameter 'list', there are a few options you can choose:
 After you have selected the IP that you wish to assign to your subuser account, make the API call to [append the IP address](http://sendgrid.com/docs/API_Reference/Customer_Subuser_API/ip_management.html#subuser-ip-assignment).
 
 #### Call Example
+
 ```
 https://api.sendgrid.com/apiv2/customer.sendip.json?api_user=ryan.burrer@sendgrid.com&api_key=xxxxxx&task=append&set=specify&user=newsubuser_username&ip[]=255.255.255.250&ip[]=255.255.255.255
 ```
@@ -67,8 +69,6 @@ When defining this call's 'set' parameter, you have a few options for appending 
 <p class="wysiwyg-text-align-left"><img src="http://content.screencast.com/users/Ryan.Burrer/folders/Jing/media/d8482205-976f-4f82-ad3a-77503e867c2f/00000095.png" alt="" align="middle"></p>
 </center>
 
-
-
 ## Assign a domain authentication for the Subuser Account (optional)
 
 After you have created the subuser account and have appended an IP address, you are now ready to assign an _existing_  [authenticated domain]({{root_url}}/ui/account-and-settings/how-to-set-up-domain-authentication/) to the account. If you have not yet created the required records for authenticating your chosen domain then this step should be skipped.
@@ -76,6 +76,7 @@ After you have created the subuser account and have appended an IP address, you 
 First, you should find out what authenticated domains you have associated with your account. This call will [list your available authenticated domains](http://sendgrid.com/docs/API_Reference/Customer_Subuser_API/whitelabel.html#list):
 
 #### Call Example
+
 ```
 https://api.sendgrid.com/apiv2/customer.whitelabel.json?api\_user=ryan.burrer@sendgrid.com&api\_key=xxxxxx&task=list
 ```
@@ -90,6 +91,7 @@ The API response above shows that email.sendgrid.com and email.example.com are b
 If you have an authenticated domain entry that you wish to apply to your subuser then you will need to [append the whitelabel entry](http://sendgrid.com/docs/API_Reference/Customer_Subuser_API/whitelabel.html#append) to your subuser:
 
 #### Call Example
+
 ```
 https://api.sendgrid.com/apiv2/customer.whitelabel.json?api_user=ryan.burrer@sendgrid.com&api_key=xxxxxx&task=append&user=newsubuser_username&mail_domain=YOUR.ALREADY.EXISTING.WHITELABEL
 ```
@@ -105,6 +107,7 @@ https://api.sendgrid.com/apiv2/customer.whitelabel.json?api_user=ryan.burrer@sen
 The final step in creating your new subuser requires you to [activate the subuser]({{root_url}}/API_Reference/Customer_Subuser_API/authenticate_a_subuser.html) account so that they have a website and SMTP access.
 
 #### Call Example
+
 ```
 https://api.sendgrid.com/apiv2/customer.auth.json?api_user=ryan.burrer@sendgrid.com&api_key=xxxxxx&user=newsubuser_username&password=newsubuser_password
 ```
@@ -117,11 +120,9 @@ https://api.sendgrid.com/apiv2/customer.auth.json?api_user=ryan.burrer@sendgrid.
 </center>
 <center>
 
-
 ## Additional Resources
 
 * [Automating Subusers]({{root_url}}/for-developers/sending-email/automating-subusers/)
 * [Event Notification URL]({{root_url}}/API_Reference/Customer_Subuser_API/event_notification_url.html)
 * [Apps]({{root_url}}/API_Reference/Customer_Subuser_API/apps.html)
 * [Account Limits]({{root_url}}/API_Reference/Customer_Subuser_API/account_limits.html)
-

--- a/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp-or-v2.md
+++ b/content/docs/for-developers/sending-email/how-to-use-a-transactional-template-with-smtp-or-v2.md
@@ -28,7 +28,7 @@ The X-SMTPAPI does not support Dynamic Transactional Templates. For sending Dyna
   
 </call-out>
 
-## 	Before you begin
+## Before you begin
 
 Before you create and send a legacy transactional template email over SMTP you need to do the following:
 
@@ -37,7 +37,7 @@ Before you create and send a legacy transactional template email over SMTP you n
 * [Build an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-x-smtpapi-header/)
 * [Create a Legacy Transactional Template](https://sendgrid.com/templates)
 
-## 	Sending a test Email
+## Sending a test Email
 
 ### Sending a test SMTP email with Telnet
 
@@ -80,17 +80,17 @@ Make sure that the version of the template you want to use is set to active by u
 
 - The [Activate a transactional template version endpoint](https://sendgrid.com/docs/api-reference/)
   ```/templates/{template_id}/versions/{version_id}/activate```
-  
+
 - Or by [activating the template version in the UI](https://sendgrid.com/templates)
 
 </call-out>
 
 To use a legacy template when you send, configure the `X-SMTPAPI` header of an SMTP message:
+
 * Enable the `templates` filter
 * Set the `template_id` to one of your legacy transactional templates
 
-
-**Example**
+#### Example
 ```json
 {
   "filters": {
@@ -113,13 +113,10 @@ The ```text``` property is substituted into the `<%body%>` of the text template 
 **Text or HTML Templates?**
 
 <call-out>
-
 It is best practice to provide content for both the ```html``` and the ```text``` properties in all of your emails.
 
 If the ```text``` property is present, but not ```html```, then the resulting email will only contain the text version of the template, not the HTML version.
-
 </call-out>
-
 
 Enabling a legacy template means that the `subject` and `body`
 content of your message will behave differently.

--- a/content/docs/for-developers/sending-email/iis75.md
+++ b/content/docs/for-developers/sending-email/iis75.md
@@ -13,7 +13,7 @@ This document was written using Windows Server 2008 R2 running IIS version 7.5 a
 
 </call-out>
 
-## 	IIS 7.5 Configuration
+## IIS 7.5 Configuration
 
 Before you get going, you'll need to set up IIS in order to support SendGrid integration. This tutorial assumes that you have set up a working site and that the root directory tests as valid.
 
@@ -39,7 +39,7 @@ If you want to configure additional security to the localhost IIS 6.0 server you
 
 </call-out>
 
-## 	Enable SMTP Service:
+## Enable SMTP Service
 
 1. Go to Start \> All Programs \> Administrative Tools \> Server Manager
 2. Click **Features** in the navigation pane.
@@ -51,7 +51,7 @@ If you want to configure additional security to the localhost IIS 6.0 server you
 
 Once the SMTP Server service is installed, the IIS 6.0 virtual server technology is activated, and the IIS 6.0 administration snap-in will now be active.
 
-## 	Configure IIS 6.0 to Relay Outbound Email to SendGrid
+## Configure IIS 6.0 to Relay Outbound Email to SendGrid
 
 1. Go to Start \> All Programs \> Administrative Tools \> IIS 6.0 Manager.
 2. Right click on the SMTP Virtual Server \#1 and select **Properties**.
@@ -70,11 +70,11 @@ Once the SMTP Server service is installed, the IIS 6.0 virtual server technology
 15. In the Smart host field: enter smtp.sendgrid.net
 16. Click on OK twice and you can close the IIS 6.0 admin MMC
 
-## 	Configure Domains
+## Configure Domains
 
 At this point you will need to configure an SMTP domain that relays messages to SendGrid. Please follow [Microsoft's instructions](https://support.microsoft.com/en-us/help/230235/xcon-how-to-configure-the-iis-smtp-service-to-relay-smtp-mail).
 
-## 	Testing Your New Configuration
+## Testing Your New Configuration
 
 First, let's test using Telnet. Open up a telnet client within Windows. You can do that in the Command Prompt by entering the following:
 
@@ -97,7 +97,7 @@ The `EHLO` command with your domain inserted tells the mail server which domain 
 
 If these manually entered commands work, then you should have the following success code returned:
 
-``` 250….Queued mail for delivery ```
+```250….Queued mail for delivery```
 
 You can also test using the logging feature we had you activate earlier. You can view the logs by navigating to and opening the IIS 6.0 7.5 log files with a text editor. It will probably be under the C:\\Windows\\System32\\LogFiles directory unless you changed the log file location during installation.
 

--- a/content/docs/for-developers/sending-email/laravel.md
+++ b/content/docs/for-developers/sending-email/laravel.md
@@ -38,7 +38,6 @@ The `MAIL_FROM_NAME` field requires double quotes because there is a space in th
 You can send `100 messages per SMTP connection` at a time, and open up to `10 concurrent connections` from a single server at a time.
 </call-out>
 
-
 ## Creating a Mailable
 
 Next you need to create a Mailable class, Laravel's CLI tool called Artisan makes that a simple feat.
@@ -99,6 +98,7 @@ In Laravel `Views` are used as 'templates' when sending an email. Let's create a
     	</body>
     </html>
 ```
+
 ## Sending an email
 
 Now that we have our Mailable Class created, all we need to do is run this code:
@@ -155,12 +155,12 @@ class TestEmail extends Mailable
         ];
 
         $header = $this->asString($headerData);
-        
+
         $this->withSwiftMessage(function ($message) use ($header) {
             $message->getHeaders()
                     ->addTextHeader('X-SMTPAPI', $header);
         });
-        
+
         return $this->view('emails.test')
                     ->from($address, $name)
                     ->cc($address, $name)
@@ -182,7 +182,7 @@ class TestEmail extends Mailable
     private function asString($data)
     {
         $json = $this->asJSON($data);
-        
+
         return wordwrap($json, 76, "\n   ");
     }
 }

--- a/content/docs/for-developers/sending-email/migrating-from-v2-to-v3-mail-send.md
+++ b/content/docs/for-developers/sending-email/migrating-from-v2-to-v3-mail-send.md
@@ -11,7 +11,7 @@ navigation:
   show: true
 ---
 
-## 	Why should you migrate?
+## Why should you migrate?
 
 <call-out>
 
@@ -28,13 +28,13 @@ With a few quick changes you will be able to take advantage of the improvements 
 
 <iframe src="https://player.vimeo.com/video/168940206" width="700" height="400" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-## 	What do you need to migrate?
+## What do you need to migrate?
 
 All you need to migrate from the v2 to v3 mail send endpoint is a SendGrid account.
 
 If you are a new SendGrid user and haven’t begun sending email yet, please go straight to our [v3 Mail Send documentation]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html) to get started.
 
-## 	JSON Schema
+## JSON Schema
 
 Some of the biggest improvements made to the mail send endpoint reside in the JSON schema used to format and submit the data payload for your email. While the v2 mail send endpoint relies on a combination of JSON and SendGrid’s x-smtpapi headers, all content and metadata sent via the v3 mail send endpoint is defined using JSON within a single request body.
 
@@ -84,11 +84,11 @@ However, the equivalent API call for the the v3 mail send endpoint would look li
 
 Notice that while the call to the v2 Mail Send endpoint does include JSON, it is only defined from within the x-smtpapi parameter, whereas the entire payload for the v3 Mail Send API Call is formatted in JSON.
 
-## 	Requirements and Limitations
+## Requirements and Limitations
 
 There are few limitations and requirements differences between the v2 and v3 mail send endpoints, making it even easier to migrate your integration to the latest version.
 
-## 	Attachments
+## Attachments
 
 Attachments are handled differently between the v2 and v3 Mail Send endpoints. When attaching files in an email sent over the v2 Mail Send endpoint, you simply needed to attach your file to the transport and specify the file names and content IDs of those files in your API call. Essentially, you specified which files you were attaching in the API call, but the files were actually sent differently.
 

--- a/content/docs/for-developers/sending-email/personalizations.md
+++ b/content/docs/for-developers/sending-email/personalizations.md
@@ -65,7 +65,7 @@ Personalization Examples Index
 * [Sending Two Different Emails to Two Different Groups of Recipients](#sending-two-different-emails-to-two-different-groups-of-recipients)
 
 ## Sending a Single Email to a Single Recipient
- 	
+
 The following example shows you what the personalization parameter would look like if you wanted to send a single email to a single recipient.
 
 ```json
@@ -106,7 +106,7 @@ The following example shows how to send one email to recipient1&#064;example&per
 ```
 
 ## 	Sending a Single Email to a Single Recipient With a CC and a BCC
- 	
+
 The following example shows how to send one email to recipient1&#064;example&period;com with a CC sent to recipient2&#064;example&period;com and a BCC sent to recipient3&#064;example&period;com.
 
 ```json

--- a/content/docs/for-developers/sending-email/postfix.md
+++ b/content/docs/for-developers/sending-email/postfix.md
@@ -67,7 +67,7 @@ $ apt-get install libsasl2-modules
 $ yum install cyrus-sasl-plain
 ```
 
-  ## 	Troubleshooting
+## Troubleshooting
  	
 If port 587 is not working for you, please try 2525 in your postfix config. You may also need to edit /etc/postfix/master.cf to remove # from `tlsmgr unix - - n 1000? 1 tlsmgr`. 
 

--- a/content/docs/for-developers/sending-email/qmail.md
+++ b/content/docs/for-developers/sending-email/qmail.md
@@ -13,4 +13,8 @@ Alternately, you can [take a look at Fehcom's very complete description of authe
 
 In general, you will need to add the following to **/var/qmail/control/smtproutes**, but you should verify the actual path and file you need to update.
 
-``` :smtp.sendgrid.net:587 username password ``` As with all configuration changes, make sure to restart qmail.
+```
+ :smtp.sendgrid.net:587 username password
+```
+
+As with all configuration changes, make sure to restart qmail.

--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -34,7 +34,7 @@ class UserNotifierMailer < ApplicationMailer
     :subject => 'Thanks for signing up for our amazing app' )
   end
 end
-``` 
+```
 
 Now we need a view that corresponds to our action and outputs HTML for our email. Create a file `app/views/user_notifier_mailer/send_signup_email.html.erb` as follows:
 
@@ -58,6 +58,7 @@ If you don't have a user model quite yet, generate one quickly.
 $ rails generate scaffold user name email login
 $ rake db:migrate
 ```
+
 Now in the controller for the user model `app/controllers/users_controller.rb`, add a call to `UserNotifierMailer.send_signup_email` when a user is saved.
 
 ``` ruby
@@ -98,7 +99,8 @@ ActionMailer::Base.smtp_settings = {
   :authentication => :plain,
   :enable_starttls_auto => true
 }
-``` 
+```
+
 That's it! When a new user object is saved, an email will be sent to
 the user via SendGrid.
 

--- a/content/docs/for-developers/sending-email/sandbox-mode.md
+++ b/content/docs/for-developers/sending-email/sandbox-mode.md
@@ -22,8 +22,8 @@ Sandbox mode is an optional parameter within `mail_settings`. Enabling sandbox m
 
 When making a request with sandbox mode enabled, we will validate the form, type, and shape of your request. In other words, sandbox mode will validate each parameter you include and the structure of your JSON payload. If you include a `template_id` in your sandbox mode request, it will be assumed that you have included a subject line and body within the template. We will not validate this content.
 
-## 	Using Sandbox Mode
- 	
+## Using Sandbox Mode
+
 <call-out type="warning">
 
 When using sandbox mode, you must include the "enable" parameter, and it must be given a boolean value of either true or false. **Do not enclose the boolean value in quotes** or you will receive the error:
@@ -32,20 +32,20 @@ When using sandbox mode, you must include the "enable" parameter, and it must be
 
 </call-out>
 
- ### 	Valid Request Body
- 	
+### Valid Request Body
+
 When your request validates, you will receive a 200 OK response (as opposed to the 202 ACCEPTED response that is returned for successful non-sandbox requests).
 
- ### 	Invalid Request Body
- 	
+### Invalid Request Body
+
 If you submit a request with sandbox mode enabled, but your request body is invalid, you will receive one or more error messages with error codes, detailed explanations for the error or errors, and links to any relevant documentation.
 
- ### 	Example Sandbox Mode JSON
- 	
+### Example Sandbox Mode JSON
 
 The following is an invalid request body intended to demonstrate the validation behavior of sandbox mode for a bad request.
 
-**Request**
+#### Request
+
 ```json
 {
 	"personalizations": [{
@@ -70,7 +70,8 @@ The following is an invalid request body intended to demonstrate the validation 
 ```
 
 **Response**
-```
+
+```json
 {
   "errors": [
     {

--- a/content/docs/for-developers/sending-email/scheduling-parameters.md
+++ b/content/docs/for-developers/sending-email/scheduling-parameters.md
@@ -35,7 +35,7 @@ Cancel Scheduled sends by including a batch ID with your send. For more informat
 
 When passing `send_at` or `send_each_at` please make sure to only use UNIX timestamps passed as integers, as shown in our examples. Any other type could result in unintended behavior.	
 
- </call-out>	
+ </call-out>
 
 <call-out type="warning">
 
@@ -43,25 +43,25 @@ Using both `send_at` and `send_each_at` is not valid. Setting both causes your r
 
 </call-out>
 
-## 	Send At
+## Send At
 
 To schedule a send request for a large batch of emails, use the `send_at` parameter which will send all emails at approximately the same time. `send_at` is a [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time).
 
-
 ### Example of send_at email header
+
 ```json
 {
   "send_at": 1409348513
 }
 ```
 
-## 	Send Each At
+## Send Each At
 
 To schedule a send request for individual recipients; use `send_each_at` to send emails to each recipient at the specified time. `send_each_at` is a sequence of UNIX timestamps, provided as an array. There must be one timestamp per email you wish to send.
 
-
 ### Example of send_each_at email header
-```
+
+```json
 {
   "to": [
     "ben@example.com",
@@ -81,12 +81,11 @@ To schedule a send request for individual recipients; use `send_each_at` to send
 
 To allow for the cancellation of a scheduled send, you must include a `batch_id` with your send. To generate a valid `batch_id`, use the [batch id generation endpoint]({{root_url}}/API_Reference/Web_API_v3/cancel_scheduled_send.html#Cancel-Scheduled-Sends). A `batch_id` is valid for 10 days (864,000 seconds) after generation.
 
-
 ### Example of including a batch_id
-```
+
+```json
 {
   "to": [
-
     "ben@example.com",
     "john@example.com",
     "mikeexampexample@example.com",
@@ -99,9 +98,9 @@ To allow for the cancellation of a scheduled send, you must include a `batch_id`
 }
 ```
 
-## 	Additional Resources
+## Additional Resources
 
-- [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
-- [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
-- [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
-- [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)
+* [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
+* [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
+* [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
+* [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)

--- a/content/docs/for-developers/sending-email/section-tags.md
+++ b/content/docs/for-developers/sending-email/section-tags.md
@@ -23,6 +23,7 @@ When passing `section` please make sure to only use strings as shown in our exam
 </call-out>
 
 The format of the SMTP API section tag has the form:
+
 ```json
 {
   "section": {
@@ -46,11 +47,11 @@ Do not use spaces inside your section or substitution tags! For example: `%first
 
 <call-out type="warning">
 
-Do not nest section tags in sections - this causes your section to not be replaced.
+Do not nest section tags in sections * this causes your section to not be replaced.
 
 </call-out>
 
-## 	Section Tag Walkthrough
+## Section Tag Walkthrough
 
 Message body sent to SendGrid:
 
@@ -112,6 +113,7 @@ The accompanying X-SMTPAPI JSON header would look like:
 ```
 
 Alice receives:
+
 ```html
 <html>
  <body>
@@ -128,6 +130,7 @@ Alice receives:
 ```
 
 Bob receives:
+
 ```html
 <html>
  <body>
@@ -144,6 +147,7 @@ Bob receives:
 ```
 
 Casey receives:
+
 ```html
 <html>
  <body>
@@ -159,10 +163,10 @@ Casey receives:
 </html>
 ```
 
-## 	Additional Resources
+## Additional Resources
 
-- [Substitution Tags]({{root_url}}/for-developers/sending-email/substitution-tags/)
-- [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
-- [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
-- [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
-- [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)
+* [Substitution Tags]({{root_url}}/for-developers/sending-email/substitution-tags/)
+* [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
+* [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
+* [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
+* [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)

--- a/content/docs/for-developers/sending-email/send-mime-messages-with-sendGrid.md
+++ b/content/docs/for-developers/sending-email/send-mime-messages-with-sendGrid.md
@@ -8,6 +8,7 @@ navigation:
 ---
 
 ## Sending MIME Mail
+
 Some mailers, such as Apple Mail, place Multipurpose Internet Mail Extensions (MIME) into emails automatically which can cause our system to parse the boundaries incorrectly. If you do notice a problem with the content from your email not rendering correctly, please do the following:
 
 1. Log into your SendGrid account, click **Settings**, then select **Mail Settings**. 
@@ -54,8 +55,4 @@ puts response.status_code
 puts response.body
 
 puts response.headers
-
 ```
-
-
-

--- a/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
+++ b/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
@@ -93,7 +93,7 @@ Each SMTP call you make returns a response. `200` responses are usually success 
   </tr>
 </table>
 
-## 	Turning off click tracking
+## Turning off click tracking
 
 To turn off click tracking, add this to your X-SMTPAPI header:
 
@@ -110,11 +110,11 @@ To turn off click tracking, add this to your X-SMTPAPI header:
 }
 ```
 
-## 	Invalid SMTP API header
+## Invalid SMTP API header
 
 When you try to send an invalid X-SMTPAPI header, you will get an email with details about the invalidations. You may also see errors on your Email Activity page or in your Event Webhook data. If this happens, the email should give you the information you need to begin troubleshooting. We also recommend uploading your JSON into a JSON validator, because this is often an invalid JSON issue.
 
-## 	Certificate verification failed for smtp.sendgrid.net
+## Certificate verification failed for smtp.sendgrid.net
 
  `"certificate verification failed for [smtp.sendgrid.net](http://smtp.sendgrid.net/)[198.37.144.225]:587: untrusted issuer /C=US/O=The Go Daddy Group, Inc./OU=Go Daddy Class 2 Certification Authority"`
 
@@ -129,17 +129,17 @@ When you try to send an invalid X-SMTPAPI header, you will get an email with det
 
  If the mail server communicates with more than just us, add this certificate to your existing CA bundle (frequently called `ca-bundle.crt`).
 
- ## 550 Unauthenticated Senders Not Allowed
+## 550 Unauthenticated Senders Not Allowed
 
- If you’re getting an “Unauthenticated Senders Not Allowed” error, the problem usually lies in authenticating with our SMTP server. This error gets triggered when there was an attempt to hand over an email message through smtp.sendgrid.net before authenticating the connection with your SendGrid username and password.
+If you’re getting an “Unauthenticated Senders Not Allowed” error, the problem usually lies in authenticating with our SMTP server. This error gets triggered when there was an attempt to hand over an email message through smtp.sendgrid.net before authenticating the connection with your SendGrid username and password.
 
 To fix this issue, you’ll want to make sure that you’ve configured your setup to connect to smtp.sendgrid.net using authentication, and that the credentials you’re using are the same credentials you use to login to the SendGrid.
 
 If you’re using cPanel/Exim, you’ll want to make sure it’s configured to authenticate every time it connects to smtp.sendgrid.net.
 
-## 	Additional Resources
+## Additional Resources
 
-- [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
-- [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
-- [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
-- [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)
+* [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
+* [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)
+* [Integrating with SMTP]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/)
+* [Building an SMTP Email]({{root_url}}/for-developers/sending-email/building-an-smtp-email/)

--- a/content/docs/for-developers/sending-email/smtp-filters.md
+++ b/content/docs/for-developers/sending-email/smtp-filters.md
@@ -11,7 +11,6 @@ Following are the settings that can be specified in the filters section of the X
 
 <call-out>
 
-
 * If you're enabling a Setting, also called a filter, via SMTPAPI, you are required to define all of the parameters for that Setting.
 * If you enable a disabled setting, our system will not pull your settings for the disabled setting. You will need to define the settings in your X-SMTPAPI header <em>Example:</em> If you have a footer designed but disabled, you can't just enable it via the API; you need to define the footer in the API call itself.
 * All filter names and setting names must be lowercase.
@@ -126,6 +125,7 @@ Rewrites links in email text and html bodies to go through our webservers, allow
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {
@@ -166,6 +166,7 @@ of your email.
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {
@@ -209,6 +210,7 @@ Inserts a footer at the bottom of the text and HTML bodies.
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {
@@ -285,7 +287,6 @@ Re-writes links to integrate with Google Analytics.
 }
 ```
 
-
 ## Filter: opentrack
 
 If you don't use 'replace' this will insert an <code>&lt;img&gt;</code> tag at the bottom of the html section of an email which will be used to track if an email is opened. If you choose to use 'replace', you can put the tracking pixel wherever you would like in the email and SendGrid will replace it at send time.
@@ -311,6 +312,7 @@ If you don't use 'replace' this will insert an <code>&lt;img&gt;</code> tag at t
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {
@@ -354,6 +356,7 @@ If you don't use 'replace' this will insert an <code>&lt;img&gt;</code> tag at t
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {
@@ -369,6 +372,7 @@ If you don't use 'replace' this will insert an <code>&lt;img&gt;</code> tag at t
 ```
 
 ## Filter: subscriptiontrack
+
 Inserts a subscription management link at the bottom of the text and html bodies or insert the link anywhere in the email.
 
 If you wish to append an unsubscription link, use the <code>text/html</code> and <code>text/plain</code> parameters. However, if you wish to have the link replace a tag (such as <code>[unsubscribe]</code>), use the <code>replace</code> parameter.
@@ -432,7 +436,6 @@ This setting refers to SendGrid's <a href="{{root_url}}/API_Reference/Web_API_v3
 
 </call-out>
 
-
 Uses a [transactional template]({{root_url}}/API_Reference/Web_API_v3/Transactional_Templates/index.html) when sending an email.
 
 <table class="table table-striped table-bordered">
@@ -456,6 +459,7 @@ Uses a [transactional template]({{root_url}}/API_Reference/Web_API_v3/Transactio
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters": {
@@ -476,7 +480,6 @@ Uses a [transactional template]({{root_url}}/API_Reference/Web_API_v3/Transactio
 This setting refers to our original Email Template app. We now support more fully featured [transactional templates](#templates). You may create multiple transactional templates that allow for versioning, in addition to several other features.
 
 </call-out>
-
 
 <p>Wraps a template around your email content. Useful for sending out marketing email and other nicely formatted messages.</p>
 
@@ -501,6 +504,7 @@ This setting refers to our original Email Template app. We now support more full
 </table>
 
 #### Example X-SMTPAPI Header Value
+
 ```json
 {
   "filters" : {


### PR DESCRIPTION
**Description of the change**:
Fix lint warnings like:
```
MD039/no-space-in-links: Spaces inside link textmarkdownlint(MD039)

MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank linesmarkdownlint(MD031)

MD009/no-trailing-spaces: Trailing spaces [Expected: 0 or 2; Actual: 1]markdownlint(MD009)

MD036/no-emphasis-as-heading/no-emphasis-as-header: Emphasis used instead of a headingmarkdownlint(MD036)
```


**Reason for the change**:
Lint checker shows warnings
