### PR TITLE
Corrected 'IP' key to lower case 'ip'

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -732,7 +732,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
 - <a name="event"></a>`event` - the event type. Possible values are processed, dropped, delivered, deferred, bounce, open, click, spam report, unsubscribe, group unsubscribe, and group resubscribe.
 - <a name="smtpid"></a>`smtp-id` - a unique ID attached to the message by the originating system.
 - <a name="useragent"></a>`useragent` - the user agent responsible for the event. This is usually a web browser. For example, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36".
-- <a name="ip"></a>`IP` - the IP address used to send the email. For `open` and `click` events, it is the IP address of the recipient who engaged with the email.
+- <a name="ip"></a>`ip` - the IP address used to send the email. For `open` and `click` events, it is the IP address of the recipient who engaged with the email.
 - <a name="sgeventid"></a>`sg_event_id` - a unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.
 - <a name="sgmessageid"></a>`sg_message_id` - a unique, internal SendGrid ID for the message. The first half of this is pulled from the `smtp-id`.
 - <a name="reason"></a>`reason` - any sort of error response returned by the receiving server that describes the reason this event type was triggered.


### PR DESCRIPTION
**Description of the change**:
IP key was wrongly stated in upper case.
**Reason for the change**:
Field in upper case does not exist.
**Link to original source**:
https://sendgrid.com/docs/for-developers/tracking-events/event/