### PR TITLE
Replacing url in spf.md to be a generic url (example.com) #5135

### DIFF
--- a/content/docs/glossary/spf.md
+++ b/content/docs/glossary/spf.md
@@ -65,7 +65,7 @@ For more information on SPF best practices and syntax, check out [www.openspf.or
 we hope that they are helpful.
 
  ### 	Record Flattening
- 	There is an experimental tool called the [dmarcian SPF Record Flattener](https://example.com/), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
+ 	There is an experimental tool called the [dmarcian SPF Record Flattener](https://dmarcian.com/spf-survey/example.com/), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
 
 If you choose to use this functionality, we suggest that you test it extensively to make sure that your customers will receive your emails and their servers can look up your records properly.
 

--- a/content/docs/glossary/spf.md
+++ b/content/docs/glossary/spf.md
@@ -65,7 +65,7 @@ For more information on SPF best practices and syntax, check out [www.openspf.or
 we hope that they are helpful.
 
  ### 	Record Flattening
- 	There is an experimental tool called the [dmarcian SPF Record Flattener](http://example.com/), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
+ 	There is an experimental tool called the [dmarcian SPF Record Flattener](https://example.com/), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
 
 If you choose to use this functionality, we suggest that you test it extensively to make sure that your customers will receive your emails and their servers can look up your records properly.
 

--- a/content/docs/glossary/spf.md
+++ b/content/docs/glossary/spf.md
@@ -65,7 +65,7 @@ For more information on SPF best practices and syntax, check out [www.openspf.or
 we hope that they are helpful.
 
  ### 	Record Flattening
- 	There is an experimental tool called the [dmarcian SPF Record Flattener](https://dmarcian.com/spf-survey/bitcointalk.org), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
+ 	There is an experimental tool called the [dmarcian SPF Record Flattener](http://example.com/), which should be considered experimental. From their site: "[this tool] rewrites this record by removing duplicate netblocks, collapsing any overlapping netblocks, and using 0 DNS-querying mechanisms/modifiers."
 
 If you choose to use this functionality, we suggest that you test it extensively to make sure that your customers will receive your emails and their servers can look up your records properly.
 


### PR DESCRIPTION
**Description of the change**: Replacing url in spf.md to be a generic url (example.com)
**Reason for the change**:  Instead of using  https://dmarcian.com/spf-survey/bitcointalk.org, it was suggested to use a more safe, generic url.
**Link to original source**: https://github.com/sendgrid/docs/issues/5135#issuecomment-539614614
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #5135 

