### PR TITLE
Update link to docs in release note

### DIFF
--- a/content/docs/release-notes/2019-09-19.md
+++ b/content/docs/release-notes/2019-09-19.md
@@ -1,11 +1,11 @@
 ---
-title: "release notes 2019-09-19"
+title: 'release notes 2019-09-19'
 date: 2019-09-19
 releaseType:
   - api
   - ui
 ---
 
-### Domain Authentication Impact from Apple iOS 13 
+### Domain Authentication Impact from Apple iOS 13
 
-Apple iOS 13 includes “Sign in with Apple” Oauth feature which provides an optional private relay email for users and sender authentication requirements for Apple app developers. In order to send email to Apple Oauth private relay email addresses (@privaterelay.appleid.com), you will need to update your Domain Authentication settings within your SendGrid account. Failure to properly complete and register your SendGrid Domain Authentication with Apple will result in email sent to “privaterelay.appleid.com” returning a bounce event with the reason “550 5.1.1 bad mailbox name.”  Visit this [blog post](https://sendgrid.com/blog/sending-to-sign-in-with-apple/) for step-by-step instructions. 
+Apple iOS 13 includes “Sign in with Apple” Oauth feature which provides an optional private relay email for users and sender authentication requirements for Apple app developers. In order to send email to Apple Oauth private relay email addresses (@privaterelay.appleid.com), you will need to update your Domain Authentication settings within your SendGrid account. Failure to properly complete and register your SendGrid Domain Authentication with Apple will result in email sent to “privaterelay.appleid.com” returning a bounce event with the reason “550 5.1.1 bad mailbox name.” Visit the [Configuring Sign in with Apple documentation]({{root_url}}/ui/account-and-settings/configuring-sign-in-with-apple/) for step-by-step instructions.


### PR DESCRIPTION
**Description of the change**: Update release note link to new doc in place of existing blog post
**Reason for the change**: The doc is the new resource for instructions related to this release note
**Link to original source**: https://sendgrid.com/docs/release-notes/#19th-september-2019
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

