### PR TITLE
override container width for stoplight docs

### DIFF
--- a/src/pages/api-reference.scss
+++ b/src/pages/api-reference.scss
@@ -19,6 +19,6 @@
   width: 100%;
   overflow: scroll;
   height: 100%;
-  max-width: 1600px;
+  max-width: 1600px !important;
   min-height: 400px;
 }


### PR DESCRIPTION
Override container width for stoplight docs. Patches layout bug.
