### PR TITLE
Removed invalid link to "infrastructure guide"

### DIFF
--- a/content/docs/glossary/phishing.md
+++ b/content/docs/glossary/phishing.md
@@ -13,3 +13,5 @@ navigation:
 Phishing is a technique for acquiring information such as user names, passwords, credit cards, social security numbers or other personal data by masquerading as a trusted entity like a bank or credit card company. Phishing emails appear to be sent by the trusted entity, which can cause the consumer to be tricked into providing their personal information.
 
 SendGrid employs both technology and staff to prevent the sending of phishing emails. We have a solid track record of working with the global email community to detect and stop the sending of phishing and spam emails.
+
+To get more information please check out our [Email Infrastructure Guide](https://sendgrid.com/resource/the-email-infrastructure-guide-build-it-or-buy-it/).

--- a/content/docs/glossary/phishing.md
+++ b/content/docs/glossary/phishing.md
@@ -13,5 +13,3 @@ navigation:
 Phishing is a technique for acquiring information such as user names, passwords, credit cards, social security numbers or other personal data by masquerading as a trusted entity like a bank or credit card company. Phishing emails appear to be sent by the trusted entity, which can cause the consumer to be tricked into providing their personal information.
 
 SendGrid employs both technology and staff to prevent the sending of phishing emails. We have a solid track record of working with the global email community to detect and stop the sending of phishing and spam emails.
-
-To get more information please check out our [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html?mc=Direct&mcd=https://sendgrid.com/docs/index.html).


### PR DESCRIPTION
**Description of the change**: Removed link to SendGrid Infrastructure Guide.
**Reason for the change**: Link gave 404, and no direct replacement found. Possibly this article, but not sure: https://sendgrid.com/marketing/guide-2019-deliverability-guide/ (doesn't talk about SendGrid's internal infrastructure).

