### PR TITLE
Fixed broken link to Email Deliverability Guide

### DIFF
--- a/content/docs/glossary/deliverability.md
+++ b/content/docs/glossary/deliverability.md
@@ -37,7 +37,7 @@ SendGrid helps you [achieve strong email deliverability](https://sendgrid.com/so
 
 SendGrid also has a world-class support team that is available 24/7 via chat, phone, and email to address any of your email deliverability needs.
 
-If email drives your business, then paying close attention to your email deliverability rates is an undeniable key to your success. Let SendGrid help you achieve that success. To learn more about how email deliverability affects your business, download our free [Deliverability Guide](https://go.sendgrid.com/Email_Deliverability_Guide_2019.html).
+If email drives your business, then paying close attention to your email deliverability rates is an undeniable key to your success. Let SendGrid help you achieve that success. To learn more about how email deliverability affects your business, download our free [Email Deliverability Guide](https://sendgrid.com/marketing/guide-2019-deliverability-guide/).
 
 
 


### PR DESCRIPTION
**Description of the change**: Fixed broken link to Email Deliverability Guide (2019 edition).
**Reason for the change**: Link gave 404 error.
**Link to original source**:
