### PR TITLE
Add info that sg_message_id might be missing for bounce events

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -547,7 +547,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td>X</td>
-    <td>X</td>
+    <td>*</td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
@@ -725,6 +725,8 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
   </tr>
 </table>
 
+\* will be included when available
+
  ### 	JSON objects
 
 - <a name="email"></a>`email` - the email address of the recipient
@@ -734,7 +736,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
 - <a name="useragent"></a>`useragent` - the user agent responsible for the event. This is usually a web browser. For example, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36".
 - <a name="ip"></a>`ip` - the IP address used to send the email. For `open` and `click` events, it is the IP address of the recipient who engaged with the email.
 - <a name="sgeventid"></a>`sg_event_id` - a unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.
-- <a name="sgmessageid"></a>`sg_message_id` - a unique, internal SendGrid ID for the message. The first half of this is pulled from the `smtp-id`.
+- <a name="sgmessageid"></a>`sg_message_id` - a unique, internal SendGrid ID for the message. The first half of this is pulled from the `smtp-id`. It is normally always present, but for bounce events it might be missing in some cases due to the receiving server.
 - <a name="reason"></a>`reason` - any sort of error response returned by the receiving server that describes the reason this event type was triggered.
 - <a name="status"></a>`status` - status code string. Corresponds to HTTP status code - for example, a JSON response of 5.0.0 is the same as a 500 error response.
 - <a name="response"></a>`response` - the full text of the HTTP response error returned from the receiving server.


### PR DESCRIPTION
**Description of the change**: Add info that `sg_message_id` might be missing for bounce events
**Reason for the change**: It is not clear that `sg_message_id` is not always present for events. For `bounce` events, `sg_message_id` is not always present. That can happen if SendGrid cannot match an event to a message due to the receiving server.

