### PR TITLE
Fix broken Keen links and drop IO

### DIFF
--- a/content/docs/for-developers/tracking-events/analytics-with-keen-io.md
+++ b/content/docs/for-developers/tracking-events/analytics-with-keen-io.md
@@ -1,25 +1,25 @@
 ---
 seo:
-  title: Keen IO Integration
+  title: Keen Integration
   description: Analyze, Visualize, and Store SendGrid Email Event Data
-  keywords: Keen IO, integrate, event data, analytics
-title: Analyze, Visualize, and Store SendGrid Event Data with Keen IO
+  keywords: Keen, integrate, event data, analytics
+title: Analyze, Visualize, and Store SendGrid Event Data with Keen
 group: partners
 weight: 142
 layout: page
 navigation:
   show: true
 ---
-The SendGrid [Event Webhook]({{root_url}}/for-developers/tracking-events/event/) lets you stream all [email events]({{root_url}}/ui/analytics-and-reporting/email-activity/) directly to <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen IO</a> for real-time analysis and long term raw storage.
+The SendGrid [Event Webhook]({{root_url}}/for-developers/tracking-events/event/) lets you stream all [email events]({{root_url}}/ui/analytics-and-reporting/email-activity/) directly to <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen</a> for real-time analysis and long term raw storage.
 
-It only takes a couple of minutes to start streaming email event data from SendGrid to Keen IO and once you do you can start analyzing and visualizing your data in a whole bunch of different ways.
+It only takes a couple of minutes to start streaming email event data from SendGrid to Keen and once you do you can start analyzing and visualizing your data in a whole bunch of different ways.
 
 
-## 	Sending Your SendGrid Data to Keen IO
+## 	Sending Your SendGrid Data to Keen
 
-**Step 1: Create a Keen IO and SendGrid account**
+**Step 1: Create a Keen and SendGrid account**
 
-* Create a <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen IO account</a> (if you don't already have one)
+* Create a <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen account</a> (if you don't already have one)
 * Create a <a href="https://sendgrid.com/user/signup"> SendGrid account</a>
 
 
@@ -36,16 +36,16 @@ https://api.keen.io/3.0/projects/YOUR_KEEN_PROJECT_ID/email/sendgrid/1.0?api_key
 ```
 You can snag a pre-built URL in Keen’s UI or make your own.
 
-In the settings, select the events you want to post to Keen IO (why not all of them?). To do this, under **Select Actions**, check **All**.
+In the settings, select the events you want to post to Keen (why not all of them?). To do this, under **Select Actions**, check **All**.
 
-That’s it! Now, as your emails make their way through SendGrid, all of the event information will be posted to Keen IO. A new Event Collection for each type of email event will be created within your Keen Project.
+That’s it! Now, as your emails make their way through SendGrid, all of the event information will be posted to Keen. A new Event Collection for each type of email event will be created within your Keen Project.
 
 
 ## 	Testing Your Integration
 
-Test that everything is working by clicking on the **"Test Your Integration"** button in SendGrid’s “Event Notification” Settings. This will send sample email data from SendGrid into your Keen IO Project. In the Keen UI, click on **“Check for SendGrid Data”** button.
+Test that everything is working by clicking on the **"Test Your Integration"** button in SendGrid’s “Event Notification” Settings. This will send sample email data from SendGrid into your Keen Project. In the Keen UI, click on **“Check for SendGrid Data”** button.
 
-Your SendGrid email data should now be populated in Keen IO.
+Your SendGrid email data should now be populated in Keen.
 
 
 ## 	Using SendGrid Email Analytics
@@ -187,9 +187,9 @@ Select **Create Dashboard**, name your dashboard, and add the query we saved to 
 
 With Keen, you have access to all of your raw data for as long as you need it. An archive of all of your email data is created, which means you have access to your historical data and can query for past user behavior.
 
-Just like SendGrid, Keen IO is 100% powered by APIs. This means you can embed rich analytics anywhere you can write code.
+Just like SendGrid, Keen is 100% powered by APIs. This means you can embed rich analytics anywhere you can write code.
 
-Many customers find it useful to embed analytics into their products for their customers or customer success teams. For step-by-step instructions on how to embed your SendGrid analytics into your product, check out our [Native Analytics Guide](https://keen.io/guides/native-analytics/). Some customers also take advantage of Keen IO's [S3 Streaming](https://keen.io/docs/streams/amazon-s3/) capabilities to write a copy of all their data to AWS.
+Many customers find it useful to embed analytics into their products for their customers or customer success teams. For step-by-step instructions on how to embed your SendGrid analytics into your product, check out our [Native Analytics Guide](https://keen.io/guides/native-analytics/). Some customers also take advantage of Keen's [S3 Streaming](https://keen.io/docs/streams/amazon-s3/) capabilities to write a copy of all their data to AWS.
 
 
 ## 	Additional Resources:

--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -12,7 +12,7 @@ navigation:
 ---
 ## Authentication
 
-In order to use the Event Webhook, you need to enter a username and password. The following characters can be used for webhook authentication. 
+In order to use the Event Webhook, you need to enter a username and password. The following characters can be used for webhook authentication.
 
 <call-out type="warning">
 
@@ -21,8 +21,8 @@ Characters not on the list below are not supported and will not authenticate to 
 </call-out>
 
 - **All lower case letters:** a b c d e f g h i j k l m n o p q r s t u v w x y z
-- **All upper case letters:** A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 
-- **All digits:** 0 1 2 3 4 5 6 7 8 9 
+- **All upper case letters:** A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+- **All digits:** 0 1 2 3 4 5 6 7 8 9
 - **The following characters:** - . _ : ~ ! $ & ' ( ) * + , ; = % @
 
 ## 	Events
@@ -740,7 +740,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
 - <a name="response"></a>`response` - the full text of the HTTP response error returned from the receiving server.
 - <a name="tls"></a>`tls` - indicates whether TLS encryption was used in sending this message. For more information about TLS, see the [TLS Glossary page]({{root_url}}/glossary/tls/).
 - <a name="url"></a>`url` - the URL where the event originates. For click events, this is the URL clicked on by the recipient.
-- <a name="url_offset"</a>`url_offset` - if there is more than one of the same links in an email, this tells you which of those identical links was clicked. 
+- <a name="url_offset"</a>`url_offset` - if there is more than one of the same links in an email, this tells you which of those identical links was clicked.
 - <a name="attempt"></a>`attempt` - the number of times SendGrid has attempted to deliver this message.
 - <a name="category"></a>`category` - [Categories]({{root_url}}/glossary/categories/) are custom tags that you set for the purpose of organizing your emails. If you send single categories as an array, they will be returned by the webhook as an array. If you send single categories as a string, they will be returned by the webhook as a string.
 - <a name="type"></a>`type` - indicates whether the bounce event was a hard bounce (type=bounce) or block (type=blocked)
@@ -1074,5 +1074,6 @@ For emails sent through our Legacy Marketing Email tool, unsubscribes look like 
 - [Troubleshooting the event webhook]({{root_url}}/for-developers/tracking-events/troubleshooting/)
 - [An Event Webhook case study](https://sendgrid.com/blog/leveraging-sendgrids-event-api/)
 - [Webhook web libraries]({{root_url}}/for-developers/sending-email/libraries/)
-- [Getting started with Keen.io]({{root_url}}/for-developers/tracking-events/analytics-with-keen-io/)
+- [Analyze, Visualize, and Store SendGrid Event Data with Keen]({{root_url}}/for-developers/tracking-events/analytics-with-keen-io/)
+- [Email Event Data with Keen]({{root_url}}/ui/analytics-and-reporting/tracking-data-with-keen-io/)
 - [Run SQL on your Sengrid webhook data](https://pipedream.com/@dylburger/run-sql-on-sendgrid-engagement-data-for-free-p_X13CGV)

--- a/content/docs/for-developers/tracking-events/getting-started-event-webhook.md
+++ b/content/docs/for-developers/tracking-events/getting-started-event-webhook.md
@@ -61,7 +61,7 @@ Storage integrations are infinitely flexible, but here are some popular options:
 
 - Locally on your servers.
 - SendGrid's [open source Event Kit](https://github.com/sendgrid/eventkit-rails) stores the data on a Heroku instance.
-- SendGrid's partner, Keen.io provides a platform to analyze, visualize, and store SendGrid Event data. For more information about getting started with Keen IO, see the [Keen.io Getting Started page]({{root_url}}/help-and-support/analytics-and-reporting/tracking-data-with-keen-io).
+- SendGrid's partner Keen provides a platform to analyze, visualize, and store SendGrid Event data. For more information about getting started with Keen, see [Email Event Data with Keen]({{root_url}}/ui/analytics-and-reporting/tracking-data-with-keen-io/).
 - You could also use [Snowplow](https://github.com/snowplow/snowplow/wiki/SendGrid-webhook-setup), a web open source platform that supports SendGrid and stores the data on Amazon Redshift.
 - Several open source web libraries support SendGrid's Event Webhook. For a full list of these libraries, see the [Webhook libraries section]({{root_url}}/for-developers/sending-email/libraries/) of our API Libraries list.
 
@@ -85,4 +85,5 @@ If you want to receive encrypted posts, your callback URL needs to support TLS 1
 - [Troubleshooting the Event Webhook]({{root_url}}/for-developers/tracking-events/troubleshooting/)
 - [An Event Webhook case study](https://sendgrid.com/blog/leveraging-sendgrids-event-api/)
 - [Webhook web libraries]({{root_url}}/for-developers/sending-email/libraries/)
-- [Getting started with Keen.io]({{root_url}}/help-and-support/analytics-and-reporting/tracking-data-with-keen-io/)
+- [Email Event Data with Keen]({{root_url}}/ui/analytics-and-reporting/tracking-data-with-keen-io/)
+- [Analyze, Visualize, and Store SendGrid Event Data with Keen]({{root_url}}/for-developers/tracking-events/analytics-with-keen-io/)

--- a/content/docs/for-developers/tracking-events/troubleshooting.md
+++ b/content/docs/for-developers/tracking-events/troubleshooting.md
@@ -42,4 +42,4 @@ The `sg_event_id` is a string up to 100 characters that is `Base64url` encoded.
 - [Event webhook reference]({{root_url}}/for-developers/tracking-events/event/)
 - [An Event Webhook case study](https://sendgrid.com/blog/leveraging-sendgrids-event-api/)
 - [Webhook web libraries]({{root_url}}/for-developers/sending-email/libraries/)
-- [Getting started with Keen.io](https://keen.io/guides/getting-started/)
+- [Getting Started with Keen](https://keen.io/guides/getting-started/)

--- a/content/docs/ui/analytics-and-reporting/tracking-data-with-keen-io.md
+++ b/content/docs/ui/analytics-and-reporting/tracking-data-with-keen-io.md
@@ -2,22 +2,22 @@
 layout: page
 weight: 90
 group: partners
-title: Email Event Data with Keen IO
+title: Email Event Data with Keen
 navigation:
   show: true
 seo:
-  title:  Email Event Data with Keen IO
+  title:  Email Event Data with Keen
 ---
 
-The SendGrid [Event Webhook]({{root_url}}/for-developers/tracking-events/getting-started-event-webhook/) lets you stream all [email events]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/) directly to Keen IO for real-time analysis and long term raw storage.
+The SendGrid [Event Webhook]({{root_url}}/for-developers/tracking-events/getting-started-event-webhook/) lets you stream all [email events]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/) directly to Keen for real-time analysis and long term raw storage.
 
-It only takes a couple of minutes to start streaming email event data from SendGrid to Keen IO and once you do you can start analyzing and visualizing your data in a whole bunch of different ways.
+It only takes a couple of minutes to start streaming email event data from SendGrid to Keen and once you do you can start analyzing and visualizing your data in a whole bunch of different ways.
 
- ### 	Send your SendGrid Data to Keen IO
+ ### 	Send your SendGrid Data to Keen
 
-**Create a Keen IO and SendGrid account**
+**Create a Keen and SendGrid account**
 
-1. Create a <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen IO account</a> (if you don't already have one)
+1. Create a <a href="https://keen.io/signup?utm_source=sendgrid_docs&utm_campaign=sendgrid">Keen account</a> (if you don't already have one)
 1. Create a <a href="https://sendgrid.com/user/signup"> SendGrid account</a>
 
 
@@ -36,15 +36,15 @@ https://api.keen.io/3.0/projects/YOUR_KEEN_PROJECT_ID/email/sendgrid/1.0?api_key
 ```
 You can snag a prebuilt URL in Keen’s UI or make your own.
 
-In the Keen IO settings, select the events you want to post to Keen IO. To do this, under **Select Actions**, check **All**.
+In the Keen settings, select the events you want to post to Keen. To do this, under **Select Actions**, check **All**.
 
-Going forward, as your emails make their way through SendGrid, all of the event information will be posted to Keen IO. A new Event Collection, for each type of email event, will be created within your Keen Project.
+Going forward, as your emails make their way through SendGrid, all of the event information will be posted to Keen. A new Event Collection, for each type of email event, will be created within your Keen Project.
 
  ### 	Test Your Integration
 
-Test that everything is working by clicking  on the **"Test Your Integration"** button in SendGrid’s “Event Notification” Settings. This will send sample email data from SendGrid into your Keen IO Project. In the Keen UI, click on **“Check for SendGrid Data”** button.
+Test that everything is working by clicking  on the **"Test Your Integration"** button in SendGrid’s “Event Notification” Settings. This will send sample email data from SendGrid into your Keen Project. In the Keen UI, click on **“Check for SendGrid Data”** button.
 
-Your SendGrid email data should now be populated in Keen IO.
+Your SendGrid email data should now be populated in Keen.
 
  ### 	SendGrid Email Analytics
 
@@ -61,6 +61,6 @@ For each of these metrics, you can download a CSV of the detailed event data. Ju
 
  ### 	Additional Resources:
 
-- [Integration Guide that includes analysis and visualization info]({{root_url}}/for-developers/tracking-events/tracking-data-with-keen-io/)
-- [Keen IO API Reference](https://keen.io/docs/api/)
+- [Integration Guide that includes analysis and visualization info]({{root_url}}/for-developers/tracking-events/analytics-with-keen-io/)
+- [Keen API Reference](https://keen.io/docs/api/)
 - [Docs for Visualization](https://keen.io/docs/visualize/)


### PR DESCRIPTION
**Description of the change**: Several of the internal Keen links had drifted out of sync and were broken, and the company name is just Keen, not Keen IO

**Reason for the change**: 404 not found; correctness

**Link to original source**: https://keen.io/ + https://keen.io/guides/getting-started/

