### PR TITLE
Add top margin to Markdown header anchors

### DIFF
--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -5,6 +5,8 @@ $border-radius: 2px;
 
 // breakpoints
 $width-small-mobile: 320px;
+$width-nav-small: 350px;
+$width-nav-medium: 493px;
 $width-small: 610px;
 $width-medium: 990px;
 $width-large: 1200px;
@@ -127,9 +129,18 @@ $alert-verification: $mantis;
 $alert-trial: $slate;
 
 // gradients
-$gradient-hero: linear-gradient(165deg, rgba(209,230,249,1) 0%, rgba(243,249,253,1) 75%, rgba(255,255,255,1) 100%);
-$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1 );
-$gradient-callout: linear-gradient(300deg, rgba(36,132,223,1) 0%, rgba(92,176,255,1) 75%);
+$gradient-hero: linear-gradient(
+  165deg,
+  rgba(209, 230, 249, 1) 0%,
+  rgba(243, 249, 253, 1) 75%,
+  rgba(255, 255, 255, 1) 100%
+);
+$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1);
+$gradient-callout: linear-gradient(
+  300deg,
+  rgba(36, 132, 223, 1) 0%,
+  rgba(92, 176, 255, 1) 75%
+);
 $gradient-dev-glossary: linear-gradient(to bottom right, $kiwi, $mantis);
 $gradient-dev-callout: linear-gradient(to bottom, darken($slate, 10%), $slate);
 

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -12,15 +12,48 @@ $aside-width: 300px;
 }
 
 .release-notes {
-  h2, h3 {
+  h2.is-size-h1 {
     margin-left: -25px;
-    display: flex;
+    display: block;
+  }
+  h2,
+  h3 {
+    display: block;
   }
 }
 
 .sg-remarked-linked-header {
+  display: block;
+}
+
+.sg-remarked-linked-header > a.anchor {
   margin-left: -25px;
-  display: flex;
+}
+
+/* Pad linked headers so they are not hidden behind the fixed top navbar
+Navbar height is:
+  256px at $width-small-mobile (its tallest)
+  138px at $width-medium (its shortest) */
+.sg-remarked-linked-header::before,
+.release-notes h2::before {
+  display: block;
+  height: 262px;
+  margin-top: -262px;
+  content: '';
+  visibility: hidden;
+
+  @media (min-width: $width-nav-small) {
+    height: 243px;
+    margin-top: -243px;
+  }
+  @media (min-width: $width-nav-medium) {
+    height: 223px;
+    margin-top: -223px;
+  }
+  @media (min-width: $width-small) {
+    height: 145px;
+    margin-top: -145px;
+  }
 }
 
 .doc-main {
@@ -28,15 +61,15 @@ $aside-width: 300px;
   padding: 0 $scaleup-8 $scaleup-6;
 
   @media (min-width: 991px) {
-      overflow: hidden;
+    overflow: hidden;
   }
 
   @media (max-width: $width-medium) {
     padding: 0 0 $scaleup-6;
   }
 
-
-  ol, ul {
+  ol,
+  ul {
     margin: $scaleup-1 0 $scaleup-1 $scaleup-1;
 
     li {


### PR DESCRIPTION
When linking to a header anchor (e.g. #sending-email),
the target anchor would be scrolled to the top of the page and
be hidden behind the navbar. This PR adds margin to the top
of these anchors, so they are now scrolled to just below the
navbar.

**Description of the change**: Add margin to headers with anchors to show below site navbar
**Reason for the change**: 
When sending links to page sections, the page section is hidden behind the navbar, which is confusing for people who may not know to scroll the page.
**Link to original source**: An example: https://sendgrid.com/docs/ui/sending-email/how-to-send-email-with-marketing-campaigns/#add-contacts

The approach to the solution is here: https://css-tricks.com/hash-tag-links-padding/

To maintain the type of header layout when text wraps that was there with `display: flex`, I removed the negative margin from the headers, which are now `display: block`. I then targeted the anchor SVG and added the margin to it to achieve the same visual layout. I hope it helps. Let me know if it needs work.

I tested on:
* Windows 10 current version of Edge and Firefox
* MacOS 10.14 Mojave current Firefox, Safari, Chrome
* iOS 12 current Safari.

<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

