### PR TITLE
Revert CSS header link margin commit

### DIFF
--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -5,8 +5,6 @@ $border-radius: 2px;
 
 // breakpoints
 $width-small-mobile: 320px;
-$width-nav-small: 350px;
-$width-nav-medium: 493px;
 $width-small: 610px;
 $width-medium: 990px;
 $width-large: 1200px;
@@ -129,18 +127,9 @@ $alert-verification: $mantis;
 $alert-trial: $slate;
 
 // gradients
-$gradient-hero: linear-gradient(
-  165deg,
-  rgba(209, 230, 249, 1) 0%,
-  rgba(243, 249, 253, 1) 75%,
-  rgba(255, 255, 255, 1) 100%
-);
-$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1);
-$gradient-callout: linear-gradient(
-  300deg,
-  rgba(36, 132, 223, 1) 0%,
-  rgba(92, 176, 255, 1) 75%
-);
+$gradient-hero: linear-gradient(165deg, rgba(209,230,249,1) 0%, rgba(243,249,253,1) 75%, rgba(255,255,255,1) 100%);
+$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1 );
+$gradient-callout: linear-gradient(300deg, rgba(36,132,223,1) 0%, rgba(92,176,255,1) 75%);
 $gradient-dev-glossary: linear-gradient(to bottom right, $kiwi, $mantis);
 $gradient-dev-callout: linear-gradient(to bottom, darken($slate, 10%), $slate);
 

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -12,48 +12,15 @@ $aside-width: 300px;
 }
 
 .release-notes {
-  h2.is-size-h1 {
+  h2, h3 {
     margin-left: -25px;
-    display: block;
-  }
-  h2,
-  h3 {
-    display: block;
+    display: flex;
   }
 }
 
 .sg-remarked-linked-header {
-  display: block;
-}
-
-.sg-remarked-linked-header > a.anchor {
   margin-left: -25px;
-}
-
-/* Pad linked headers so they are not hidden behind the fixed top navbar
-Navbar height is:
-  256px at $width-small-mobile (its tallest)
-  138px at $width-medium (its shortest) */
-.sg-remarked-linked-header::before,
-.release-notes h2::before {
-  display: block;
-  height: 262px;
-  margin-top: -262px;
-  content: '';
-  visibility: hidden;
-
-  @media (min-width: $width-nav-small) {
-    height: 243px;
-    margin-top: -243px;
-  }
-  @media (min-width: $width-nav-medium) {
-    height: 223px;
-    margin-top: -223px;
-  }
-  @media (min-width: $width-small) {
-    height: 145px;
-    margin-top: -145px;
-  }
+  display: flex;
 }
 
 .doc-main {
@@ -61,15 +28,15 @@ Navbar height is:
   padding: 0 $scaleup-8 $scaleup-6;
 
   @media (min-width: 991px) {
-    overflow: hidden;
+      overflow: hidden;
   }
 
   @media (max-width: $width-medium) {
     padding: 0 0 $scaleup-6;
   }
 
-  ol,
-  ul {
+
+  ol, ul {
     margin: $scaleup-1 0 $scaleup-1 $scaleup-1;
 
     li {


### PR DESCRIPTION
The PR #5658 added a bug causing some header
links negative margins to overlap links above them. 
This made them unclickable. This is a roll back until
that can be fixed in a robust way.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

