### PR TITLE
Add top margin to Markdown anchor links

### DIFF
--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -5,8 +5,6 @@ $border-radius: 2px;
 
 // breakpoints
 $width-small-mobile: 320px;
-$width-nav-small: 350px;
-$width-nav-medium: 493px;
 $width-small: 610px;
 $width-medium: 990px;
 $width-large: 1200px;
@@ -129,18 +127,9 @@ $alert-verification: $mantis;
 $alert-trial: $slate;
 
 // gradients
-$gradient-hero: linear-gradient(
-  165deg,
-  rgba(209, 230, 249, 1) 0%,
-  rgba(243, 249, 253, 1) 75%,
-  rgba(255, 255, 255, 1) 100%
-);
-$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1);
-$gradient-callout: linear-gradient(
-  300deg,
-  rgba(36, 132, 223, 1) 0%,
-  rgba(92, 176, 255, 1) 75%
-);
+$gradient-hero: linear-gradient(165deg, rgba(209,230,249,1) 0%, rgba(243,249,253,1) 75%, rgba(255,255,255,1) 100%);
+$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1 );
+$gradient-callout: linear-gradient(300deg, rgba(36,132,223,1) 0%, rgba(92,176,255,1) 75%);
 $gradient-dev-glossary: linear-gradient(to bottom right, $kiwi, $mantis);
 $gradient-dev-callout: linear-gradient(to bottom, darken($slate, 10%), $slate);
 

--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -5,6 +5,8 @@ $border-radius: 2px;
 
 // breakpoints
 $width-small-mobile: 320px;
+$width-nav-small: 350px;
+$width-nav-medium: 493px;
 $width-small: 610px;
 $width-medium: 990px;
 $width-large: 1200px;
@@ -127,9 +129,18 @@ $alert-verification: $mantis;
 $alert-trial: $slate;
 
 // gradients
-$gradient-hero: linear-gradient(165deg, rgba(209,230,249,1) 0%, rgba(243,249,253,1) 75%, rgba(255,255,255,1) 100%);
-$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1 );
-$gradient-callout: linear-gradient(300deg, rgba(36,132,223,1) 0%, rgba(92,176,255,1) 75%);
+$gradient-hero: linear-gradient(
+  165deg,
+  rgba(209, 230, 249, 1) 0%,
+  rgba(243, 249, 253, 1) 75%,
+  rgba(255, 255, 255, 1) 100%
+);
+$gradient-home-featured: linear-gradient(315deg, $seafoam, #6afcb1);
+$gradient-callout: linear-gradient(
+  300deg,
+  rgba(36, 132, 223, 1) 0%,
+  rgba(92, 176, 255, 1) 75%
+);
 $gradient-dev-glossary: linear-gradient(to bottom right, $kiwi, $mantis);
 $gradient-dev-callout: linear-gradient(to bottom, darken($slate, 10%), $slate);
 

--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -5,6 +5,8 @@ $border-radius: 2px;
 
 // breakpoints
 $width-small-mobile: 320px;
+$width-nav-small: 350px;
+$width-nav-medium: 493px;
 $width-small: 610px;
 $width-medium: 990px;
 $width-large: 1200px;

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -11,17 +11,64 @@ $aside-width: 300px;
   }
 }
 
-.release-notes {
-  h2, h3 {
-    margin-left: -25px;
-    display: flex;
+/* Push headings below paragraphs in the
+stacking order to prevent covering links */
+.release-note {
+  h2 {
+    display: block;
+    position: relative;
+    z-index: 1;
+  }
+  h3 {
+    display: block;
+    position: relative;
+    z-index: 0;
   }
 }
 
-.sg-remarked-linked-header {
-  margin-left: -25px;
-  display: flex;
+/* Pull elements above headings in the
+stacking order to prevent covering links */
+.release-notes-key, .release-note p {
+  position: relative;
+  z-index: 2;
 }
+
+.sg-remarked-linked-header {
+  display: block;
+
+  & > a.anchor {
+    margin-left: -25px;
+  }
+}
+
+
+/* Pad linked headers so they are not hidden behind the fixed top navbar
+Navbar height is:
+  256px at $width-small-mobile (its tallest)
+  138px at $width-medium (its shortest) */
+.doc-main > div > .sg-remarked-linked-header::before,
+.release-note h2::before,
+.release-note h3::before {
+  display: block;
+  height: 262px;
+  margin-top: -262px;
+  content: '';
+  visibility: hidden;
+
+  @media (min-width: $width-nav-small) {
+    height: 243px;
+    margin-top: -243px;
+  }
+  @media (min-width: $width-nav-medium) {
+    height: 223px;
+    margin-top: -223px;
+  }
+  @media (min-width: $width-small) {
+    height: 145px;
+    margin-top: -145px;
+  }
+}
+
 
 .doc-main {
   flex: 1;

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -12,48 +12,15 @@ $aside-width: 300px;
 }
 
 .release-notes {
-  h2.is-size-h1 {
+  h2, h3 {
     margin-left: -25px;
-    display: block;
-  }
-  h2,
-  h3 {
-    display: block;
+    display: flex;
   }
 }
 
 .sg-remarked-linked-header {
-  display: block;
-}
-
-.sg-remarked-linked-header > a.anchor {
   margin-left: -25px;
-}
-
-/* Pad linked headers so they are not hidden behind the fixed top navbar
-Navbar height is:
-  256px at $width-small-mobile (its tallest)
-  138px at $width-medium (its shortest) */
-.sg-remarked-linked-header::before,
-.release-notes h2::before {
-  display: block;
-  height: 262px;
-  margin-top: -262px;
-  content: '';
-  visibility: hidden;
-
-  @media (min-width: $width-nav-small) {
-    height: 243px;
-    margin-top: -243px;
-  }
-  @media (min-width: $width-nav-medium) {
-    height: 223px;
-    margin-top: -223px;
-  }
-  @media (min-width: $width-small) {
-    height: 145px;
-    margin-top: -145px;
-  }
+  display: flex;
 }
 
 .doc-main {
@@ -61,15 +28,15 @@ Navbar height is:
   padding: 0 $scaleup-8 $scaleup-6;
 
   @media (min-width: 991px) {
-    overflow: hidden;
+      overflow: hidden;
   }
 
   @media (max-width: $width-medium) {
     padding: 0 0 $scaleup-6;
   }
 
-  ol,
-  ul {
+
+  ol, ul {
     margin: $scaleup-1 0 $scaleup-1 $scaleup-1;
 
     li {

--- a/src/templates/doc.scss
+++ b/src/templates/doc.scss
@@ -12,15 +12,48 @@ $aside-width: 300px;
 }
 
 .release-notes {
-  h2, h3 {
+  h2.is-size-h1 {
     margin-left: -25px;
-    display: flex;
+    display: block;
+  }
+  h2,
+  h3 {
+    display: block;
   }
 }
 
 .sg-remarked-linked-header {
+  display: block;
+}
+
+.sg-remarked-linked-header > a.anchor {
   margin-left: -25px;
-  display: flex;
+}
+
+/* Pad linked headers so they are not hidden behind the fixed top navbar
+Navbar height is:
+  256px at $width-small-mobile (its tallest)
+  138px at $width-medium (its shortest) */
+.sg-remarked-linked-header::before,
+.release-notes h2::before {
+  display: block;
+  height: 262px;
+  margin-top: -262px;
+  content: '';
+  visibility: hidden;
+
+  @media (min-width: $width-nav-small) {
+    height: 243px;
+    margin-top: -243px;
+  }
+  @media (min-width: $width-nav-medium) {
+    height: 223px;
+    margin-top: -223px;
+  }
+  @media (min-width: $width-small) {
+    height: 145px;
+    margin-top: -145px;
+  }
 }
 
 .doc-main {
@@ -28,15 +61,15 @@ $aside-width: 300px;
   padding: 0 $scaleup-8 $scaleup-6;
 
   @media (min-width: 991px) {
-      overflow: hidden;
+    overflow: hidden;
   }
 
   @media (max-width: $width-medium) {
     padding: 0 0 $scaleup-6;
   }
 
-
-  ol, ul {
+  ol,
+  ul {
     margin: $scaleup-1 0 $scaleup-1 $scaleup-1;
 
     li {


### PR DESCRIPTION
**Description of the change**: This change prevents linked anchors from scrolling to the top of the window and becoming hidden behind the navbar.
**Reason for the change**: When sending links to page sections (e.g. /#sender-validation), the heading is hidden behind the nav and search bars.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

