### PR TITLE
[Docs]: add contributing guidelines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ The master branch is continuously deployed to production.
 
 ## Table of Contents
 
-* [CLAs and CCLAs](#cla)
+* [Contributing Guidelines](#contributing)
 * [Local Setup](#local)
 * [About](#about)
 * [License](#license)
 
-<a name="cla"></a>
+<a name="contributing"></a>
 ## Contributing
 
 Please see the [contributing guidelines](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -27,14 +27,9 @@ The master branch is continuously deployed to production.
 * [License](#license)
 
 <a name="cla"></a>
-## CLAs and CCLAs
+## Contributing
 
-Before you get started, SendGrid requires that a SendGrid Contributor License Agreement (CLA) be filled out by every contributor to a SendGrid open source project.
-
-Our goal with the CLA is to clarify the rights of our contributors and reduce other risks arising from inappropriate contributions. The CLA also clarifies the rights SendGrid holds in each contribution and helps to avoid misunderstandings over what rights each contributor is required to grant to SendGrid when contributing. In this way, the CLA encourages broad participation by our open source community and helps us build strong open source projects, free from any individual contributor withholding or revoking rights to any contribution.
-
-
-SendGrid does not merge a pull request made against a SendGrid open source project until that pull request is associated with a signed CLA. Copies of the CLA are available [here](https://gist.github.com/SendGridDX/98b42c0a5d500058357b80278fde3be8#file-sendgrid_cla).
+Please see the [contributing guidelines](./CONTRIBUTING.md).
 
 <a name="local"></a>
 ## Local Setup


### PR DESCRIPTION
- Included a link to the `CONTRIBUTING.md` file.
- Removed CLA information as it would appear redundant with this update.