### PR TITLE
Fix broken link formatting

### DIFF
--- a/content/docs/ui/sending-email/migrating-from-legacy-marketing-campaigns.md
+++ b/content/docs/ui/sending-email/migrating-from-legacy-marketing-campaigns.md
@@ -17,7 +17,7 @@ The new Marketing Campaigns builds on the existing, well-loved workflows for bui
 
 ### Automation
 
-Create a recurring email or series of emails that send automatically whenever a contact joins a list. Choose when each email sends, and whether a contact should exit the automation if they no longer meet the entry criteria. [Learn More] ({{root_url}}/ui/sending-email/getting-started-with-automation/). 
+Create a recurring email or series of emails that send automatically whenever a contact joins a list. Choose when each email sends, and whether a contact should exit the automation if they no longer meet the entry criteria. [Learn More]({{root_url}}/ui/sending-email/getting-started-with-automation/). 
 
 ### Email Testing 
 


### PR DESCRIPTION
**Description of the change**: Remove space from Markdown link
**Reason for the change**: Link was broken
**Link to original source**: https://sendgrid.com/docs/ui/sending-email/migrating-from-legacy-marketing-campaigns/
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

