### PR TITLE
Fix link formatting in response codes table

### DIFF
--- a/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
+++ b/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
@@ -54,7 +54,7 @@ Each SMTP call you make returns a response. `200` responses are usually success 
   <tr>
     <td>451</td>
     <td>`Authentication failed: Maximum credits exceeded`</td>
-    <td>There is a credit limit of emails per day enforced in error. [Contact support](https://support.sendgrid.com/hc/en-us) to remove that limit.</td>
+    <td>There is a credit limit of emails per day enforced in error. Contact support at https://support.sendgrid.com/hc/en-us to remove that limit.</td>
   </tr>
   <tr>
     <td>452</td>


### PR DESCRIPTION
**Description of the change**:
Fixes link formatting in response codes table

**Reason for the change**:
Improves presentation.

#### Before:
<img width="880" alt="Screen Shot 2019-12-31 at 11 44 35" src="https://user-images.githubusercontent.com/273718/71632428-5ef5b700-2bc3-11ea-9886-c8aa23ffb615.png">

#### After:
<img width="907" alt="Screen Shot 2019-12-31 at 11 45 28" src="https://user-images.githubusercontent.com/273718/71632433-67e68880-2bc3-11ea-8424-3d0bdac1052e.png">

**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
N/A

