### PR TITLE
Add deprecation warning to SMTP Sections page

### DIFF
--- a/source/API_Reference/SMTP_API/section_tags.md
+++ b/source/API_Reference/SMTP_API/section_tags.md
@@ -10,6 +10,10 @@ navigation:
   show: true
 ---
 
+{% warning %}
+Due to low usage, this setting will be deprecated Q1 of 2020. [Click](https://sendgrid.com/docs/ui/account-and-settings/retired-mail-settings/) here for more information.
+{% endwarning %}
+
 Section tags allow you to substitute in content in an SMTP message. Section tags are similar to [substitution tags]({{root_url}}/API_Reference/SMTP_API/substitution_tags.html) but are specific to the message, and not the recipient. You have to have a substitution tag value for **each** recipient, but you can have any number of section tags. Section tags can then contain Substitution tags for the recipient if needed. Section tags have to be contained within a Substitution tag since SendGrid needs to know which data to populate for the recipient.
 See the [Section Tag Example Walkthrough](#-Section-Tag-Example-Walkthrough) below.
 


### PR DESCRIPTION
**Reason for the change**: Low usage features are being deprecated. This informs customers of the upcoming change.
**Link to original source**: https://sendgrid.com/docs/API_Reference/SMTP_API/section_tags.html

