### PR TITLE
Update phone support time to match the automated call system

### DIFF
--- a/content/docs/ui/account-and-settings/support.md
+++ b/content/docs/ui/account-and-settings/support.md
@@ -26,4 +26,4 @@ You can contact SendGrid support from the [SendGrid Support Portal](https://supp
  	
 * Ticket support - 24/7
 * Chat support - 24/7
-* Phone support is available 7:00AM - 5:00PM MST, Monday - Friday.
+* Phone support is available 8:00AM - 5:00PM MST, Monday - Friday.

--- a/content/docs/ui/account-and-settings/support.md
+++ b/content/docs/ui/account-and-settings/support.md
@@ -20,10 +20,10 @@ navigation:
   <div class="col-md-4"></div>
 </div>
 
-You can contact SendGrid support from the [SendGrid Support Portal](https://support.sendgrid.com). Click **Login & Contact Support**, and then **Contact Support** to see your support contact options. Paying SendGrid customers have the option to contact support via phone, chat, or by submitting a ticket using our web form. All SendGrid customers have the option to submit a ticket using our web form.
+You can contact SendGrid support from the [SendGrid Support Portal](https://support.sendgrid.com). Click **Login & Contact Support**, and then **Contact Support** to see your support contact options. Paying SendGrid customers have the option to contact support via chat, or by submitting a ticket using our web form. SendGrid customers with a Pro or higher tier plan have access to phone support as well. All SendGrid customers have the option to submit a ticket using our web form.
 
 ## 	Support Hours
  	
 * Ticket support - 24/7
-* Chat support - 24/7
-* Phone support is available 8:00AM - 5:00PM MST, Monday - Friday.
+* Chat support - 24/7 (For paying customers) 
+* Phone support is available for customers with a Pro or higher account 7:00AM - 5:00PM MST, Monday - Friday.


### PR DESCRIPTION
Hey, I've been trying to reach your support team but have had no luck with either my support ticket or callbacks.

One thing I did spot was that the automated call system states you open 8am not 7am.

Also, the chat widget isn't there anymore on the site. I suspect that either that line should be removed or something needs fixing.

Cheers!

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

