### PR TITLE
 ping and traceroute troubleshooting with hping 

### DIFF
--- a/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
+++ b/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
@@ -32,7 +32,7 @@ Experiencing delays? Check our [Status Page](http://status.sendgrid.com/) for th
 * [Go](https://github.com/sendgrid/sendgrid-go/blob/master/README.md)
 * [Java](https://github.com/sendgrid/sendgrid-java/blob/master/README.md)
 
-**2.** You can use our SMTPAPI to greatly increase your message throughput. As with SMTP, 100 messages can be sent with each connection, but there can be 1000 [TO: recipients]({{root_url}}/for-developers/sending-email/getting-started-smtp/) for each message using the x-smtpapi header. You can use this option through SMTP sending as well as the [Web API v3]({{root_url}}/api-reference).
+**2.** You can use our SMTPAPI to greatly increase your message throughput. As with SMTP, 5000 messages can be sent with each connection, but there can be 1000 [TO: recipients]({{root_url}}/for-developers/sending-email/getting-started-smtp/) for each message using the x-smtpapi header. You can use this option through SMTP sending as well as the [Web API v3]({{root_url}}/api-reference).
 
 **3.** Lastly, you can try to open additional connections from your end: Generally, we recommend a maximum of 10 concurrent connections. However, please note that SendGrid can generally handle as much mail as you can throw at us. One thing to ensure is to make certain that the maximum amount of mail is passed before terminating each connection. We recommend using caution when incrementing your number of active connections.
 
@@ -40,14 +40,11 @@ Experiencing delays? Check our [Status Page](http://status.sendgrid.com/) for th
 
 More often that not, one of the 3 suggestions above will resolve a latency problem. However, some latency issues are simply due to the quality of your connection or traffic shaping. There is always the possibility that network problem issue lies with either yours or your ISPs configuration. Below are a number of methods that will help you determine where a latency issue really is.
 
-**Installing hping**
-- Open "terminal". Type "brew install hping".
-
 **Hping**
-1. We'll begin with hping. You should always test hping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a hping command to our SMTP server at **smtp.sendgrid.net**
-2. How to run hping: Open “terminal”. Type “sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S” and you will see a ping occur continually.
+1. We'll begin with [hping](http://www.hping.org/). You should always test hping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a hping command to our SMTP server at **smtp.sendgrid.net**
+2. How to run hping: Open “terminal”. Type “sudo hping smtp.sendgrid.net -p 587 -S” and you will see a ping occur continually.
 ```
-sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S
+sudo hping smtp.sendgrid.net -p 587 -S
 Password:
 HPING smtp.sendgrid.net (gpd0 169.45.89.186): S set, 40 headers + 0 data bytes
 len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=0 win=29200 rtt=40.5 ms
@@ -69,9 +66,9 @@ round-trip min/avg/max = 40.5/44.5/51.8 ms
 **Hping - traceroute mode**
 
 1. A traceroute is along the same lines as a ping, you can think of a traceroute as a deeper analysis in the sense that it allows you to see at which “hop” the latency may begin to occur. You are able to see every stop along the route that the packet travels from the customer’s network to SendGrid’s servers. At each stop, details are given as to the address it travels to, and the amount of time to get there also in milliseconds.
-2. How to run a traceroute: Open “terminal” and type “sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S -T -c 10”
+2. How to run a traceroute: Open “terminal” and type “sudo hping smtp.sendgrid.net -p 587 -S -T -c 10”
 ```
-sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S -T -c 10
+sudo hping smtp.sendgrid.net -p 587 -S -T -c 10
 HPING smtp.sendgrid.net (en0 169.45.113.201): S set, 40 headers + 0 data bytess
 hop=1 TTL 0 during transit from ip=172.22.16.1 name=UNKNOWN
 hop=1 hoprtt=2.8 ms

--- a/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
+++ b/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
@@ -41,7 +41,9 @@ Experiencing delays? Check our [Status Page](http://status.sendgrid.com/) for th
 More often that not, one of the 3 suggestions above will resolve a latency problem. However, some latency issues are simply due to the quality of your connection or traffic shaping. There is always the possibility that network problem issue lies with either yours or your ISPs configuration. Below are a number of methods that will help you determine where a latency issue really is.
 
 **Hping**
-1. We'll begin with [hping](http://www.hping.org/). You should always test hping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a hping command to our SMTP server at **smtp.sendgrid.net**
+1. We'll begin with [hping](http://www.hping.org/)
+ (or [Test-NetConnection](https://docs.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=win10-ps) as a Windows alternative).
+ You should always test hping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a hping command to our SMTP server at **smtp.sendgrid.net**
 2. How to run hping: Open “terminal”. Type “sudo hping smtp.sendgrid.net -p 587 -S” and you will see a ping occur continually.
 ```
 sudo hping smtp.sendgrid.net -p 587 -S

--- a/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
+++ b/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
@@ -40,27 +40,52 @@ Experiencing delays? Check our [Status Page](http://status.sendgrid.com/) for th
 
 More often that not, one of the 3 suggestions above will resolve a latency problem. However, some latency issues are simply due to the quality of your connection or traffic shaping. There is always the possibility that network problem issue lies with either yours or your ISPs configuration. Below are a number of methods that will help you determine where a latency issue really is.
 
-**Ping**
+**Installing hping**
+- Open "terminal". Type "brew install hping".
 
-1. We'll begin with the simplest method, Ping! You should always test ping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a ping command to our SMTP server at **smtp.sendgrid.net**
-2. How to ping using _Mac_: Open “terminal” or “network utility”. Type “ping smtp.sendgrid.net” and you will see a ping occur continually. Notice that on Mac there is no need to specify a parameter for continuous ping as in Windows.
-3. How to ping using _Windows_: Open your command prompt, usually by hitting the Windows key, typing "cmd" and hitting enter. Type “ping smtp.sendgrid.net” followed by the enter key. This will create a single ping to one of SendGrid’s IP addresses. Adding the parameter “-t” will allow for a continuous ping.
+**Hping**
+1. We'll begin with hping. You should always test hping to help determine response time and TTL (time to live) in milliseconds. In our troubleshooting scenario below, we'll run a hping command to our SMTP server at **smtp.sendgrid.net**
+2. How to run hping: Open “terminal”. Type “sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S” and you will see a ping occur continually.
+```
+sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S
+Password:
+HPING smtp.sendgrid.net (gpd0 169.45.89.186): S set, 40 headers + 0 data bytes
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=0 win=29200 rtt=40.5 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=1 win=29200 rtt=40.5 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=2 win=29200 rtt=45.7 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=3 win=29200 rtt=42.8 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=4 win=29200 rtt=47.2 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=5 win=29200 rtt=51.8 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=6 win=29200 rtt=42.4 ms
+len=44 ip=169.45.89.186 ttl=49 DF id=0 sport=587 flags=SA seq=7 win=29200 rtt=45.2 ms
+^C
+--- smtp.sendgrid.net hping statistic ---
+8 packets tramitted, 8 packets received, 0% packet loss
+round-trip min/avg/max = 40.5/44.5/51.8 ms
+```
 
 **Anything exceeding 150.000 ms should be the first indication that something may be amiss regarding your network connection. Let your IT department know pronto.**
 
-![]({{root_url}}/images/smtpPING.gif)
+**Hping - traceroute mode**
 
-**Traceroute**
+1. A traceroute is along the same lines as a ping, you can think of a traceroute as a deeper analysis in the sense that it allows you to see at which “hop” the latency may begin to occur. You are able to see every stop along the route that the packet travels from the customer’s network to SendGrid’s servers. At each stop, details are given as to the address it travels to, and the amount of time to get there also in milliseconds.
+2. How to run a traceroute: Open “terminal” and type “sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S -T -c 10”
+```
+sudo /usr/local/sbin/hping smtp.sendgrid.net -p 587 -S -T -c 10
+HPING smtp.sendgrid.net (en0 169.45.113.201): S set, 40 headers + 0 data bytess
+hop=1 TTL 0 during transit from ip=172.22.16.1 name=UNKNOWN
+hop=1 hoprtt=2.8 ms
+hop=2 TTL 0 during transit from ip=4.31.56.1 name=UNKNOWN
+hop=2 hoprtt=15.9 ms
+hop=3 TTL 0 during transit from ip=4.69.203.121 name=ae-1-3501.ear3.sanjose1.level3.net
+hop=3 hoprtt=28.0 ms
+hop=4 TTL 0 during transit from ip=4.7.16.38 name=UNKNOWN
+hop=4 hoprtt=25.9 ms
+hop=5 TTL 0 during transit from ip=50.97.17.78 name=ae6.cbs02.eq01.sjc02.networklayer.com
+hop=5 hoprtt=25.2 ms
+```
 
-1. A Traceroute is along the same lines as a ping, you can think of a traceroute as a deeper analysis in the sense that it allows you to see at which “hop” the latency may begin to occur. You are able to see every stop along the route that the packet travels from the customer’s network to SendGrid’s servers. At each stop, details are given as to the address it travels to, and the amount of time to get there also in milliseconds.
-2. How to run a traceroute on _Mac_: Open “terminal” or “network utility” and type “traceroute smtp.sendgrid.net”
-3. How to run a traceroute on _Windows_: Open your command prompt, and type ”tracert smtp.sendgrid.net”.
-
-**As with the ping method, keep an eye out for any large times over 150.000 ms**. You'll also want to pay close attention to notice if there are any major increases from one hop to the next. This could indicate the inherent latency from when the packet leaves a server in France en route to a server in Canada. Another flag to watch out for are any of the increases early in the transit, as this could mean the latency lies within your local network, or at a certain ISP.
-
-Keep in mind that many modern network nodes will de-prioritize ICMP packets, which traceroute sends, so timeouts at certain hops may not necessarily be indicative of a faulty connection. That said, a traceroute can still go along way in helping isolate where a network issue exists.
-
-![]({{root_url}}/images/smtpTRACE.gif)
+**As with the hping method, keep an eye out for any large times over 150.000 ms**. You'll also want to pay close attention to notice if there are any major increases from one hop to the next. This could indicate the inherent latency from when the packet leaves a server in France en route to a server in Canada. Another flag to watch out for are any of the increases early in the transit, as this could mean the latency lies within your local network, or at a certain ISP.
 
 **Google Header Analyzer**
 

--- a/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
+++ b/content/docs/ui/account-and-settings/troubleshooting-delays-and-latency.md
@@ -84,6 +84,8 @@ hop=5 hoprtt=25.2 ms
 
 **As with the hping method, keep an eye out for any large times over 150.000 ms**. You'll also want to pay close attention to notice if there are any major increases from one hop to the next. This could indicate the inherent latency from when the packet leaves a server in France en route to a server in Canada. Another flag to watch out for are any of the increases early in the transit, as this could mean the latency lies within your local network, or at a certain ISP.
 
+Keep in mind that many modern network nodes will de-prioritize ICMP packets, which traceroute sends, so timeouts at certain hops may not necessarily be indicative of a faulty connection. That said, a traceroute can still go along way in helping isolate where a network issue exists.
+
 **Google Header Analyzer**
 
 Google provides a great free [header analyzer tool](https://toolbox.googleapps.com/apps/messageheader/analyzeheader) that you can use to analyze the headers of an email, and find out how long an email spent in a particular location. For more information on how to grab the original headers from an email, [check here.]({{root_url}}/help0support/account-and-settings/checking-email-source/)


### PR DESCRIPTION
**Description of the change**:
updated troubleshooting steps for ping and traceroute methods with hping 
**Reason for the change**:
The new aws geopods won't support ping or traceroute. This is a tcp alternatives that will work.
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

