### PR TITLE
Corrected bounce/block syntax

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -271,7 +271,8 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
       "sg_event_id":"6g4ZI7SA-xmRDv57GoPIPw==",
       "sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0",
       "reason":"500 unknown recipient",
-      "status":"5.0.0"
+      "status":"5.0.0",
+      "type":"bounce"
    }
 ]
 ```
@@ -292,7 +293,7 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
       "sg_event_id":"6g4ZI7SA-xmRDv57GoPIPw==",
       "sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0",
       "reason":"500 unknown recipient",
-      "status":"5.0.0"
+      "status":"5.0.0",
       "type":"blocked"
    }
 ]


### PR DESCRIPTION
Just added type to bounce event log example and comma to make syntax correct