### PR TITLE
Add PHPMailer SMTP instructions to Drupal page

### DIFF
--- a/content/docs/for-developers/sending-email/drupal.md
+++ b/content/docs/for-developers/sending-email/drupal.md
@@ -6,7 +6,7 @@ group: plugins
 navigation:
   show: true
 ---
-To send emails from Drupal using SendGrid, you may use the SendGrid Integration module, the SMTP Authentication Support module, the Swift Mailer module or the PHPMailer SMTP Module depending on your needs.
+To send emails from Drupal using SendGrid, you may use the SendGrid Integration module, the SMTP Authentication Support module, the Swift Mailer module, or the PHPMailer SMTP Module depending on your needs.
 
 ## 	Using the SendGrid Integration Module
 
@@ -61,5 +61,4 @@ Under **SMTP Authentication**, set your username and password:
 
 -   **Username** - SendGrid Username
 -   **Password** - SendGrid Password
-
 


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

**Description of the change**:

Add basic instructions for integrating the Drupal module PHPMailer SMTP with SendGrid.

I have a screenshot but am unsure how to add it.

![phpmailer_smtp_config](https://user-images.githubusercontent.com/22160890/75828759-b224f980-5e00-11ea-80e7-b1e02cb7f151.png)