### PR TITLE
Update "real-time" to say "over time" for Segment updates

### DIFF
--- a/content/docs/ui/managing-contacts/segmenting-your-contacts.md
+++ b/content/docs/ui/managing-contacts/segmenting-your-contacts.md
@@ -20,7 +20,7 @@ The content on this page describes the experience in the latest version of Marke
 
 </call-out>
 
-You can use the information stored on your contacts from [custom fields]({{root_url}}/ui/managing-contacts/custom-fields/), reserved fields or engagement data (how recipients have engaged with your prior emails) to create segments. Segments are similar to contact lists, except they update in real-time when a contact’s data matches the criteria that you set. Segments can pull from *All Contacts* or any of your Contact lists. 
+You can use the information stored on your contacts from [custom fields]({{root_url}}/ui/managing-contacts/custom-fields/), reserved fields or engagement data (how recipients have engaged with your prior emails) to create segments. Segments are similar to contact lists, except they update over time when a contact’s data matches the criteria that you set. Segments can pull from *All Contacts* or any of your Contact lists. 
 
 When you segment your audience, you are able to create personalized Automation emails and Single Sends that directly address the wants and needs of your particular audience. [Custom fields]({{root_url}}/ui/managing-contacts/custom-fields/) and data about how recipients have interacted with your emails allow you to use unique information to identify contacts for different segments. As the traits of your contacts change and you add more contacts that meet the criteria of your segment over time, your segments will dynamically update to reflect these updates. For example, a segment with the criteria “lives in Denver” or “is under 30 years old” will evolve as a contact’s address changes and they grow older. 
 


### PR DESCRIPTION
**Description of the change**: 
Update "real-time" to say "over time" for Segment contacts to update.

**Reason for the change**:
The real-time here threw me off. I was expecting segments to update as soon as a contact was updated with the criteria needed to be segmented. Seems to be taking from 20 mins to over an hour for segments to update. I saw in the glossary [https://sendgrid.com/docs/glossary/segments/](url) that you use the term "over time". So, I figured that would work here as well. 🙂

It could be useful to add (within X number of hours) to give people an idea on how long it will take before their contacts start receiving emails from their automations tied to their segments, but I know that might be hard to predict.

**Link to original source**:
[https://sendgrid.com/docs/ui/managing-contacts/segmenting-your-contacts/](url)
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
