### PR TITLE
remove utm param from app link

### DIFF
--- a/src/constants/pageLinks.js
+++ b/src/constants/pageLinks.js
@@ -1,5 +1,5 @@
 const LINKS = {
-  APP: 'https://app.sendgrid.com/?utm_source=docs',
+  APP: 'https://app.sendgrid.com/',
   FOR_DEVELOPERS: '/for-developers/',
   GLOSSARY: '/glossary/',
   LOGOUT: 'https://app.sendgrid.com/logout/',


### PR DESCRIPTION
> Using UTM parameters to point from one page of a website to another page within the same website can mess with google analytics data (specifically, it creates a new session).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
