### PR TITLE
Fix search bug that adds anchor to result URLs

### DIFF
--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -32,8 +32,9 @@ class Search extends Component {
         const updatedUrlHits = hits.map(((hit) => {
           const rootUrl = config.env === 'development' ? config.siteUrl + config.pathPrefix : config.siteUrl;
           hit.url = hit.url.replace('#___gatsby', '');
+          hit.url = hit.url.replace('#gatsby-focus-wrapper', '');
           hit.url = hit.url.replace(rootUrl, '');
-          if (hit.anchor === '___gatsby') {
+          if (hit.anchor === '___gatsby' || hit.anchor === 'gatsby-focus-wrapper') {
             hit.anchor = '';
           }
           return hit;


### PR DESCRIPTION
**Description of the change**: When using the site search, the anchor, "#gatsby-focus-wrapper," is added to the result's URL.
**Reason for the change**: The anchor should not be part of the search result because it is a page anchor that is part of each Gatsby page and not a legitimate part of the search result.
**Link to original source**: Search any term from the home page, https://sendgrid.com/docs, and click through to the result. The address bar will show the extraneous anchor.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
