### PR TITLE
Update billing with email credit note

### DIFF
--- a/content/docs/ui/account-and-settings/billing.md
+++ b/content/docs/ui/account-and-settings/billing.md
@@ -155,6 +155,12 @@ If you exceed your allotment of contacts in a given month, you’ll be charged o
 
 ## Email API Plans
 
+<call-out type="warning">
+
+Every email processed by SendGrid uses an email credit. Free, Essentials, Pro, and Premier accounts will see their email credits reset the 1st day of each month at 12:01 Pacific Time.
+
+</call-out>
+
 The [Email API package](https://sendgrid.com/pricing/) includes charges for any emails you send over the Twilio SendGrid Email API. Sending emails through the API with this package will not deduct from your Marketing Campaigns plan.
 
 ### Free


### PR DESCRIPTION
**Description of the change**: Add note to billing page
**Reason for the change**: Documentation relating email credits to emails sent was missing.
**Link to original source**: https://sendgrid.com/docs/ui/account-and-settings/billing/

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
