### PR TITLE
Added line 28

### DIFF
--- a/content/docs/for-developers/sending-email/django.md
+++ b/content/docs/for-developers/sending-email/django.md
@@ -25,6 +25,7 @@ EMAIL_USE_TLS = True
 ```
 
 Then to send email you can do the following:
+Inside yourapp.views.py
 
 ``` python
 from django.core.mail import send_mail


### PR DESCRIPTION
It took me a lot of time to realize that the 'send email' code was located at myapp.views.py. So I am suggesting adding its description  (on line 28) so that newer django developers can easily locate where to use the code.

**Description of the change**:
**Reason for the change**:
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
