### PR TITLE
Release only originating ip docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
     "stylelint": "^11.1.1",
     "stylelint-config-standard": "^19.0.0"
   },
-  "resolutions": {
-    "**/**/serialize-javascript": "^2.1.1"
-  },
   "keywords": [
     "gatsby"
   ],

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "stylelint": "^11.1.1",
     "stylelint-config-standard": "^19.0.0"
   },
+  "resolutions": {
+    "**/**/serialize-javascript": "^2.1.1"
+  },
   "keywords": [
     "gatsby"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12756,10 +12756,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
**Description of the change**: Releasing the removal of originating ip docs.
**Reason for the change**: Changes have been made in `develop` branch, but there are other changes in the `develop` branch that have not yet been vetted. These docs need to go out now.

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
