### PR TITLE
Remove unnecessary string escaping

### DIFF
--- a/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
+++ b/content/docs/for-developers/sending-email/smtp-errors-and-troubleshooting.md
@@ -122,9 +122,9 @@ When you try to send an invalid X-SMTPAPI header, you will get an email with det
 
  *To update your certificates:*
 
-1. Download the GoDaddy CA bundle from [https://certs.godaddy.com/anonymous/repository.pki](https://certs.godaddy.com/anonymous/repository.pki) (grab the one called `"gd\_bundle-g2-g1.crt"`).
+1. Download the GoDaddy CA bundle from [https://certs.godaddy.com/anonymous/repository.pki](https://certs.godaddy.com/anonymous/repository.pki) (grab the one called `"gd_bundle-g2-g1.crt"`).
 1. Save that on your server.
-1. Tell Postfix where to find it by adding or editing the following line in `/etc/postfix/` [main.cf](http://main.cf/): `"smtp\_tls\_CAfile = /etc/postfix/ssl/gd\_bundle-g2-g1.crt"`
+1. Tell Postfix where to find it by adding or editing the following line in `/etc/postfix/` [main.cf](http://main.cf/): `"smtp_tls_CAfile = /etc/postfix/ssl/gd_bundle-g2-g1.crt"`
 1. Restart Postfix to make the change take effect.
 
  If the mail server communicates with more than just us, add this certificate to your existing CA bundle (frequently called `ca-bundle.crt`).


### PR DESCRIPTION
**Description of the change**: Remove backslashes from strings already escaped with backticks. The backslashes appear in the strings on the [live documentation page](https://sendgrid.com/docs/for-developers/sending-email/smtp-errors-and-troubleshooting/#certificate-verification-failed-for-smtpsendgridnet), making them inaccurate. For example, people adding the line with backslashes to their Postfix configuration file will receive an error.

**Reason for the change**: This makes the documentation more accurate.

**Link to original source**: n/a

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
