### PR TITLE
Fix pull request branch name in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -264,6 +264,6 @@ via `_plugins/jekyll_asset_pipeline.rb`.
    ```
 
 7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/)
-    with a clear title and description against the `master` branch. All tests must be passing before we will review the PR.
+    with a clear title and description against the `develop` branch. All tests must be passing before we will review the PR.
 
 If you have any additional questions, please feel free to [email](mailto:dx@sendgrid.com) us or create an issue in this repo.


### PR DESCRIPTION
**Description of the change**: Update CONTRIBUTING to advise opening pull requests against the `develop` branch, not `master`. This advice contradicts all other documentation (including earlier in the same file) and is outdated.

Note that I have only updated `.github/CONTRIBUTING` and not the `CONTRIBUTING` file in the repository's root folder. See #5879.  

**Reason for the change**: Someone who only reads the "Creating a Pull Request" section might think that they need to have their pull request based on the `master` branch instead of `develop`.

**Link to original source**: n/a


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
