### PR TITLE
Update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,10 +1,16 @@
 
 <!-- 
-If you have a question, please do not ask it here, please [contact our support team](https://support.sendgrid.com).
-You can contact SendGrid support from the [SendGrid Support Portal](https://support.sendgrid.com). 
-Click **Login & Contact Support**, and then **Contact Support** to see your contact options.
+Please avoid submitting support questions here. You can contact our support team at https://support.sendgrid.com.
 
-If you're reporting an issue with our docs, thanks for letting us know!
+If you are able to login to https://support.sendgrid.com:
+1. Click "Login & Contact Support."
+2. Then, select "Contact Support" to see your contact options.
+
+If you are unable to login to https://support.sendgrid.com:
+1. Click "Trouble Logging in?"
+2. Then, select "I am having a different login issue."
+
+If you are reporting an issue with our docs, thanks for letting us know!
 -->
 
 ## Expected content

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,10 +1,13 @@
+### Checklist
+**Required**
+- [ ] I acknowledge that all my contributions will be made under the project's license.
+
+### PR Details
 **Description of the change**:
 **Reason for the change**:
 **Link to original source**:
+
 <!-- 
-If this pull request closes an issue, add in the issue number here 
+If this pull request closes an issue, add the issue number here:  
 -->
 Closes #
-
-### Checklist
-- [ ] I acknowledge that all my contributions will be made under the project's license


### PR DESCRIPTION
**Description of the change**: Update GitHub PR and Issues templates
**Reason for the change**: Moves the most important information to the top in the PR template. Also attempts to provide better help for users submitting support Issues.
**Link to original source**: NA

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
