### PR TITLE
Add Not PII alert to relevant docs

### DIFF
--- a/content/docs/for-developers/partners/magento.md
+++ b/content/docs/for-developers/partners/magento.md
@@ -13,94 +13,98 @@ navigation:
 
 This extension allows you to configure Magento 2.0 to send all emails using SendGrid. To get started, [click here](https://marketplace.magento.com/sendgrid-email-delivery-simplified.html)!
 
-## 	Description
+## Description
 
 The official SendGrid extension for Magento 2.0 makes it easy to ensure delivery of your most important transactional emails. Purchase receipts, shipping confirmations, and password reset emails are at the core of how you engage with your customers, helping to fuel your store’s growth. Email delivery is our passion. Entrust our industry-leading email delivery platform, including world-class deliverability tools and expertise to make sure your transactional emails get to the inbox.
 
 Transactional email is an important component of any email communication strategy. SendGrid relieves businesses of the cost and complexity of maintaining custom email systems. SendGrid provides reliable delivery, scalability, and real-time analytics along with flexible APIs that make custom integration a breeze. SendGrid for Magento 2.0 allows you to choose between the SMTP relay or the Email API to send outgoing emails from your Magento installation.
 
-## 	Main Features
+## Main Features
 
- ### 	Proven Deliverability
+### Proven Deliverability
 
 Trusted email deliverability features including email authentication, reputation monitoring, dedicated IP addresses, and more.
 
- ### 	Scale with Confidence
+### Scale with Confidence
 
 Our world-class email platform delivers over 30 billion emails per month for our customers.
 
- ### 	Support
+### Support
 
 [24/7 support](https://support.sendgrid.com) available to answer your email needs. We also provide a full library of self-support materials here.
 
- ### 	Reporting
+### Reporting
 
 Learn more about your shoppers’ engagement with performance feedback and real-time analytics on requests, deliveries, opens, bounces, unsubscribes, clicks, and more.
 
-## 	What’s the functionality of your extension?
+## What’s the functionality of your extension?
 
-* Our extension easily integrates with your SendGrid API key and allows you to send your Magento email with confidence through our world-class infrastructure.
-* In addition to reliable delivery and scalability, our extension allows you have access to real-time analytics and insights for quick, well-informed decision making about your customers to grow your e-commerce store.
-* Integrate easily with your SendGrid API key.
+- Our extension easily integrates with your SendGrid API key and allows you to send your Magento email with confidence through our world-class infrastructure.
+- In addition to reliable delivery and scalability, our extension allows you have access to real-time analytics and insights for quick, well-informed decision making about your customers to grow your e-commerce store.
+- Integrate easily with your SendGrid API key.
 
-## 	What makes your extension unique?
+## What makes your extension unique?
 
-* SendGrid pioneered the cloud-based email industry, and we are trusted by leading senders like Uber, AirBnB, and Spotify to achieve optimal deliverability at scale.
-* Flexible API and SMTP setup for easy transactional email Integration.
-* Key email deliverability features including email authentication, reputation monitoring, dedicated IP addresses, and more.
-* Real-time analytics and reporting including opens, clicks, bounces, unsubscribe tracking, and more.
-* Leverage our step-by-step documentation or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
-* This official extension was built for M2 by SendGrid’s dedicated partner-focused teams for continued management and future development.
+- SendGrid pioneered the cloud-based email industry, and we are trusted by leading senders like Uber, AirBnB, and Spotify to achieve optimal deliverability at scale.
+- Flexible API and SMTP setup for easy transactional email Integration.
+- Key email deliverability features including email authentication, reputation monitoring, dedicated IP addresses, and more.
+- Real-time analytics and reporting including opens, clicks, bounces, unsubscribe tracking, and more.
+- Leverage our step-by-step documentation or get quick help from our [24/7 Support Team](https://support.sendgrid.com).
+- This official extension was built for M2 by SendGrid’s dedicated partner-focused teams for continued management and future development.
 
-## 	Configuration
+## Configuration
 
-First, log in to your **Magento Dashboard**, then click  **System** in the left-hand navigation bar. Select **SendGrid** and click **Settings**. Here, you can enter your SendGrid account settings.
+First, log in to your **Magento Dashboard**, then click **System** in the left-hand navigation bar. Select **SendGrid** and click **Settings**. Here, you can enter your SendGrid account settings.
 
 1. To get the SendGrid plugin running after activation, navigate to the plugin's settings page and enter your **SendGrid API Key**. Next, choose how your email will be sent (SMTP Relay or Email API).
 
-    ![]({{root_url}}/images/magento_1.jpg)
+   ![]({{root_url}}/images/magento_1.jpg)
 
 2. You can also set default values for the "From Name", "Sending Address" and the "Reply Address", so that you don't need to enter values for these headers every time you want to send an email from your application.
 
-    ![]({{root_url}}/images/magento_2.png)
+   ![]({{root_url}}/images/magento_2.png)
 
-    ![]({{root_url}}/images/magento_3.jpg)
+   ![]({{root_url}}/images/magento_3.jpg)
 
+3) Emails are automatically tracked and tagged to provide you with deliverability and engagement statistics viewable from the **SendGrid Dashboard**. You can also add other [categories]({{root_url}}/ui/analytics-and-reporting/categories/) for your emails in the field Categories.
 
-3. Emails are automatically tracked and tagged to provide you with deliverability and engagement statistics viewable from the **SendGrid Dashboard**. You can also add other [categories]({{root_url}}/ui/analytics-and-reporting/categories/) for your emails in the field Categories.
+<call-out type="warning">
 
-    ![]({{root_url}}/images/magento_4.png)
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+![]({{root_url}}/images/magento_4.png)
 
 4. Set the **template ID** to be used in all your emails on the settings page.
 
-    ![]({{root_url}}/images/magento_5.png)
+   ![]({{root_url}}/images/magento_5.png)
 
+5) Next, select the [unsubscribe group]({{root_url}}/ui/sending-email/unsubscribe-groups/).
 
-5. Next, select the [unsubscribe group]({{root_url}}/ui/sending-email/unsubscribe-groups/).
+   ![]({{root_url}}/images/magento_6.png)
 
-    ![]({{root_url}}/images/magento_6.png)
+6) If you would like to [configure categories for statistics]({{root_url}}/ui/analytics-and-reporting/categories/), you can configure it by setting the **Categories** field under **Statistics Settings**.
 
-6. If you would like to [configure categories for statistics]({{root_url}}/ui/analytics-and-reporting/categories/), you can configure it by setting the **Categories** field under **Statistics Settings**.
+   ![]({{root_url}}/images/magento_7.png)
 
-    ![]({{root_url}}/images/magento_7.png)
-
- ### 	Statistics
+### Statistics
 
 Log into your **Magento Dashboard**, then click **System** in the left-hand navigation bar. Select **SendGrid** and click **Statistics** to see your statistics.
 
-  ![]({{root_url}}/images/magento_8.jpg)
+![]({{root_url}}/images/magento_8.jpg)
 
- ### 	Requirements
+### Requirements
 
-* Magento Community Edition 2.x or Magento Enterprise Edition 2.x
+- Magento Community Edition 2.x or Magento Enterprise Edition 2.x
 
-## 	Frequently Asked Questions
+## Frequently Asked Questions
 
- ### 	What credentials do I need to add on settings page?
+### What credentials do I need to add on settings page?
 
 [Create a SendGrid account](https://sendgrid.com/partners/magento/) and [generate a new API key](https://app.sendgrid.com/settings/api_keys). For more information about API Keys, [click here]({{root_url}}/ui/account-and-settings/api-keys/).
 
- ### 	What permissions should my API keys have?
+### What permissions should my API keys have?
 
 Your API Key must have the following permissions:
 

--- a/content/docs/for-developers/sending-email/building-an-x-smtpapi-header.md
+++ b/content/docs/for-developers/sending-email/building-an-x-smtpapi-header.md
@@ -10,31 +10,21 @@ layout: page
 navigation:
   show: true
 ---
+
 Now that you've [sent a test SMTP email with Telnet]({{root_url}}/for-developers/sending-email/getting-started-smtp/), and [integrated with SendGrid]({{root_url}}/for-developers/sending-email/integrating-with-the-smtp-api/), it's time to build content.
 
-## 	Getting started building
+## Getting started building
 
 SMTP works by passing a JSON string with as many SMTP objects as you want to SendGrid. To do this, add the JSON string to your message under a header named "X-SMTPAPI" like this:
 
 ```json
 {
-  "to": [
-    "example@example.com",
-    "example@example.com"
-  ],
+  "to": ["example@example.com", "example@example.com"],
   "sub": {
-    "%name%": [
-      "Ben",
-      "Joe"
-    ],
-    "%role%": [
-      "%sellerSection%",
-      "%buyerSection%"
-    ]
+    "%name%": ["Ben", "Joe"],
+    "%role%": ["%sellerSection%", "%buyerSection%"]
   },
-  "category": [
-    "Orders"
-  ],
+  "category": ["Orders"],
   "unique_args": {
     "orderNumber": "12345",
     "eventID": "6789"
@@ -51,29 +41,29 @@ SMTP works by passing a JSON string with as many SMTP objects as you want to Sen
 }
 ```
 
- ### 	Limitations
+### Limitations
 
 - There is a hard limit of 10,000 addresses in a multiple recipient email. However, the best practice is to split up large jobs to around 1,000 recipients - this allows better processing load distribution. If you have a large number of additional substitutions or sections in the headers, it is best to split the send into even smaller groups.
 - When using the X-SMTPAPI to send to multiple recipients, you cannot use the standard SMTP protocols "TO" field to send to multiple recipients because doing so can generate duplicate messages to the addresses listed in both. For more information, see [RFC 5321](https://tools.ietf.org/html/rfc5321).
 - Ensure that the header is limited to a maximum total line length of 1,000 characters. Failure to do this can cause intermediate MTA's to split the header on non-space boundaries- this causes inserted spaces in the final email. If your email is going through another MTA before reaching SendGrid, it is likely to have an even lower setting for maximum header length and may truncate the header.
 - When using the API, if our system encounters a parsing error, the message will be bounced to the address specified in the MAIL FROM portion of the SMTP session. The MAIL FROM address is re-written when we send the email out for final delivery, so it is safe to set this to an address that can receive the bounces so that you will be alerted to any errors.
-- When sending Unicode characters via the SMTP API, you should escape these characters using the `\u` escape character. When you do this, Unicode characters like ` á` becomes `\u00E1`.
+- When sending Unicode characters via the SMTP API, you should escape these characters using the `\u` escape character. When you do this, Unicode characters like `á` becomes `\u00E1`.
 
-## 	Customizing your send (filters)	
+## Customizing your send (filters)
 
-You can customize the emails you send via SMTP by using different settings (also referred to as filters). Change these settings in the **X-SMTPAPI header**.	
+You can customize the emails you send via SMTP by using different settings (also referred to as filters). Change these settings in the **X-SMTPAPI header**.
 
-The X-SMTPAPI header is a JSON-encoded associative array consisting of several sections, below are examples of JSON strings using each section. Add this header to any SMTP message sent to SendGrid and the instructions in the header will be interpreted and applied to that message’s transaction. You can enable these sections with the X-SMTPAPI header:	
+The X-SMTPAPI header is a JSON-encoded associative array consisting of several sections, below are examples of JSON strings using each section. Add this header to any SMTP message sent to SendGrid and the instructions in the header will be interpreted and applied to that message’s transaction. You can enable these sections with the X-SMTPAPI header:
 
-- [Scheduling Your Send](#scheduling-your-send)	
-- [Substitution Tags](#substitution-tags)	
-- [Suppression Groups](#suppression-groups)	
-- [Categories](#categories)	
-- [Unique Arguments](#unique-arguments)	
-- [SMTP Filters](#smtp-filters)	
+- [Scheduling Your Send](#scheduling-your-send)
+- [Substitution Tags](#substitution-tags)
+- [Suppression Groups](#suppression-groups)
+- [Categories](#categories)
+- [Unique Arguments](#unique-arguments)
+- [SMTP Filters](#smtp-filters)
 - [IP Pools](#ip-pools)
 
- ### 	Scheduling Your Send
+### Scheduling Your Send
 
 Schedule your email send time using the `send_at` parameter within your X-SMTPAPI header. Set the value of `send_at` to the [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time).
 
@@ -85,7 +75,7 @@ Schedule your email send time using the `send_at` parameter within your X-SMTPAP
 
 For more information, see our [scheduling parameters documentation]({{root_url}}/for-developers/sending-email/scheduling-parameters/).
 
- ### 	Substitution Tags
+### Substitution Tags
 
 Substitution tags allow you to dynamically insert specific content relevant to each of your recipients, such as their first and last names.
 
@@ -95,8 +85,9 @@ For example, to use a substitution tag to replace the first name of your recipie
 <html>
   <head></head>
   <body>
-    <p>Hello {{name}},<br>
-        The body of your email would go here...
+    <p>
+      Hello {{name}},<br />
+      The body of your email would go here...
     </p>
   </body>
 </html>
@@ -106,28 +97,22 @@ To define the value that will replace the {{name}} tag, define the following in 
 
 ```json
 {
-  "to": [
-    "john.doeexampexample@example.com",
-    "example@example.com"
-  ],
+  "to": ["john.doeexampexample@example.com", "example@example.com"],
   "sub": {
-    "{{name}}": [
-      "John",
-      "Jane"
-    ]
+    "{{name}}": ["John", "Jane"]
   }
 }
 ```
 
 For more information, see our [substitution tags documentation]({{root_url}}/for-developers/sending-email/substitution-tags/).
 
- ### 	Section Tags
+### Section Tags
 
 Section tags are similar to substitution tags, but rather than replace tags with content for each recipient; section tags allow you to replace a tag with more generic content— like a salutation.
 
 For more information, see our [section tags documentation]({{root_url}}/for-developers/sending-email/section-tags/).
 
- ### 	Suppression Groups
+### Suppression Groups
 
 You can easily specify an unsubscribe group for an email sent via SMTP by including the `asm_group_id` parameter in your X-SMTPAPI header. Simply set the value of `asm_group_id` to the numerical ID of the group you would like to use.
 
@@ -139,7 +124,13 @@ You can easily specify an unsubscribe group for an email sent via SMTP by includ
 
 For more information, see our [suppression groups documentation]({{root_url}}/for-developers/sending-email/suppressions/).
 
- ### 	Categories
+### Categories
+
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 Categories allow you to track your emails according to broad topics that you define, like "Weekly Newsletter" or "Confirmation Email". Simply define the category by using the `category` parameter within your X-SMTPAPI header:
 
@@ -157,7 +148,13 @@ Categories should only be used for broad topics. To attach unique identifiers, p
 
 </call-out>
 
- ### 	Unique Arguments
+### Unique Arguments
+
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 Use unique arguments to track your emails based on specific identifiers unique to individual messages. Unique arguments can be retrieved via SendGrid's [Event Webhook]({{root_url}}/for-developers/tracking-events/event/) or your [email activity page]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/).
 
@@ -181,8 +178,7 @@ For more information, see our [IP Pools documentation]({{root_url}}/API_Referenc
 }
 ```
 
-## 	Additional Resources
-
+## Additional Resources
 
 - [How to send email]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/)
 - [Getting started with the API]({{root_url}}/api-reference/)

--- a/content/docs/for-developers/sending-email/categories.md
+++ b/content/docs/for-developers/sending-email/categories.md
@@ -7,6 +7,12 @@ navigation:
   show: true
 ---
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 You can add [categories]({{root_url}}/glossary/categories/) to the X-SMTPAPI header of the emails you send via SendGrid. This will allow you to track emails based on your own categorization system.
 
 <call-out type="warning">
@@ -17,11 +23,11 @@ Categories must be in 7bit encoding using the US-ASCII character set.
 
 <call-out>
 
-Currently, there is no limit to the number of categories you can track. However, we recommend *no more than ~100 total unique categories* as this will increase your ease of use in the Statistics area. Additionally, a high rate of unique categories on your account can negatively impact the rate at which we process the messages you send.
+Currently, there is no limit to the number of categories you can track. However, we recommend _no more than ~100 total unique categories_ as this will increase your ease of use in the Statistics area. Additionally, a high rate of unique categories on your account can negatively impact the rate at which we process the messages you send.
 
 </call-out>
 
-## 	Example
+## Example
 
 You can use SendGrid's [SMTP API]({{root_url}}/ui/for-developers/sending-email/getting-started-smtp/) to add these categories to your email. The following should be added to the email's header:
 
@@ -32,6 +38,7 @@ When passing `category` please make sure to only use strings as shown in our exa
 </call-out>
 
 ### Example Category Header
+
 ```json
 {
   "category": "Example Category"
@@ -40,18 +47,13 @@ When passing `category` please make sure to only use strings as shown in our exa
 
 In this example, SendGrid would associate statistics for the email containing that header with the category **Example Category**.
 
-## 	Limitations
+## Limitations
 
 You can assign up to 10 categories per message:
 
 ```json
 {
-  "category": [
-    "dogs",
-    "animals",
-    "pets",
-    "mammals"
-  ]
+  "category": ["dogs", "animals", "pets", "mammals"]
 }
 ```
 

--- a/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
+++ b/content/docs/for-developers/sending-email/getting-started-email-activity-api.md
@@ -1,15 +1,16 @@
 ---
 seo:
- title: Getting Started with the Email Activity Feed API
- description: Use the Email Activity Feed query language to get started with the Email Activity Feed API.
- keywords: email activity, query language, email stats, email events
+  title: Getting Started with the Email Activity Feed API
+  description: Use the Email Activity Feed query language to get started with the Email Activity Feed API.
+  keywords: email activity, query language, email stats, email events
 title: Getting Started with the Email Activity Feed API
 group: sending-email
 weight: 0
 layout: page
 navigation:
- show: true
+  show: true
 ---
+
 <call-out>
 
 In order to gain access to the Email Activity Feed API, you must purchase [additional email activity history](https://app.sendgrid.com/settings/billing/addons/email_activity).
@@ -136,7 +137,7 @@ curl --request GET \
 
 There are several operators and keywords that you can use to build [Compound queries](#creating-compound-queries). Use these operators between query statements. If the character used as the delimiter is found within the string. The escape character is `\`, which must be escaped with a preceding `\`. All queries need to be URL encoded.
 
-*This is a full list of accepted operators and keywords:*
+_This is a full list of accepted operators and keywords:_
 
 - `=`
 - `!=`
@@ -174,6 +175,12 @@ There are several operators and keywords that you can use to build [Compound que
 - YEAR
 
 ## Query reference
+
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 This is a full list of basic query types and examples: (replace the data in quotes with the information you want to query, and then URL encode it)
 

--- a/content/docs/for-developers/sending-email/laravel.md
+++ b/content/docs/for-developers/sending-email/laravel.md
@@ -14,10 +14,9 @@ Laravel provides a clean API over the popular SwiftMailer library with drivers f
 
 Laravel 5.5 LTS uses Mailable classes. Mailables in Laravel abstracts building emails with a mailable class. Mailables are responsible for collating data and passing them to views.
 
-
 ## Before you begin
 
-Check your `.env` file and configure these variables: 
+Check your `.env` file and configure these variables:
 
 ```
 MAIL_DRIVER=smtp
@@ -40,6 +39,12 @@ You can send `100 messages per SMTP connection` at a time, and open up to `10 co
 
 ## Creating a Mailable
 
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 Next you need to create a Mailable class, Laravel's CLI tool called Artisan makes that a simple feat.
 Open CLI, go to the project directory and type:
 
@@ -47,7 +52,7 @@ Open CLI, go to the project directory and type:
 
 This command will create a new file under `app/Mail/TestEmail.php` and it should look something like this:
 
-``` php
+```php
 <?php
 
 namespace App\Mail;
@@ -73,7 +78,7 @@ class TestEmail extends Mailable
         $address = 'janeexampexample@example.com';
         $subject = 'This is a demo!';
         $name = 'Jane Doe';
-        
+
         return $this->view('emails.test')
                     ->from($address, $name)
                     ->cc($address, $name)
@@ -84,26 +89,27 @@ class TestEmail extends Mailable
     }
 }
 ```
+
 In Laravel `Views` are used as 'templates' when sending an email. Let's create a file under `app/resources/views/emails/test.blade.php` and insert this code:
 
-``` html
+```html
 <!DOCTYPE html>
-    <html lang="en-US">
-    	<head>
-    		<meta charset="utf-8">
-    	</head>
-    	<body>
-    		<h2>Test Email</h2>
-    		<p>{{ $test_message }}</p>
-    	</body>
-    </html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h2>Test Email</h2>
+    <p>{{ $test_message }}</p>
+  </body>
+</html>
 ```
 
 ## Sending an email
 
 Now that we have our Mailable Class created, all we need to do is run this code:
 
-``` php
+```php
 <?php
     use App\Mail\TestEmail;
 
@@ -120,7 +126,7 @@ Another useful tool is event notifications. If you want to complete the feedback
 
 The `withSwiftMessage` method of the `Mailable` base class allows you to register the callback that is invoked with the raw SwiftMailer message instance before sending the message. This knowledge allows you to customize the message before delivery. To customize your message, use something similar to this:
 
-``` php
+```php
 <?php
 
 namespace App\Mail;

--- a/content/docs/for-developers/sending-email/smtp-perl-code-example.md
+++ b/content/docs/for-developers/sending-email/smtp-perl-code-example.md
@@ -7,8 +7,15 @@ navigation:
   show: true
 ---
 
-## 	SmtpApiHeader.pm
- 	```perl
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+## SmtpApiHeader.pm
+
+```perl
 #!/usr/bin/perl
 
 # Version 1.0
@@ -19,88 +26,89 @@ use JSON;
 
 sub new
 {
-  my $self = shift;
-  my @a = ();
-  $self = { 'data' => { }};
-  bless($self);
-  return $self;
+my $self = shift;
+my @a = ();
+$self = { 'data' => { }};
+bless($self);
+return $self;
 }
 
 sub addTo
 {
-  my $self = shift;
-  my @to = @_;
-  push(@{$self->{data}->{to}}, @to);
+my $self = shift;
+my @to = @_;
+push(@{$self->{data}->{to}}, @to);
 }
 
 sub addSubVal
 {
-  my $self = shift;
-  my $var = shift;
-  my @val = @_;
+my $self = shift;
+my $var = shift;
+my @val = @_;
 
-  if (!defined($self->{data}->{sub}->{$var}))
-  {
-    $self->{data}->{sub}->{$var} = ();
-  }
-  push(@{$self->{data}->{sub}->{$var}}, @val);
+if (!defined($self->{data}->{sub}->{$var}))
+{
+  $self->{data}->{sub}->{$var} = ();
+}
+push(@{$self->{data}->{sub}->{$var}}, @val);
 }
 
 sub setUniqueArgs
 {
-  my $self = shift;
-  my $val = shift;
-  if (ref($val) eq 'HASH')
-  {
-    $self->{data}->{unique_args} = $val;
-  }
+my $self = shift;
+my $val = shift;
+if (ref($val) eq 'HASH')
+{
+  $self->{data}->{unique_args} = $val;
+}
 }
 
 sub setCategory
 {
-  my $self = shift;
-  my $cat = shift;
-  $self->{data}->{category} = $cat;
+my $self = shift;
+my $cat = shift;
+$self->{data}->{category} = $cat;
 }
 
 sub addFilterSetting
 {
-  my $self = shift;
-  my $filter = shift;
-  my $setting = shift;
-  my $val = shift;
-  if (!defined($self->{data}->{filters}->{$filter}))
-  {
-    $self->{data}->{filters}->{$filter} = {};
-  }
-  if (!defined($self->{data}->{filters}->{$filter}->{settings}))
-  {
-    $self->{data}->{filters}->{$filter}->{settings} = {};
-  }
-  $self->{data}->{filters}->{$filter}->{settings}->{$setting} = $val;
+my $self = shift;
+my $filter = shift;
+my $setting = shift;
+my $val = shift;
+if (!defined($self->{data}->{filters}->{$filter}))
+{
+  $self->{data}->{filters}->{$filter} = {};
+}
+if (!defined($self->{data}->{filters}->{$filter}->{settings}))
+{
+  $self->{data}->{filters}->{$filter}->{settings} = {};
+}
+$self->{data}->{filters}->{$filter}->{settings}->{$setting} = $val;
 }
 
 sub asJSON
 {
-  my $self = shift;
-  my $json = JSON->new;
-  $json->space_before(1);
-  $json->space_after(1);
-  return $json->encode($self->{data});
+my $self = shift;
+my $json = JSON->new;
+$json->space_before(1);
+$json->space_after(1);
+return $json->encode($self->{data});
 }
 
 sub as_string
 {
-  my $self = shift;
-  my $json = $self->asJSON;
-  $json =~ s/(.{1,72})(\s)/$1\n   /g;
-  my $str = "X-SMTPAPI: $json";
-  return $str;
+my $self = shift;
+my $json = $self->asJSON;
+$json =~ s/(.{1,72})(\s)/$1\n   /g;
+my $str = "X-SMTPAPI: $json";
+return $str;
 }
 ```
 
-## 	Example Perl Usage
- 	```perl
+## Example Perl Usage
+
+```perl
 #!/usr/bin/perl
 use SmtpApiHeader;
 
@@ -124,16 +132,16 @@ $hdr->setUniqueArgs({'test'=>1, 'foo'=>2});
 print $hdr->as_string;
 
 print "\n";
- </code>
+</code>
 
 ## 	Full Perl Example
- 	 <p>The following code builds a MIME mail message demonstrating all the portions of the SMTP API protocol. To use this example, you will need to have the following perl modules installed:</p>
- <ul class="regular">
-    <li>MIME::Entity</li>
-    <li>Authen::SASL</li>
-    <li>JSON</li>
- </ul>
- <code>
+ <p>The following code builds a MIME mail message demonstrating all the portions of the SMTP API protocol. To use this example, you will need to have the following perl modules installed:</p>
+<ul class="regular">
+  <li>MIME::Entity</li>
+  <li>Authen::SASL</li>
+  <li>JSON</li>
+</ul>
+<code>
 #!/usr/bin/perl
 use strict;
 use SmtpApiHeader;
@@ -179,16 +187,16 @@ EOM
 
 my $html = <<EOM;
 <html>
- <head></head>
- <body>
-  <p>Hello -name-,<br />
-   Thank you for your interest in our products. We have set up an appointment<br />
-   to call you at -time- EST to discuss your needs in more detail.<br />
+<head></head>
+<body>
+<p>Hello -name-,<br />
+ Thank you for your interest in our products. We have set up an appointment<br />
+ to call you at -time- EST to discuss your needs in more detail.<br />
 
-    Regards,<br />
-    Fred<br />
-  </p>
- </body>
+  Regards,<br />
+  Fred<br />
+</p>
+</body>
 </html>
 EOM
 
@@ -205,12 +213,12 @@ $mime->head->add("X-SMTPAPI", $hdr->asJSON);
 
 # Add body
 $mime->attach(Type => 'text/plain',
-                    Encoding =>'-SUGGEST',
-                    Data => $plain);
+                  Encoding =>'-SUGGEST',
+                  Data => $plain);
 
 $mime->attach(Type => 'text/html',
-                    Encoding =>'-SUGGEST',
-                    Data => $html);
+                  Encoding =>'-SUGGEST',
+                  Data => $html);
 
 # Login credentials
 my $username = 'example@example.com';
@@ -218,9 +226,9 @@ my $password = "yourpassword";
 
 # Open a connection to the SendGrid mail server
 my $smtp = Net::SMTP->new('smtp.sendgrid.net',
-                    Port=> 25,
-                    Timeout => 20,
-                    Hello => "yourdomain.com");
+                  Port=> 25,
+                  Timeout => 20,
+                  Hello => "yourdomain.com");
 
 # Authenticate
 $smtp->auth($username, $password);

--- a/content/docs/for-developers/sending-email/smtp-ruby-code-example.md
+++ b/content/docs/for-developers/sending-email/smtp-ruby-code-example.md
@@ -9,8 +9,14 @@ navigation:
 
 These examples require the [JSON Ruby Library](http://www.ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html).
 
-## 	SmtpApiHeader.rb
- 	
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+## SmtpApiHeader.rb
+
 This header is required for each example.
 
 ```ruby
@@ -79,9 +85,8 @@ class SmtpApiHeader
 end
 ```
 
+## Example Ruby Usage
 
-## 	Example Ruby Usage
- 	
 ```ruby
 require './SmtpApiHeader.rb'
 require 'mail'

--- a/content/docs/for-developers/sending-email/substitution-tags.md
+++ b/content/docs/for-developers/sending-email/substitution-tags.md
@@ -19,8 +19,8 @@ Substitution tags allow you to generate dynamic content for each recipient on yo
 
 These tags can also be used in more complex scenarios. For example, you could use a -customerID- to build a custom URL that is specific to that user.
 
-
 ### A customer specific ID can replace -customerID- in the URL within your email
+
 ```html
 <a href="http://example.com/customerOffer?id=-customerID-">Claim your offer!</a>
 ```
@@ -28,6 +28,12 @@ These tags can also be used in more complex scenarios. For example, you could us
 <call-out>
 
 Substitution tags will work in the Subject line, body of the email and in [Unique Arguments]({{root_url}}/for-developers/sending-email/unique-arguments/).
+
+</call-out>
+
+<call-out type="warning">
+
+Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
 
 </call-out>
 
@@ -63,20 +69,22 @@ Do not nest substitution tags in substitutions as they will fail and your substi
 
 </call-out>
 
-## 	Substitution Tag Example
+## Substitution Tag Example
 
 Email HTML content:
+
 ```html
 <html>
   <head></head>
   <body>
-    <p>Hello -name-,<br>
-       Thank you for your interest in our products. I have set up an appointment to call you at -time- EST to discuss your needs in more detail. If you would like to reschedule this call, please visit the following link: `<a href="http://example.com/reschedule?id=-customerID-">reschedule</a>`
-
-                Regards,
-
-                -salesContact-
-                -contactPhoneNumber-<br>
+    <p>
+      Hello -name-,<br />
+      Thank you for your interest in our products. I have set up an appointment
+      to call you at -time- EST to discuss your needs in more detail. If you
+      would like to reschedule this call, please visit the following link: `<a
+        href="http://example.com/reschedule?id=-customerID-"
+        >reschedule</a
+      >` Regards, -salesContact- -contactPhoneNumber-<br />
     </p>
   </body>
 </html>
@@ -86,31 +94,13 @@ Email HTML content:
 
 ```json
 {
-  "to": [
-    "example@example.com",
-    "example@example.com"
-  ],
+  "to": ["example@example.com", "example@example.com"],
   "sub": {
-    "-name-": [
-      "John",
-      "Jane"
-    ],
-    "-customerID-": [
-      "1234",
-      "5678"
-    ],
-    "-salesContact-": [
-      "Jared",
-      "Ben"
-    ],
-    "-contactPhoneNumber-": [
-      "555.555.5555",
-      "777.777.7777"
-    ],
-    "-time-": [
-      "3:00pm",
-      "5:15pm"
-    ]
+    "-name-": ["John", "Jane"],
+    "-customerID-": ["1234", "5678"],
+    "-salesContact-": ["Jared", "Ben"],
+    "-contactPhoneNumber-": ["555.555.5555", "777.777.7777"],
+    "-time-": ["3:00pm", "5:15pm"]
   }
 }
 ```
@@ -121,13 +111,14 @@ The resulting email for John would look like this:
 <html>
   <head></head>
   <body>
-    <p>Hello John,<br>
-       Thank you for your interest in our products. I have set up an appointment to call you at 3:00 pm EST to discuss your needs in more detail. If you would like to reschedule this call, please visit the following link:
+    <p>
+      Hello John,<br />
+      Thank you for your interest in our products. I have set up an appointment
+      to call you at 3:00 pm EST to discuss your needs in more detail. If you
+      would like to reschedule this call, please visit the following link:
       <a href="http://example.com/reschedule?id=1234">reschedule</a>
-      Regards,
-
-      Jared
-      555.555.5555
+      Regards, Jared 555.555.5555
+    </p>
   </body>
 </html>
 ```
@@ -138,21 +129,23 @@ In contrast, the resulting email for Jane will look like the following, with her
 <html>
   <head></head>
   <body>
-  <p>Hello Jane,<br>
-       Thank you for your interest in our products. I have set up an appointment to call you at 5:15pm EST to discuss your needs in more detail. If you would like to reschedule this call please visit the following link:
-   <a href="http://example.com/reschedule?id=5678">reschedule</a>
-    Regards,
-
-    Ben
-    777.777.7777
+    <p>
+      Hello Jane,<br />
+      Thank you for your interest in our products. I have set up an appointment
+      to call you at 5:15pm EST to discuss your needs in more detail. If you
+      would like to reschedule this call please visit the following link:
+      <a href="http://example.com/reschedule?id=5678">reschedule</a>
+      Regards, Ben 777.777.7777
+    </p>
   </body>
 </html>
 ```
 
-## 	SendGrid Defined Substitution Tags
- 	While the tags above are tags that you define at the time of your send in the SMTP API headers, SendGrid also offers [Unsubscribe Groups tags]({{root_url}}/ui/sending-email/create-and-edit-transactional-templates/) that have been pre-defined for you. You can use these tags within the content of your email, and you do not have to and should not, define them.
+## SendGrid Defined Substitution Tags
 
-## 	Additional Resources
+While the tags above are tags that you define at the time of your send in the SMTP API headers, SendGrid also offers [Unsubscribe Groups tags]({{root_url}}/ui/sending-email/create-and-edit-transactional-templates/) that have been pre-defined for you. You can use these tags within the content of your email, and you do not have to and should not, define them.
+
+## Additional Resources
 
 - [Section Tags]({{root_url}}/for-developers/sending-email/section-tags/)
 - [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)

--- a/content/docs/for-developers/sending-email/unique-arguments.md
+++ b/content/docs/for-developers/sending-email/unique-arguments.md
@@ -11,6 +11,12 @@ navigation:
   show: true
 ---
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 The SMTP API JSON string allows you to attach an unlimited number of unique arguments to your email **up to 10,000 bytes**. The arguments are used only for tracking. They can be retrieved through the [Event API]({{root_url}}/for-developers/tracking-events/event/) or the [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/) page.
 
 <call-out type="warning">
@@ -37,6 +43,7 @@ These arguments can be added using a JSON string like this:
 These arguments can then be seen in posts from the [SendGrid Event Webhook]({{root_url}}/for-developers/tracking-events/event/). The contents of one of these POST requests would look something like this:
 
 ### Example Webhook Post Data
+
 ```json
 {
   "sg_message_id": "145cea24eb8.1c420.57425.filter-132.3382.5368192A3.0",
@@ -65,10 +72,7 @@ To apply different unique arguments to individual emails, you may use [substitut
 ```json
 {
   "sub": {
-    "-account_number-": [
-      "314159",
-      "271828"
-    ]
+    "-account_number-": ["314159", "271828"]
   },
   "unique_args": {
     "customerAccountNumber": "-account_number-"
@@ -76,7 +80,7 @@ To apply different unique arguments to individual emails, you may use [substitut
 }
 ```
 
-## 	Additional Resources
+## Additional Resources
 
 - [SMTP Service Crash Course](https://sendgrid.com/blog/smtp-service-crash-course/)
 - [Getting Started with the SMTP API]({{root_url}}/for-developers/sending-email/getting-started-smtp/)

--- a/content/docs/for-developers/sending-email/wordpress-plugin.md
+++ b/content/docs/for-developers/sending-email/wordpress-plugin.md
@@ -1,25 +1,26 @@
 ---
 st:
- published_at: 2016-07-25
- type: [integrate]
+  published_at: 2016-07-25
+  type: [integrate]
 seo:
- title: SendGrid's WordPress Plugin
- description: Learn how to send your WordPress email through SendGrid.
- keywords: WordPress, SendGrid, integrate, plugin, subscription widget
+  title: SendGrid's WordPress Plugin
+  description: Learn how to send your WordPress email through SendGrid.
+  keywords: WordPress, SendGrid, integrate, plugin, subscription widget
 title: SendGrid's WordPress Plugin
 group: plugins
 weight: 100
 layout: page
 navigation:
- show: true
+  show: true
 ---
+
 SendGrid's cloud-based email infrastructure relieves businesses of the cost and complexity of maintaining custom email systems. SendGrid provides reliable deliverability, scalability, and real-time analytics along with flexible APIs that make custom integration with your application a breeze.
 
 SendGrid’s [WordPress plugin](https://wordpress.org/plugins/sendgrid-email-delivery-simplified/) replaces WordPress’s default **wp_mail()** function by using either an SMTP or API integration with SendGrid to send outgoing email from your WordPress installation. It also allows you to upload contacts directly to your SendGrid Marketing Campaigns account via a [subscription widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/).
 
 By using the SendGrid plugin, you will be able to take advantage of improved deliverability and an expanded feature set, including tracking and analytics, to enhance user engagement on your WordPress installation. SendGrid also provides world class customer support, should you run into any issues.
 
-## 	Installing SendGrid’s WordPress Plugin
+## Installing SendGrid’s WordPress Plugin
 
 In order to send emails through SMTP, you first need to install the [Swift Mailer](https://wordpress.org/plugins/swift-mailer/) plugin.
 
@@ -43,13 +44,13 @@ When using the SMTP method you must also define the `To` address. It does not ma
 
 Emails are automatically tracked, allowing you to retrieve delivery and engagement statistics from within the SendGrid Dashboard. You can also specify certain [categories](#how-to-use-categories) for any of your emails to help you organize them by type.
 
-## 	Configuring SendGrid’s WordPress Plugin
+## Configuring SendGrid’s WordPress Plugin
 
 While it is possible to simply install and configure the SendGrid plugin for WordPress as described above to immediately begin sending your emails through SendGrid, you may take steps to further customize the SendGrid WordPress plugin.
 
 The following explanations and examples show how you can use SendGrid to adjust WordPress’s `wp_mail()` function.
 
- ##### 	The wp_mail() Function
+##### The wp_mail() Function
 
 The SendGrid plugin makes adjustments to the `wp_mail()` function so that all emails sent from WordPress are delivered by SendGrid.
 
@@ -84,9 +85,15 @@ After you’ve run wp_mail(), you must remove the ‘text/html’ filter in orde
 remove_filter('wp_mail_content_type', 'set_html_content_type');
 ```
 
-## 	Sending HTML in Your Email Using Different Headers
+## Sending HTML in Your Email Using Different Headers
 
- #### 	Using an Array to Set Your Headers
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+#### Using an Array to Set Your Headers
 
 ```php
 $subject = 'Test SendGrid plugin';
@@ -110,7 +117,7 @@ $mail = wp_mail($to, $subject, $message, $headers, $attachments);
 remove_filter('wp_mail_content_type', 'set_html_content_type');
 ```
 
- #### 	Using SendGrid\Email() to Set Your Headers
+#### Using SendGrid\Email() to Set Your Headers
 
 ```php
 $subject = 'Test SendGrid plugin';
@@ -135,7 +142,7 @@ $mail = wp_mail($to, $subject, $message, $headers, $attachments);
 remove_filter('wp_mail_content_type', 'set_html_content_type');
 ```
 
-## 	Substitution Tags and Sections
+## Substitution Tags and Sections
 
 ```php
 $subject = 'Hey %name%, you work at %place%';
@@ -157,7 +164,13 @@ $mail = wp_mail($to, $subject, $message, $headers);
 
 For more examples of how you can use SendGrid SMTPAPI headers, please visit the [SendGrid PHP Library on GitHub](https://github.com/sendgrid/sendgrid-php#smtpapi).
 
-## 	How to Use Categories
+## How to Use Categories
+
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 You can use [categories]({{root_url}}/ui/analytics-and-reporting/categories/) to help organize and track the emails sent from WordPress via the SendGrid plugin.
 
@@ -173,7 +186,7 @@ $headers[] = 'categories: category1, category2';
 
 If you would like to configure categories for statistics tracking, simply set your desired category as the value of the 'Categories' field in the 'Statistics settings' section.
 
-## 	Multisite
+## Multisite
 
 If you are using the SendGrid plugin in a multisite environment, you need to enable it for use across your multisite network.
 
@@ -193,7 +206,7 @@ You can enable access for SendGrid settings to each subsite in the Multisite Set
 
 If you have already installed the SendGrid plugin in a multisite environment and you update to any version **after** 1.9.0 you may need to re-configure your plugin.
 
-## 	Additional Resources
+## Additional Resources
 
-* [SendGrid's WordPress Subscription Widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/)
-* [SendGrid's WordPress Integration FAQ]({{root_url}}/for-developers/sending-email/wordpress-faq/)
+- [SendGrid's WordPress Subscription Widget]({{root_url}}/for-developers/sending-email/wordpress-subscription-widget/)
+- [SendGrid's WordPress Integration FAQ]({{root_url}}/for-developers/sending-email/wordpress-faq/)

--- a/content/docs/for-developers/sending-email/wordpress-subscription-widget.md
+++ b/content/docs/for-developers/sending-email/wordpress-subscription-widget.md
@@ -1,32 +1,32 @@
 ---
 st:
- published_at: 2016-07-25
- type: [integrate]
+  published_at: 2016-07-25
+  type: [integrate]
 seo:
- title: WordPress Subscription Widget
- description: Learn how to send your WordPress email through SendGrid.
- keywords: WordPress, SendGrid, integrate, plugin, subscription widget
+  title: WordPress Subscription Widget
+  description: Learn how to send your WordPress email through SendGrid.
+  keywords: WordPress, SendGrid, integrate, plugin, subscription widget
 title: WordPress Subscription Widget
 group: plugins
 weight: 100
 layout: page
 navigation:
- show: true
+  show: true
 ---
 
-## 	What is the Subscription Widget
+## What is the Subscription Widget
 
 SendGrid’s WordPress Subscription Widget makes it easy for people visiting your WordPress site to subscribe to your marketing emails, such as any newsletters, announcements, or promotional offers you may send. Upon signup, they’ll automatically receive an opt-in email allowing them to confirm their desire to begin receiving your emails. This confirmation constitutes “double opt-in,” a deliverability best practice.
 
-## 	Installing the Subscription Widget
+## Installing the Subscription Widget
 
- ### 	Requirements
+### Requirements
 
-* PHP version >= 5.6 and <= 7.1. Installing this plugin on PHP versions 5.3 and earlier will cause your website to break. Installation on PHP versions 5.4 and 5.5 will work but it is not recommended.
-* To send emails through SMTP you need to install the [Swift Mailer plugin](https://wordpress.org/plugins/swift-mailer/).
-* If the `wp_mail()` function has been declared by another plugin that you have installed, you won't be able to use the SendGrid plugin.
+- PHP version >= 5.6 and <= 7.1. Installing this plugin on PHP versions 5.3 and earlier will cause your website to break. Installation on PHP versions 5.4 and 5.5 will work but it is not recommended.
+- To send emails through SMTP you need to install the [Swift Mailer plugin](https://wordpress.org/plugins/swift-mailer/).
+- If the `wp_mail()` function has been declared by another plugin that you have installed, you won't be able to use the SendGrid plugin.
 
- ### 	Automatically Install the SendGrid Plugin from the WordPress Admin Page
+### Automatically Install the SendGrid Plugin from the WordPress Admin Page
 
 1. After logging into your WordPress account, navigate to **Plugins** and click **Add New**.
 2. Search for "SendGrid Plugin" and click **Install Now**
@@ -34,18 +34,18 @@ SendGrid’s WordPress Subscription Widget makes it easy for people visiting you
 4. [Create a SendGrid account](http://sendgrid.com/partner/wordpress) on the WordPress Partner's Page
 5. Navigate to **Settings**, select **SendGrid Settings**, and enter your SendGrid credentials.
 
- ### 	Manually Install the SendGrid Plugin by Uploading the SendGrid Plugin ZIP File
+### Manually Install the SendGrid Plugin by Uploading the SendGrid Plugin ZIP File
 
 1. Upload the WordPress SendGrid Plugin to the **/wp-contents/plugins/** folder.
 2. Activate the plugin from the **Plugins** menu in WordPress.
-4. [Create a SendGrid account](http://sendgrid.com/partner/wordpress) on the WordPress Partner's Page
+3. [Create a SendGrid account](http://sendgrid.com/partner/wordpress) on the WordPress Partner's Page
 4. Navigate to **Settings**, select **SendGrid Settings**, and enter your SendGrid credentials.
 
-## 	Configuring the SendGrid Subscription Widget in WordPress
+## Configuring the SendGrid Subscription Widget in WordPress
 
 To set up the subscription widget from the WordPress interface, open the SendGrid WordPress plugin page, navigate to **Settings**, and click on the tab labeled **Subscription Widget**.
 
- ### 	Configuring Your Credentials
+### Configuring Your Credentials
 
 To enable the Subscription Widget, you’ll first need an API key to authenticate your access to SendGrid services. If you’ve already set up the General settings for the plugin, you may choose to use the same API key by checking the “Use same authentication as transactional” option.
 
@@ -55,7 +55,7 @@ To create a dedicated API Key for your plugin, log into your SendGrid account, n
 
 ![]({{root_url}}/images/wp_subscription_widget_1.png)
 
- ### 	Choosing Your Marketing Campaigns Recipient List
+### Choosing Your Marketing Campaigns Recipient List
 
 After you set up a valid API key you must choose a specific list where your new contacts will be stored.
 
@@ -65,7 +65,7 @@ If you don't have a list set up for your signups from the Subscription Widget, o
 
 ![]({{root_url}}/images/wp_subscription_widget_2_1.png)
 
- ### 	Configuring Your Subscription Widget Form
+### Configuring Your Subscription Widget Form
 
 Once you have selected the contact list to which you would like your new signups to be uploaded, simply complete the form to reflect your preferences. You can decide whether you’ll include first and last names on your signup form and whether they’ll be required. You can also craft the subject line and content of the opt-in confirmation email. Lastly, you’ll be able to choose the page your new signups see upon clicking the confirmation link within the opt-in confirmation email.
 
@@ -83,7 +83,7 @@ When writing the content for your signup confirmation email, you can choose betw
 
 Finally, select the WordPress page that will be displayed to the user by selecting it from the drop down menu on the settings page.
 
- ### 	Configuring Your Subscription Opt-In Confirmation Page
+### Configuring Your Subscription Opt-In Confirmation Page
 
 If you would like to create your own custom opt-in confirmation page, simply create a static WordPress page as you would for any other area of your site (for example, your "About" or "Contact" page).
 
@@ -91,9 +91,9 @@ If you would like to create your own custom opt-in confirmation page, simply cre
 
 You may use the following substitution tags when building your confirmation page:
 
-* **[sendgridSubscriptionFirstName]** - the first name of your new subscriber
-* **[sendgridSubscriptionLastName]** - the last name of your new subscriber
-* **[sendgridSubscriptionEmail]** - the email address for your new subscriber
+- **[sendgridSubscriptionFirstName]** - the first name of your new subscriber
+- **[sendgridSubscriptionLastName]** - the last name of your new subscriber
+- **[sendgridSubscriptionEmail]** - the email address for your new subscriber
 
 Once you have created and saved this new page, it will appear in the dropdown menu alongside the "Default Confirmation Page" option.
 
@@ -101,7 +101,7 @@ Once you have created and saved this new page, it will appear in the dropdown me
 
 For more information on how to create a new WordPress page, please visit the [WordPress documentation](https://codex.wordpress.org/Pages).
 
- ### 	Form Customization
+### Form Customization
 
 If you want to customize your subscription form, you can do so from the settings page. You can set labels for the "First Name", "Last Name", and "Email" fields in addition to the "Subscribe" button.
 
@@ -111,9 +111,9 @@ You can also adjust the padding surrounding the input fields and buttons.
 
 If you want additional or advanced configuration options (for example, CSS styles), you can use the following .css classes:
 
-* `sendgrid_mc_label` for the labels
-* `sendgrid_mc_input` for the input fields
-* `sendgrid_mc_button` for the subscribe button
+- `sendgrid_mc_label` for the labels
+- `sendgrid_mc_input` for the input fields
+- `sendgrid_mc_button` for the subscribe button
 
 For example, if you want your form to look like the following:
 
@@ -122,7 +122,7 @@ For example, if you want your form to look like the following:
 You would need to add the following to your CSS file:
 
 ```css
-.sendgrid_mc_label{
+.sendgrid_mc_label {
   color: #ff0000;
 }
 .sendgrid_mc_input {
@@ -133,7 +133,7 @@ You would need to add the following to your CSS file:
 }
 ```
 
- ### 	Testing Your Subscription Widget
+### Testing Your Subscription Widget
 
 Once you have configured your credentials and have selected a valid list for your new contacts, a form to test the subscription widget will appear at the bottom of the page of the Subscription Widget settings tab. You can test the subscription process by entering an email address and clicking **Test**.
 
@@ -143,7 +143,7 @@ The opt-in confirmation email you configured for the subscription widget will be
 
 ![]({{root_url}}/images/wp_subscription_widget_5.png)
 
- ### 	Using Your Subscription Widget
+### Using Your Subscription Widget
 
 To display the widget on your website, navigate to the widgets page in WordPress and, using drag and drop, add it to the section of your page where you would like it to be displayed. Remember that only the "email" field is required by default, but you may include the first and last name fields.
 
@@ -155,13 +155,13 @@ If you would like to add the “First Name” and “Last Name” fields, and re
 
 You may also configure your installation of the subscription widget by defining specific SendGrid settings as global variables within the wp-config.php file. See the next section for a list of specific settings and the corresponding PHP required to add those settings to the wp-config.php file.
 
-## 	Manually Configuring Your Subscription Widget (Advanced)
+## Manually Configuring Your Subscription Widget (Advanced)
 
 You can manually configure your subscription widget by defining your settings within the wp-config.php file. **It is important to note that the information presented below refers to the same configuration steps previously described.** There is no added functionality that comes with manually editing your wp-config.php file, it is simply an alternative method of changing the same settings.
 
 Continue reading below for examples of what PHP should be included in your wp-config.php file to configure your subscription widget.
 
- ### 	Manually Configuring Your Credentials In wp-config.php (Advanced)
+### Manually Configuring Your Credentials In wp-config.php (Advanced)
 
 You can use an API key to authenticate when integrating with the SendGrid WordPress Subscription Widget
 
@@ -169,33 +169,39 @@ If you are using your login credentials, both your username and password will ne
 
 You must set the Mail Send permissions to FULL ACCESS, Stats to READ ACCESS and Template Engine to READ or FULL ACCESS when creating the API Key, so you can send emails and see statistics on wordpress. For more information about API Key Permissions, click [here]({{root_url}}/ui/account-and-settings/api-keys/).
 
- ### 	Credentials Settings for the SendGrid WordPress Subscription Widget
+### Credentials Settings for the SendGrid WordPress Subscription Widget
 
 - **API Key**: `define('SENDGRID_API_KEY', 'sendgrid_api_key');`
 
   Your SendGrid API Key.
 
- ### 	Manually Configuring Your Email Settings (Advanced)
+### Manually Configuring Your Email Settings (Advanced)
 
- ### 	Email Settings for the SendGrid WordPress Subscription Widget
+### Email Settings for the SendGrid WordPress Subscription Widget
 
 - **Send Method**: `define('SENDGRID_SEND_METHOD', 'api');` - The method used to deliver email. Can be either SMTP or the Web API. SMTP can only be used if the Swift Mailer plugin is installed.
 
 - **From name**: `define('SENDGRID_FROM_NAME', 'Example Name');` - The name of the sender.
 
-- **From email**: `define('SENDGRID_FROM_EMAIL', 'from_email@example.com');` -  The email address of the sender.
+- **From email**: `define('SENDGRID_FROM_EMAIL', 'from_email@example.com');` - The email address of the sender.
 
 - **Reply to email**: `define('SENDGRID_REPLY_TO', 'reply_to@example.com');` - The email address that will populate the "reply to" field when recipients click the "reply" button.
 
 - **Categories**: `define('SENDGRID_CATEGORIES', 'category_1,category_2');` - Any [categories]({{root_url}}/ui/analytics-and-reporting/categories/) that you would like to tag your WordPress emails with.
 
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 - **Template**: `define('SENDGRID_TEMPLATE', 'templateID');` - The template that you would like to apply to your WordPress emails.
 
 - **Content**: `define('SENDGRID_CONTENT_TYPE', 'html');` - Denotes the type of data included in your email. Can be "plaintext" or "html".
 
- ### 	Manually Configuring Your Widget Settings (Advanced)
+### Manually Configuring Your Widget Settings (Advanced)
 
- ### 	Widget Settings
+### Widget Settings
 
 - **Marketing Campaigns API Keys**: `define('SENDGRID_MC_API_KEY', 'sendgrid_mc_api_key');` - Your API Key generated to authenticate use of the Marketing Campaigns API.
 
@@ -205,31 +211,29 @@ You must set the Mail Send permissions to FULL ACCESS, Stats to READ ACCESS and 
 
   To find your list ID, navigate to **Marketing Campaigns**, then click **Contacts**. Click on the list you would like to use. When viewing the list, the last 6 digits of the URL make up the list ID.
 
+* **Display the first and last name fields ('true' or 'false')**: `define('SENDGRID_MC_OPT_INCL_FNAME_LNAME', 'true');` - Indicates whether you want to display fields for your subscribers to enter both their first and last names on the subscription form.
 
-- **Display the first and last name fields ('true' or 'false')**: `define('SENDGRID_MC_OPT_INCL_FNAME_LNAME', 'true');` - Indicates whether you want to display fields for your subscribers to enter both their first and last names on the subscription form.
+* **First and last name fields are required ('true' or 'false')**: `define('SENDGRID_MC_OPT_REQ_FNAME_LNAME', 'true');` - Indicates whether you want to require your subscribers to submit both their first and last names on the subscription form.
 
-- **First and last name fields are required ('true' or 'false')**: `define('SENDGRID_MC_OPT_REQ_FNAME_LNAME', 'true');` - Indicates whether you want to require your subscribers to submit both their first and last names on the subscription form.
+* **Signup confirmation email subject**: `define('SENDGRID_MC_SIGNUP_EMAIL_SUBJECT', 'Confirm subscription');`
 
-- **Signup confirmation email subject**: `define('SENDGRID_MC_SIGNUP_EMAIL_SUBJECT', 'Confirm subscription');`
+* **Signup confirmation email content**: `define('SENDGRID_MC_SIGNUP_EMAIL_CONTENT', '&lta href="%confirmation_link%"&gtclick here&lt/a&gt');`
 
-- **Signup confirmation email content**: `define('SENDGRID_MC_SIGNUP_EMAIL_CONTENT', '&lta href="%confirmation_link%"&gtclick here&lt/a&gt');`
-
-- **Signup confirmation page ID**: `define('SENDGRID_MC_SIGNUP_CONFIRMATION_PAGE', 'page_id');`
+* **Signup confirmation page ID**: `define('SENDGRID_MC_SIGNUP_CONFIRMATION_PAGE', 'page_id');`
 
   The WordPress page ID of the page you would like to link users to when confirming their subscription.
 
   To find your page ID, log into your WordPress account and click **Pages** in the left hand nav of your dashboard. Select your confirmation page. In the URL you will see the text "post=XX" where XX represents your page ID.
 
-- **First Name Label**: `define('SENDGRID_MC_FIRST_NAME_LABEL', 'First Name');`
+* **First Name Label**: `define('SENDGRID_MC_FIRST_NAME_LABEL', 'First Name');`
 
-- **Last Name Label**: `define('SENDGRID_MC_LAST_NAME_LABEL', 'Last Name');`
+* **Last Name Label**: `define('SENDGRID_MC_LAST_NAME_LABEL', 'Last Name');`
 
-- **Email Label**: `define('SENDGRID_MC_EMAIL_LABEL', ‘Email’);`
+* **Email Label**: `define('SENDGRID_MC_EMAIL_LABEL', ‘Email’);`
 
-- **Subscribe Label**: `define('SENDGRID_MC_SUBSCRIBE_LABEL', 'Subscribe');`
-
+* **Subscribe Label**: `define('SENDGRID_MC_SUBSCRIBE_LABEL', 'Subscribe');`
 
 ## Additional Resources
 
-* [SendGrid's WordPress Plugin]({{root_url}}/for-developers/sending-email/wordpress-plugin/)
-* [SendGrid's WordPress Integration FAQ]({{root_url}}/for-developers/sending-email/wordpress-faq/)
+- [SendGrid's WordPress Plugin]({{root_url}}/for-developers/sending-email/wordpress-plugin/)
+- [SendGrid's WordPress Integration FAQ]({{root_url}}/for-developers/sending-email/wordpress-faq/)

--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -10,6 +10,7 @@ layout: page
 navigation:
   show: true
 ---
+
 ## Authentication
 
 In order to use the Event Webhook, you need to enter a username and password. The following characters can be used for webhook authentication.
@@ -23,9 +24,15 @@ Characters not on the list below are not supported and will not authenticate to 
 - **All lower case letters:** a b c d e f g h i j k l m n o p q r s t u v w x y z
 - **All upper case letters:** A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
 - **All digits:** 0 1 2 3 4 5 6 7 8 9
-- **The following characters:** - . _ : ~ ! $ & ' ( ) * + , ; = % @
+- **The following characters:** - . \_ : ~ ! \$ & ' ( ) \* + , ; = % @
 
-## 	Events
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+## Events
 
 Events are generated when email is processed by SendGrid and email service providers. There are 2 types of events - delivery and engagement events. Delivery events indicate the status of email delivery to the recipient. Engagement events indicate how the recipient is interacting with the email.
 
@@ -33,129 +40,129 @@ Here is an event response that includes an example of each type of event:
 
 ```json
 [
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"processed",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"deferred",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "response":"400 try again later",
-      "attempt":"5"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"delivered",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "response":"250 OK"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"open",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-      "ip":"255.255.255.255"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"click",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-      "ip":"255.255.255.255",
-      "url":"http://www.sendgrid.com/"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"bounce",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "reason":"500 unknown recipient",
-      "status":"5.0.0"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"dropped",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "reason":"Bounced Address",
-      "status":"5.0.0"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"spamreport",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"unsubscribe",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id"
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"group_unsubscribe",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-      "ip":"255.255.255.255",
-      "url":"http://www.sendgrid.com/",
-      "asm_group_id":10
-   },
-   {
-      "email":"example@test.com",
-      "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
-      "event":"group_resubscribe",
-      "category":"cat facts",
-      "sg_event_id":"sg_event_id",
-      "sg_message_id":"sg_message_id",
-      "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
-      "ip":"000.000.000.000",
-      "url":"http://www.sendgrid.com/",
-      "asm_group_id":10
-   }
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "processed",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "deferred",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "response": "400 try again later",
+    "attempt": "5"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "delivered",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "response": "250 OK"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "open",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "click",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255",
+    "url": "http://www.sendgrid.com/"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "bounce",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "reason": "500 unknown recipient",
+    "status": "5.0.0"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "dropped",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "reason": "Bounced Address",
+    "status": "5.0.0"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "spamreport",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "unsubscribe",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "group_unsubscribe",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "255.255.255.255",
+    "url": "http://www.sendgrid.com/",
+    "asm_group_id": 10
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "group_resubscribe",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+    "ip": "000.000.000.000",
+    "url": "http://www.sendgrid.com/",
+    "asm_group_id": 10
+  }
 ]
 ```
 
- ### 	Delivery events
+### Delivery events
 
 Delivery events include processed, dropped, delivered, deferred, and bounce.
 
@@ -303,7 +310,7 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
    </tbody>
 </table>
 
- ### 	Engagement events
+### Engagement events
 
 Engagement events include open, click, spam report, unsubscribe, group unsubscribe, and group resubscribe.
 
@@ -449,7 +456,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    </tbody>
 </table>
 
-## 	Event objects
+## Event objects
 
 <table class="table auto">
   <tr>
@@ -750,7 +757,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
 
 \* In the case of a delayed or asynchronous bounce, the message ID will be unavailable.
 
- ### 	JSON objects
+### JSON objects
 
 - <a name="email"></a>`email` - the email address of the recipient
 - <a name="timestamp"></a>`timestamp` - the <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX timestamp</a> of when the message was sent
@@ -796,10 +803,7 @@ Array:
   {
     "email": "john.doe@sendgrid.com",
     "timestamp": 1337966815,
-    "category": [
-      "newuser",
-      "transactional"
-    ],
+    "category": ["newuser", "transactional"],
     "event": "open"
   },
   {
@@ -813,7 +817,8 @@ Array:
 
 - <a name="asmgroupid"></a>`asm_group_id` - The ID of the unsubscribe group the recipient's email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.
 - <a name="uniqueargs"></a>`unique_args` or `custom_args`
-## 	Unique Arguments and Custom Arguments
+
+## Unique Arguments and Custom Arguments
 
 Events generated by SendGrid can include [unique arguments]({{root_url}}/for-developers/sending-email/unique-arguments/) or custom arguments.
 
@@ -823,7 +828,7 @@ Unique arguments and custom arguments essentially have the same function. Howeve
 
 </call-out>
 
- ### 	Unique Arguments
+### Unique Arguments
 
 To define and receive unique arguments when sending email with the [SMTP API]({{root_url}}/for-developers/sending-email/building-an-smtp-email/) or the [v2 Mail Send endpoint]({{root_url}}/API_Reference/Web_API/mail.html), use the `unique_args` parameter in the X-SMTPAPI header. For example, if you have an application and want to receive custom parameters such as the `userid` and the email `template`, you would submit them with the X-SMTPAPI header, as described [here]({{root_url}}/for-developers/sending-email/unique-arguments/).
 
@@ -843,7 +848,7 @@ You will receive the same unique argument included with the data posted to your 
 ```json
 [
   {
-    "sg_message_id":"sendgrid_internal_message_id",
+    "sg_message_id": "sendgrid_internal_message_id",
     "email": "john.doe@sendgrid.com",
     "timestamp": 1337966815,
     "event": "click",
@@ -860,7 +865,7 @@ You can create unique arguments with the same words as reserved keys, such as "e
 
 </call-out>
 
- ### 	Reserved Keys in Unique Arguments
+### Reserved Keys in Unique Arguments
 
 ```json
 //for this example, assume we're sending to john.doe@sendgrid.com
@@ -875,13 +880,13 @@ You can create unique arguments with the same words as reserved keys, such as "e
 }
 ```
 
- ### 	The resulting webhook call
+### The resulting webhook call
 
 ```json
 [
   {
     "event": "Processed",
-    "timestamp":"123456789",
+    "timestamp": "123456789",
     "customerAccountNumber": "55555",
     "activationAttempt": "1",
     "New Argument 1": "New Value 1",
@@ -896,7 +901,7 @@ You'll notice that the unique arguments, "event" and "email", were overwritten b
 
 </call-out>
 
- ### 	Custom Arguments
+### Custom Arguments
 
 Any custom arguments that you include with an email sent through [v3 Mail Send]({{root_url}}/API_Reference/Web_API_v3/Mail/index.html) gets added to your Event Webhook response.
 
@@ -944,27 +949,27 @@ The Event Webhook response:
 
 For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both `marketing_campaign_name` and `marketing_campaign_id` are displayed as unique arguments in the event data.
 
- ### 	Example event from a standard (non-A/B test) campaign send:
+### Example event from a standard (non-A/B test) campaign send:
 
 ```json
-  {
-    "category": [],
-    "email": "email@example.com",
-    "event": "processed",
-    "marketing_campaign_id": 12345,
-    "marketing_campaign_name": "campaign name",
-    "post_type": "event",
-    "sg_event_id": "sendgrid_internal_event_id",
-    "sg_message_id": "sendgrid_internal_message_id",
-    "sg_user_id": 12345,
-    "smtp-id": "",
-    "timestamp": 1442349428
-  }
+{
+  "category": [],
+  "email": "email@example.com",
+  "event": "processed",
+  "marketing_campaign_id": 12345,
+  "marketing_campaign_name": "campaign name",
+  "post_type": "event",
+  "sg_event_id": "sendgrid_internal_event_id",
+  "sg_message_id": "sendgrid_internal_message_id",
+  "sg_user_id": 12345,
+  "smtp-id": "",
+  "timestamp": 1442349428
+}
 ```
 
- ### 	Example event from an A/B Test:
+### Example event from an A/B Test:
 
- `marketing_campaign_version` is displayed in the event data for emails sent as part of an A/B Test. The value for `marketing_campaign_version` are returned as `A`, `B`, `C`, etc.
+`marketing_campaign_version` is displayed in the event data for emails sent as part of an A/B Test. The value for `marketing_campaign_version` are returned as `A`, `B`, `C`, etc.
 
 ```json
 {
@@ -984,7 +989,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 }
 ```
 
- ### 	Example event from the winning phase of an A/B Test:
+### Example event from the winning phase of an A/B Test:
 
 ```json
 {
@@ -1003,7 +1008,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 }
 ```
 
- ### 	Legacy Marketing Email Unsubscribes
+### Legacy Marketing Email Unsubscribes
 
 For emails sent through our Legacy Marketing Email tool, unsubscribes look like the following example:
 
@@ -1017,10 +1022,7 @@ For emails sent through our Legacy Marketing Email tool, unsubscribes look like 
       "newsletter_id": "1943530",
       "newsletter_send_id": "2308608"
     },
-    "category": [
-      "Tests",
-      "Newsletter"
-    ],
+    "category": ["Tests", "Newsletter"],
     "event": "unsubscribe"
   }
 ]
@@ -1030,22 +1032,22 @@ For emails sent through our Legacy Marketing Email tool, unsubscribes look like 
 
 ```json
 [
-    {
-        "email": "john.doe@sendgrid.com",
-        "smtp-id": "<14c583da911.2c36.1c804d@ismtpd-073>",
-        "timestamp": 1427409578,
-        "pool": {
-            "name": "new_MY_test",
-            "id": 210
-        },
-        "sg_event_id": "RHFZB1IrTD2Y9Q7bUdZxUw",
-        "sg_message_id": "14c583da911.2c36.1c804d.filter-406.22375.55148AA99.0",
-        "event": "processed"
-    }
+  {
+    "email": "john.doe@sendgrid.com",
+    "smtp-id": "<14c583da911.2c36.1c804d@ismtpd-073>",
+    "timestamp": 1427409578,
+    "pool": {
+      "name": "new_MY_test",
+      "id": 210
+    },
+    "sg_event_id": "RHFZB1IrTD2Y9Q7bUdZxUw",
+    "sg_message_id": "14c583da911.2c36.1c804d.filter-406.22375.55148AA99.0",
+    "event": "processed"
+  }
 ]
 ```
 
- ### 	Click
+### Click
 
 <table class="table table-bordered table-striped">
    <thead>
@@ -1068,32 +1070,32 @@ For emails sent through our Legacy Marketing Email tool, unsubscribes look like 
 
 ```json
 [
-    {
-  "sg_event_id":"sendgrid_internal_event_id",
-  "sg_message_id":"sendgrid_internal_message_id",
-  "ip":"255.255.255.255",
-  "useragent":"Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
-  "event":"click",
-  "email":"email@example.com",
-  "timestamp":1249948800,
-  "url":"http://yourdomain.com/blog/news.html",
-  "url_offset": {
-    "index": 0,
-    "type": "html"
-  },
-  "unique_arg_key":"unique_arg_value",
-  "category":["category1", "category2"],
-  "newsletter": {
-    "newsletter_user_list_id": "10557865",
-    "newsletter_id": "1943530",
-    "newsletter_send_id": "2308608"
-  },
-  "asm_group_id": 1
-    }
+  {
+    "sg_event_id": "sendgrid_internal_event_id",
+    "sg_message_id": "sendgrid_internal_message_id",
+    "ip": "255.255.255.255",
+    "useragent": "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
+    "event": "click",
+    "email": "email@example.com",
+    "timestamp": 1249948800,
+    "url": "http://yourdomain.com/blog/news.html",
+    "url_offset": {
+      "index": 0,
+      "type": "html"
+    },
+    "unique_arg_key": "unique_arg_value",
+    "category": ["category1", "category2"],
+    "newsletter": {
+      "newsletter_user_list_id": "10557865",
+      "newsletter_id": "1943530",
+      "newsletter_send_id": "2308608"
+    },
+    "asm_group_id": 1
+  }
 ]
 ```
 
-## 	Additional Resources
+## Additional Resources
 
 - [Getting started with the Event Webhook]({{root_url}}/for-developers/tracking-events/getting-started-event-webhook/)
 - [Troubleshooting the event webhook]({{root_url}}/for-developers/tracking-events/troubleshooting/)

--- a/content/docs/for-developers/tracking-events/getting-started-event-webhook.md
+++ b/content/docs/for-developers/tracking-events/getting-started-event-webhook.md
@@ -13,11 +13,17 @@ navigation:
 
 SendGrid's Event Webhook will notify a URL of your choice via HTTP POST with information about events that occur as SendGrid processes your email. You can use this data to remove unsubscribes, react to spam reports, [determine unengaged recipients](https://sendgrid.com/blog/infer-engagement-with-the-event-api/), identify bounced email addresses, or create advanced analytics of your email program. With Unique Arguments and Category parameters, you can insert dynamic data that will help build a clear image of your email program.
 
+<call-out type="warning">
+
+Categories and Unique Arguments will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 You should set up the Event Webhook if you want to keep track of more event data that we store for you. Due to the sheer volume of email we send, we can only store so much information. Your [Email Activity Feed]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/) can hold up to 30 days worth of events. After that time passes, the email event data is gone.
 
 ## Getting started
 
-*To get started with the Event Webhook:*
+_To get started with the Event Webhook:_
 
 1. Go to the [Webhook tester](https://webhook.site/).
 1. Copy the unique URL.
@@ -27,9 +33,9 @@ You should set up the Event Webhook if you want to keep track of more event data
 1. Select the Event notifications you would like to test.
 1. Click the checkmark in the top corner to save these updates into your settings.
 1. Click **Test Your Integration**.
-    <br> This returns an HTTP POST containing a JSON array of your selected events in one request after a very short delay. Our servers send these POSTs to the URL you defined in the Event Notification app options.
+   <br> This returns an HTTP POST containing a JSON array of your selected events in one request after a very short delay. Our servers send these POSTs to the URL you defined in the Event Notification app options.
 1. Go back to the [Webhook tester](https://webhook.site/) and reload the page.
-     <br> This loads the JSON array of your selected events that you set in the last step.
+   <br> This loads the JSON array of your selected events that you set in the last step.
 
 <call-out type="warning">
 

--- a/content/docs/glossary/categories.md
+++ b/content/docs/glossary/categories.md
@@ -12,31 +12,31 @@ seo:
 
 Categories help organize your email analytics by enabling you to tag emails you send by topics you define.
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 Just as you can view the statistics on all your activity under the '[Statistics]({{root_url}}/ui/analytics-and-reporting/stats-overview)' tab, you can go a step further and view the [statistics broken down to a particular category]({{root_url}}/ui/analytics-and-reporting/categories/).
 
 The events that can be associated with category include:
 
--   Emails sent
--   Clicks
--   Emails opened
--   Emails bounced
--   Spam Reports
--   Unsubscribes
+- Emails sent
+- Clicks
+- Emails opened
+- Emails bounced
+- Spam Reports
+- Unsubscribes
 
 The actual statistics included vary depending upon the set of enabled apps. Emails sent, bounces, and spam reports will always get tracked. [Unsubscribes]({{root_url}}/ui/sending-email/subscription-tracking/), [Clicks]({{root_url}}/ui/analytics-and-reporting/click-tracking/), and Opens require that the associated Setting is enabled. Check out [Settings](https://app.sendgrid.com/settings) to see which apps you have enabled.
 
 In order to add the X-SMTPAPI categories header, please look at our [SMTP API Categories]({{root_url}}/for-developers/sending-email/categories/) documentation. You can also get a [full category list]({{root_url}}/for-developers/sending-email/categories#get) or get [category specific statistics]({{root_url}}/API_Reference/Web_API_v3/Stats/categories.html) from the SendGrid API.
 
-
 <call-out-link linktext="EXPERT INSIGHTS" img="/img/expert-insights-promo2.png" link="https://sendgrid.com/solutions/expert-insights/">
-
 
 ### Looking for more visibility into your email performance?
 
-
 Send better email with Expert Insights. Our detailed monthly reports will enable you to understand your email reputation and recipient engagement and repair issues with expert how-to steps.
 
-
 </call-out-link>
-
-

--- a/content/docs/ui/analytics-and-reporting/categories.md
+++ b/content/docs/ui/analytics-and-reporting/categories.md
@@ -11,6 +11,12 @@ navigation:
   show: true
 ---
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 Categories can help organize your email analytics by enabling you to “tag” emails by type. Just as you can view the statistics on all your [email activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/), you can go a step further and view the statistics broken down to a particular category.
 
 The actual statistics included vary depending upon your [account settings]({{root_url}}/ui/account-and-settings/account/). Emails sent, bounces, and spam reports will always get tracked. Unsubscribes, clicks, and opens require that the associated settings are enabled.
@@ -19,13 +25,13 @@ In order to see statistics for a category, select the category and the page will
 
 You can change which metrics, date, or grouping by adjusting the [statistics filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters).
 
-## 	Figures
+## Figures
 
 The figures table gives you all of the specific counts or percentages of each event, according to how you’ve grouped your statistics (day, week, or month). For example, if you wanted to see what percentage of the emails you sent were actually opened on the second week of April, this is a great place to check.
 
 This table will refresh with new or adjusted data based on the various filters available at the top of the page. You can also choose to show actual counts or percentages, by clicking the corresponding button above and to the right of the table.
 
-## 	Using the API
+## Using the API
 
 [Using Categories with the SMTP API]({{root_url}}/for-developers/sending-email/categories/)
 
@@ -35,7 +41,7 @@ Want deeper data and insights? With [SendGrid Email Insights Reports](https://go
 
 </call-out>
 
-## 	Additional Resources
+## Additional Resources
 
 - [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/)
 - [Statistics Filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters)

--- a/content/docs/ui/analytics-and-reporting/category-comparison.md
+++ b/content/docs/ui/analytics-and-reporting/category-comparison.md
@@ -11,21 +11,25 @@ navigation:
   show: true
 ---
 
-
 <call-out>
 
 Parent accounts will see aggregated statistics for their account and all subuser accounts. Subuser accounts will only see their own statistics.
 
 </call-out>
 
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 Categories can help organize your email analytics by enabling you to “tag” emails by type. As a result, you may want to compare one category to another. The category comparison tool allows you to do this.
 
-## 	Select Your Categories
+## Select Your Categories
 
 You can compare up to 10 categories at a time. To select them, click the **+** sign next to each category name in the left-side list. Then, click **Compare**.
 
-## 	Comparison Overview
+## Comparison Overview
 
 Once you have selected the categories, your top most graph will show you how each selected category has fared for each individual metric in a single graph. Each category will be assigned a color in this bar chart.
 
@@ -33,7 +37,7 @@ You can remove individual categories from the list of categories you selected in
 
 You can change which metrics, date, or grouping by adjusting the [statistics filters]({{root_url}}/ui/analytics-and-reporting/stats-overview/#statistics-filters).
 
-## 	Individual Metrics Comparison
+## Individual Metrics Comparison
 
 When you initially choose the categories to compare, this graph will be titled “Comparison for Deliveries” and will show you the delivery rates over time for each of the compared categories.
 
@@ -41,7 +45,7 @@ You can remove individual categories from the list of categories you selected in
 
 To change this graph to see another metric for your categories, click the button next to the Categories button and choose another metric.
 
-## 	Individual Metrics Figures
+## Individual Metrics Figures
 
 When you initially choose the categories to compare, this table will be titled “Figures for Delivered” and will show you the actual delivery numbers over time for each of the compared categories.
 
@@ -57,7 +61,7 @@ Want deeper data and insights? With [SendGrid Email Insights Reports](https://go
 
 </call-out>
 
-## 	Additional Resources
+## Additional Resources
 
 - [Subusers]({{root_url}}/ui/account-and-settings/subusers/)
 - [Using Categories with the SMTP API]({{root_url}}/for-developers/sending-email/categories/)

--- a/content/docs/ui/analytics-and-reporting/stats-overview.md
+++ b/content/docs/ui/analytics-and-reporting/stats-overview.md
@@ -18,7 +18,7 @@ Tracking your emails is an important part of being a good sender and learning ab
 We have broken up statistics in specific ways so that you can get at-a-glance data, as well as allowing you to get into the details of how your email is being used.
 </p>
 
-## 	Available Email Reports
+## Available Email Reports
 
 <call-out>
 
@@ -32,11 +32,17 @@ The timezone for statistics pages is set in your [account settings]({{root_url}}
 
 **[Category Statistics]({{root_url}}/ui/analytics-and-reporting/categories/)** -You can define your categories when you send, so that you can view your email performance by category later.
 
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 **[Category Comparison]({{root_url}}/ui/analytics-and-reporting/category-comparison/)** - Compare the performance of emails from up to 10 categories against each other.
 
 **[Subuser Statistics]({{root_url}}/ui/analytics-and-reporting/subuser/)** - You can segment your email to be sent by different subusers, which allows you to compare how each type or subset of your email is performing.
 
-**[Subuser Comparison]({{root_url}}/ui/analytics-and-reporting/subuser-comparison/)**  - Compare the performance of emails from up to 10 subusers against each other.
+**[Subuser Comparison]({{root_url}}/ui/analytics-and-reporting/subuser-comparison/)** - Compare the performance of emails from up to 10 subusers against each other.
 
 **[Geographical]({{root_url}}/ui/analytics-and-reporting/geographic/)** - See where you get the best engagement and compare engagement by geographical region.
 
@@ -52,8 +58,8 @@ The timezone for statistics pages is set in your [account settings]({{root_url}}
 
 **[Parse Webhook]({{root_url}}/for-developers/parsing-email/inbound-email/)** - View the number of requests you have received via the Parse Webhook.
 
+## Metrics
 
-## 	Metrics
  	<p>
 On the available statistics reports, you will find that your deliverability is broken down by the following metrics. Each one gives you a different piece of information about how SendGrid or your recipients interact with your email.
 </p>
@@ -83,11 +89,9 @@ On the available statistics reports, you will find that your deliverability is b
 
 **Unsubscribe Drops** - The number of emails dropped by SendGrid because the recipient unsubscribed from your emails.
 
-
 ## Filters
 
 These filters are available on most of the statistics pages. They will help you see your statistics in more or less details, depending on your needs.
-
 
 **Metric Filters** - You can select all of the metrics or only some of them.
 
@@ -95,10 +99,9 @@ These filters are available on most of the statistics pages. They will help you 
 
 **Grouping Filter** - Display statistics grouped by day, week, or month.
 
+## Top 5 Categories
 
-## 	Top 5 Categories
-
-  The Top 5 Categories report allows you to see your top 5 most used categories by number of requests. Switch your view by actual number of emails or percentage using the toggle at the top right of this section.
+The Top 5 Categories report allows you to see your top 5 most used categories by number of requests. Switch your view by actual number of emails or percentage using the toggle at the top right of this section.
 
 <call-out>
 
@@ -106,8 +109,8 @@ Want deeper data and insights? With [SendGrid Email Insights Reports](https://go
 
 </call-out>
 
-## 	Additional Resources
+## Additional Resources
 
-* [API Statistics Overview]({{root_url}}/API_Reference/Web_API_v3/Stats/index.html)
+- [API Statistics Overview]({{root_url}}/API_Reference/Web_API_v3/Stats/index.html)
 
-* [Advanced Analytics and Reporting]({{root_url}}/API_Reference/Web_API/Statistics/statistics_advanced.html)
+- [Advanced Analytics and Reporting]({{root_url}}/API_Reference/Web_API/Statistics/statistics_advanced.html)

--- a/content/docs/ui/analytics-and-reporting/subscribing-to-expert-insights.md
+++ b/content/docs/ui/analytics-and-reporting/subscribing-to-expert-insights.md
@@ -11,13 +11,13 @@ navigation:
   show: true
 ---
 
-Expert Insights is a monthly report that will give you deeper visibility into the health and performance of your email program. This report equips you with the data and insights you need to reach the inbox and increase your email ROI.  **See an example of [Expert Insights report.](https://sendgrid.com/wp-content/uploads/pdf/Expert-Insights-Sample.pdf)**
+Expert Insights is a monthly report that will give you deeper visibility into the health and performance of your email program. This report equips you with the data and insights you need to reach the inbox and increase your email ROI. **See an example of [Expert Insights report.](https://sendgrid.com/wp-content/uploads/pdf/Expert-Insights-Sample.pdf)**
 
 Expert Insights is designed to help you:
-* Understand your performance trends in an easy-to-understand, shareable format.
-* Identify areas of improvement with in-depth data on the factors that impact deliverability.
-* Know exactly what to do if you run into an issue with step-by-step instructions from our experts.
 
+- Understand your performance trends in an easy-to-understand, shareable format.
+- Identify areas of improvement with in-depth data on the factors that impact deliverability.
+- Know exactly what to do if you run into an issue with step-by-step instructions from our experts.
 
 ## How Expert Insights Works
 
@@ -31,15 +31,20 @@ For privacy reasons, your first Expert Insights report will cover 37 days of dat
 
 </call-out>
 
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
 
 [Categories](https://sendgrid.com/docs/ui/analytics-and-reporting/categories/) help organize your email analytics by enabling you to tag emails you send by topics you define. We recommend using 3-5 categories so we can provide more detailed email analytics in your Expert Insights report.
 
-Reports are generated per [subuser.] (https://sendgrid.com/docs/ui/account-and-settings/subusers/) Please reach out to our [Sales team] (https://sendgrid.com/contact-us-form/) to purchase reports for multiple subusers.
+Reports are generated per [subuser.](https://sendgrid.com/docs/ui/account-and-settings/subusers/) Please reach out to our [Sales team](https://sendgrid.com/contact-us-form/) to purchase reports for multiple subusers.
 
 ## How to Subscribe to Expert Insights
 
 1. Before you purchase Expert Insights, you will need to determine the subusers that you want to us to run a report on and where we should email the reports. We can send your reports to up to 3 email addresses.
-1. Pro customers can purchase Expert Insights directly on their [Billing page.] (https://app.sendgrid.com/account/billing) If you’re a Premier customer, please [contact sales] (https://sendgrid.com/expert-services-questions/) or speak to your Customer Success Manager to purchase Expert Insights.
+1. Pro customers can purchase Expert Insights directly on their [Billing page.](https://app.sendgrid.com/account/billing) If you’re a Premier customer, please [contact sales](https://sendgrid.com/expert-services-questions/) or speak to your Customer Success Manager to purchase Expert Insights.
 1. After you complete your purchase, you will receive your first report at the email addresses you’ve provided us as well as at your account administration email address within 1-2 business days. Moving forward, Expert Insights will appear on your regular monthly [invoice]({{root_url}}/ui/account-and-settings/reading-your-invoice/). If you purchase the report before the first of the month, prorated charges for your report will appear on your next invoice, as well as the full charge for next month’s report.
 1. We will send your monthly report to the emails you’ve provided us at the beginning of each month.
 
@@ -55,14 +60,13 @@ Need additional help? SendGrid's team of Email Consultants have over 95 years of
 
 </call-out>
 
-
 ## Managing Your Expert Insights Subscription
 
-Please reach out to our [Support team] (https://support.sendgrid.com/hc/en-us) at any time to change the email recipients of your monthly reports or the subuser that the report pertains to.
+Please reach out to our [Support team](https://support.sendgrid.com/hc/en-us) at any time to change the email recipients of your monthly reports or the subuser that the report pertains to.
 
-* Pro customers can cancel their Expert Insights directly on their [Billing page.] (https://app.sendgrid.com/account/billing)
-* Premier customers should reach out to their Customer Success Manager to cancel their subscription.
-* If you cancel your Expert Insights subscription, you will no longer receive monthly reports. This change is reflected on your invoice in the following month.
-* If you have would like to cancel your subscription for a specific user or users, please contact our [Support team.] (https://support.sendgrid.com/hc/en-us)
+- Pro customers can cancel their Expert Insights directly on their [Billing page.](https://app.sendgrid.com/account/billing)
+- Premier customers should reach out to their Customer Success Manager to cancel their subscription.
+- If you cancel your Expert Insights subscription, you will no longer receive monthly reports. This change is reflected on your invoice in the following month.
+- If you have would like to cancel your subscription for a specific user or users, please contact our [Support team.](https://support.sendgrid.com/hc/en-us)
 
-You will still receive a report if you have paid for a report this month but have not yet received it. This will be your final report. We will immediately stop collecting your data after your last report. While you can always re-purchase Expert Insights through our [Sales Team,] (https://sendgrid.com/expert-services-questions/) note that you will see a gap in your report data if you do so.
+You will still receive a report if you have paid for a report this month but have not yet received it. This will be your final report. We will immediately stop collecting your data after your last report. While you can always re-purchase Expert Insights through our [Sales Team,](https://sendgrid.com/expert-services-questions/) note that you will see a gap in your report data if you do so.

--- a/content/docs/ui/sending-email/editor.md
+++ b/content/docs/ui/sending-email/editor.md
@@ -31,9 +31,9 @@ The [Design Editor](#the-design-editor) features a number of convenient ways to 
 
 <call-out type="warning">
 
-Twilio SendGrid recommends only having one instance of a template or Marketing Campaign email open in one instance of the editor at a time.  Multiple instances in different browsers or computers will cause autosave to undo changes made and there is no recovery option.
+Twilio SendGrid recommends only having one instance of a template or Marketing Campaign email open in one instance of the editor at a time. Multiple instances in different browsers or computers will cause autosave to undo changes made and there is no recovery option.
 
-</call-out>  
+</call-out>
 
 ## The Code Editor
 
@@ -53,18 +53,17 @@ Easily pinpoint the HTML element you wish to edit. Click anywhere on the right-s
 **Syntax Highlighting** -
 As you edit, parts of your code highlights in various colors according to the type of syntax. This added dimension provides clarity and efficiency as you search for, locate, and edit code elements.
 
-
 ### Getting Started With The Code Editor
 
-*To use the code editor for Single Sends:*
+_To use the code editor for Single Sends:_
 
-1. From the left-hand navigation, select **Marketing**, and then click **Single Sends** 
+1. From the left-hand navigation, select **Marketing**, and then click **Single Sends**
 1. Click **Create a Single Send**.
-<br>To create a Single Send email using an existing (drafted or sent) email, find the Single Send you'd like to use and click the action menu next to the email.
+   <br>To create a Single Send email using an existing (drafted or sent) email, find the Single Send you'd like to use and click the action menu next to the email.
 1. Then, select **Edit** or **Duplicate**.
 1. Select **Code Editor**, and then click **Continue**.
 
-*To use the code editor for Automations:*
+_To use the code editor for Automations:_
 
 1. From the left-hand navigation, select **Marketing**, and then click **Automations** .
 1. Click **Create an Automation**.
@@ -77,7 +76,7 @@ The Welcome Series Automation can only be edited with the [design editor]({{root
 </call-out>
 
 1. Give the automation a name, entry criteria, exit criteria, and select an [Unsubscribe Group](https://sendgrid.com/docs/ui/sending-email/create-and-manage-unsubscribe-groups/).
-1. Select the send time and then click the edit button next to *Email 1*. 
+1. Select the send time and then click the edit button next to _Email 1_.
 1. Select **Code Editor**, and then click **Continue**.
 
 <call-out>
@@ -104,7 +103,7 @@ Once you create a new single send or automation email in the Code Editor, it can
 2. Select the image you want to add from your image library.
 3. Select the **image details** tab and copy the URL in the **Image Source URL** tab by clicking **Copy URL**.
 4. Paste this URL in an image source tag in your email or template's HTML.
-Example: `<img src="your image URL here">`
+   Example: `<img src="your image URL here">`
 
 ### Using Substitution Tags
 
@@ -116,8 +115,6 @@ Substitution tags allow you to easily generate dynamic content for each recipien
 2. Click the **Tags** tab at the top of the Settings window.
 3. Locate the tag you want to add to your email and click it to automatically copy it to your clipboard.
 4. Paste the tag into the email.
-
-
 
 <table class="table" style="table-layout:fixed">
  <tr>
@@ -249,29 +246,32 @@ Substitution tags allow you to easily generate dynamic content for each recipien
  </tr>
 </table>
 
-
 <call-out>
-
 
 For contacts with no entry in a custom field, the substitution tag appears blank. To set a default value, use the following pattern:
 
 `{{first_name | Valued Customer}}`
 
-
 </call-out>
 
 ### Adding Categories to Single Sends
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 Assigning categories to a single send allows you to track emails based on your own categorization system. By assigning your single send to a category, you can track statistics across multiple similar single sends and automations. Example categories may include: “Weekly Digest,” “Product Announcements.”
 
-1. Click the *Settings* panel located on the left-hand side of the window to expand it.
-1. Navigate to the *Settings* tab, and click **Single Send Settings** to expand the menu.
-1. Locate the *Categories* field under *Single Send Settings*.
-1. Select the *Add Categories* field. Type in the tag that you'd like to add, and press enter.
+1. Click the _Settings_ panel located on the left-hand side of the window to expand it.
+1. Navigate to the _Settings_ tab, and click **Single Send Settings** to expand the menu.
+1. Locate the _Categories_ field under _Single Send Settings_.
+1. Select the _Add Categories_ field. Type in the tag that you'd like to add, and press enter.
 
 <call-out>
 
-Currently, only 10 categories can be added to each single send. 
+Currently, only 10 categories can be added to each single send.
 
 </call-out>
 
@@ -285,37 +285,37 @@ SendGrid’s flexible design editor allows you to build your templates and email
 
 ### Getting Started With the Design Editor
 
-*To use the design editor for Single Sends:*
+_To use the design editor for Single Sends:_
 
-1. From the left-hand navigation, select **Marketing**, and then click **Single Sends** 
+1. From the left-hand navigation, select **Marketing**, and then click **Single Sends**
 1. Click **Create a Single Send**.
-<br>To create a single send email using an existing (drafted or sent) email, find the single send you'd like to use and click the action menu next to the email.
+   <br>To create a single send email using an existing (drafted or sent) email, find the single send you'd like to use and click the action menu next to the email.
 1. Then, select **Edit** or **Duplicate**.
 1. Select **Design Editor**, and then click **Continue**.
 
-*To use the design editor for Automations:*
+_To use the design editor for Automations:_
 
 1. From the left-hand navigation, select **Marketing**, and then click **Automations** .
 1. Click **Create an Automation**.
-1. Determine whether you’d like to send a pre-made Welcome series or a custom automation and then click **Select**. 
+1. Determine whether you’d like to send a pre-made Welcome series or a custom automation and then click **Select**.
 1. Give the automation a name, entry criteria, exit criteria, and select an unsubscribe group.
-1. Select the send time and then click the edit button next to *Email 1*. 
+1. Select the send time and then click the edit button next to _Email 1_.
 1. Select **Design Editor**, and then click **Continue**.
-<br>The Design Editor opens.
-7. Select the template that you want to use for your email.
-<br>You can select a Blank Template, a custom template that you have already created, or one of Twilio SendGrid’s pre-built templates. For more information, see [Working With Marketing Templates]({{root_url}}/ui/sending-email/working-with-marketing-templates/)
-8. Select **Design Editor** and then click **Continue**.
-<br>The Design Editor opens.
+   <br>The Design Editor opens.
+1. Select the template that you want to use for your email.
+   <br>You can select a Blank Template, a custom template that you have already created, or one of Twilio SendGrid’s pre-built templates. For more information, see [Working With Marketing Templates]({{root_url}}/ui/sending-email/working-with-marketing-templates/)
+1. Select **Design Editor** and then click **Continue**.
+   <br>The Design Editor opens.
 
 ### Using Drag & Drop Modules
 
 Drag & drop editing helps you swiftly build your email, using pre-built content modules. You can easily edit individual modules in the left-hand sidebar and reorder modules in your email body with a simple click and drag of your mouse.
 
-*To add a drag & drop module:*
+_To add a drag & drop module:_
 
 1. Navigate to the **Build** tab and then click **Add Modules**.
 
-  ![]({{root_url}}/img/design_editor_drag_drop.png "Drag and drop editor")
+![]({{root_url}}/img/design_editor_drag_drop.png 'Drag and drop editor')
 
 2. Find the module tile you want to add to your email. Then, drag and drop it into your content area.
 3. Edit the module settings and add your custom content to build your email.
@@ -388,7 +388,7 @@ In addition to editing the styles for individual modules within your email/templ
 
 The email body is the entire area that your email or template fills inside your recipient’s browser or email inbox.
 
-Under the Global Styles dropdown menu in the left hand sidebar, click **Email Body**  or **Content Container** to view and edit the following styles:
+Under the Global Styles dropdown menu in the left hand sidebar, click **Email Body** or **Content Container** to view and edit the following styles:
 
 <table class="table" style="table-layout:fixed">
 <tr>
@@ -414,10 +414,10 @@ Under the Global Styles dropdown menu in the left hand sidebar, click **Email Bo
 
 ### Editing Module HTML
 
-*To edit Module HTML:*
+_To edit Module HTML:_
 
 1. Select the module in the design editor and click the **&lt; &gt;** icon.
-<br>A window opens where you can edit the module HTML.
+   <br>A window opens where you can edit the module HTML.
 1. When you are finished editing the HTML, click **Update**.
 
 <call-out>
@@ -432,20 +432,20 @@ The code module is a unique drag & drop module that allows you to insert any cus
 
 <call-out type="warning">
 
-The Design Editor does not modify or validate any HTML inserted via a code module. Please be careful when using custom HTML.  Always preview your email before sending it.
+The Design Editor does not modify or validate any HTML inserted via a code module. Please be careful when using custom HTML. Always preview your email before sending it.
 
 </call-out>
 
 ### Adding Images
 
-*To upload an image:*
+_To upload an image:_
 
 1. Navigate to the **Build** tab and then click **Add Modules**.
 1. Select the Images module and drag and drop it into your content area.
-<br>This opens a window where you can upload images to your image library.
+   <br>This opens a window where you can upload images to your image library.
 1. Drag and drop the image you want to use from your files or select **Choose images** to upload.
 
-*To insert an image:*
+_To insert an image:_
 
 1. Navigate to the **Build** tab and then click **Add Modules**.
 1. Drag and drop the **Images** module into your content area.
@@ -458,7 +458,7 @@ The Design Editor does not modify or validate any HTML inserted via a code modul
 
 Substitution tags allow you to use any custom field data you've added to Marketing Campaigns to dynamically generate unique content for each recipient of your email. A common example is to add a recipient's first name to the body (or even the subject line) of your email.
 
-*To add a substitution tag to your email:*
+_To add a substitution tag to your email:_
 
 1. Navigate to the **Tags** tab.
 1. Locate the tag you want to add to your email and click the **copy** icon.
@@ -513,13 +513,11 @@ You'll also see a number of System Fields that you can place in the body of your
  </tr>
 </table>
 
-
-&ast; For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Tags tab of the Design Editor.
+\* For your convenience, these substitution tags are included by default in the Unsubscribe Module found on the Tags tab of the Design Editor.
 
 <call-out type="warning">
 
-The `<%asm_group_unsubscribe_raw_url%>`, `<%asm_preferences_raw_url%>`, and `<%asm_global_unsubscribe
-_raw_url%>` tags are reserved for use in Transactional Templates and should not be used in Marketing Campaigns.
+The `<%asm_group_unsubscribe_raw_url%>`, `<%asm_preferences_raw_url%>`, and `<%asm_global_unsubscribe _raw_url%>` tags are reserved for use in Transactional Templates and should not be used in Marketing Campaigns.
 
 </call-out>
 
@@ -545,14 +543,13 @@ When previewing an email, you also see a preview of the From name, the Subject, 
 
 The HTML `<head>` element is where you can define any metadata you would like to include with your email or template. For example, you can use the `<head>` element to define any custom fonts or CSS styles you would like to use.
 
-*To edit the HTML head of your email or template:*
+_To edit the HTML head of your email or template:_
 
 1. Navigate to the **Build** tab in the left-hand toolbar and scroll to the **Advanced** menu.
 1. Expand the option titled **Edit HTML Head**.
-1. Click  **Edit** to begin editing your HTML head.
+1. Click **Edit** to begin editing your HTML head.
    <br>A window appears where you can insert your custom HTML.
 1. Once you've finished making your changes, click the **Update** button.
-
 
 #### Adding Custom Fonts Using the HTML Head
 
@@ -566,15 +563,15 @@ Make sure that you define a web-safe font to use as a fallback if one of your re
 
 While some inbox providers do not support web fonts, the following popular clients do provide web font support:
 
-* Apple Mail
-* Outlook.com app
-* Outlook 2000
-* Default Android Mail app (not the Android Gmail app)
-* iOS Mail
+- Apple Mail
+- Outlook.com app
+- Outlook 2000
+- Default Android Mail app (not the Android Gmail app)
+- iOS Mail
 
 This list may change and we cannot guarantee 100% support from any of these clients.
 
-*To add a custom font using the HTML head:*
+_To add a custom font using the HTML head:_
 
 1. Open the HTML Head by navigating to the **Build** tab in the design editor.
 1. Scroll down to the **Advanced** drop-down menu and select **Edit HTML Head**.
@@ -582,18 +579,18 @@ This list may change and we cannot guarantee 100% support from any of these clie
 1. Insert a `<link>` tag containing an href attribute pointing to your web font.
 
 For example:
+
 ```html
-<link href="https://fonts.google.com/specimen/Oswald" rel="stylesheet">
+<link href="https://fonts.google.com/specimen/Oswald" rel="stylesheet" />
 ```
 
 Next, you’ll have to add a `<style>` to specify that you want to use this new font family:
 
 ```html
 <style>
-    body {
-        font-family: 'Oswald',
-        sans-serif;
-    }
+  body {
+    font-family: 'Oswald', sans-serif;
+  }
 </style>
 ```
 
@@ -601,7 +598,7 @@ Next, you’ll have to add a `<style>` to specify that you want to use this new 
 
 If you are writing your own custom HTML that you plan on importing into the design editor, refer to the [drag & drop code examples](#drag--drop-code-examples) to ensure that any modules you create are compatible with our drag & drop functionality. If you do not specify a data type that matches one of our drag & drop modules, your code is imported as a text module.
 
-*To import custom HTML:*
+_To import custom HTML:_
 
 1. Navigate to the **Build** tab in the left-hand navigation.
 2. Scroll down and select the **Advanced** drop-down menu.
@@ -609,7 +606,7 @@ If you are writing your own custom HTML that you plan on importing into the desi
 4. Click **Import**.
    <br>A window opens where you can paste in your own HTML.
 
-  ![]({{root_url}}/img/import_custom_html.png "Import custom HTML")
+![]({{root_url}}/img/import_custom_html.png 'Import custom HTML')
 
 5. Paste or enter the HTML you want to use and then click **Import**.
 
@@ -623,18 +620,16 @@ Any HTML that you import replaces all existing content in your email or template
 
 Twilio SendGrid parses your custom HTML, looking for any [drag & drop compatible modules](#drag--drop-code-examples).
 
-  * First, we look for any HTML elements that contain the attribute `role="modules-container"`.
-  * Next, we look for all HTML elements with the attribute `role="module"` that are descendants of the "modules-container" element.
+- First, we look for any HTML elements that contain the attribute `role="modules-container"`.
+- Next, we look for all HTML elements with the attribute `role="module"` that are descendants of the "modules-container" element.
 
 The `role="modules-container"` attribute is required so that we know where your drag and drop modules are located. All of the Twilio SendGrid pre-built templates include the `role="modules-container"` by default. You are only required to include this attribute when creating an email or template from scratch that you want to be compatible with the design editor.
 
 <call-out type="warning">
 
-
 Any HTML outside an element with the "modules-container" attribute is discarded. Only [supported styling options and attributes](#drag--drop-module-descriptions-and-styles) are included.
 
 If you don't include the "modules-container" attribute in any of your custom HTML, then all of your HTML is imported as a single text module.
-
 
 </call-out>
 
@@ -706,6 +701,7 @@ Following is an example of how you should structure and organize your custom HTM
     </tr>
   </table>
 ```
+
 ```code
   <table class="module" role="module" data-type="code">
     <tr>
@@ -764,6 +760,7 @@ Following is an example of how you should structure and organize your custom HTM
     </tr>
   </table>
 ```
+
 ```spacer
   <table class="module" role="module" data-type="spacer">
     <tr>
@@ -772,6 +769,7 @@ Following is an example of how you should structure and organize your custom HTM
     </tr>
   </table>
 ```
+
 ```social
   <table class="module" role="module" data-type="social">
     <tbody>
@@ -789,12 +787,12 @@ Following is an example of how you should structure and organize your custom HTM
     </tbody>
   </table>
 ```
-</code-group>
 
+</code-group>
 
 ### Exporting HTML From the Design Editor
 
-*To export template HTML from the design editor:*
+_To export template HTML from the design editor:_
 
 1. Navigate to the **Build** tab in the left-hand navigation.
 1. Scroll down and select the **Advanced** drop-down menu.
@@ -803,30 +801,36 @@ Following is an example of how you should structure and organize your custom HTM
 
 SendGrid hosts the images included in the pre-built templates and any images you have uploaded to the image library, so when you export a template’s HTML from the design editor, the embedded URLs in each `<img>` tag remains valid.
 
-*To open exported HTML in the code editor using Single Sends:*
+_To open exported HTML in the code editor using Single Sends:_
 
 1. From the left-hand navigation, select **Marketing** and then click **Single Sends**.
 1. Click **New Campaign** and then select **Blank Template**.
 1. Select **Code Editor**.
 1. Paste the raw SendGrid template HTML into the code editor.
 
-*To open exported HTML in the code editor using Automations:*
+_To open exported HTML in the code editor using Automations:_
 
 1. From the left-hand navigation, select **Marketing** and then click **Automations**.
-1. Click **Create an Automation** and then navigate to *Custom Automation* and click **Select**.
+1. Click **Create an Automation** and then navigate to _Custom Automation_ and click **Select**.
 1. Navigate to the first email in the Automation series and click **Edit Email Content**.
-1. Locate the blank template and click **Select**.  
+1. Locate the blank template and click **Select**.
 1. Select **Code Editor**.
 1. Paste the raw SendGrid template HTML into the code editor.
 
 ### Adding Categories to Single Sends
 
+<call-out type="warning">
+
+This information will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 Assigning categories to a single send allows you to track emails based on your own categorization system. By assigning your single send to a category, you can track statistics across multiple similar single sends and automations. Example categories: “Weekly Digest,” “Product Announcements.”
 
-*To add a category:*
+_To add a category:_
 
-1. Navigate to the *Settings* tab and click **Single Send Settings** to expand the menu.
-1. Find the *Categories* field.
+1. Navigate to the _Settings_ tab and click **Single Send Settings** to expand the menu.
+1. Find the _Categories_ field.
 1. Enter the name of a new category or select a previously used category from the drop-down menu.
 
 ### Email Testing
@@ -835,9 +839,7 @@ Email testing offers robust, pre-send testing of your emails, including in-app s
 
 ## Additional Resources
 
-* [Sending an Email]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/)
-* [A/B Testing]({{root_url}}/ui/sending-email/a-b-testing/)
-* [Campaign Statistics]({{root_url}}/ui/analytics-and-reporting/marketing-campaigns-stats/)
-* [Marketing Templates]({{root_url}}/ui/sending-email/working-with-marketing-templates/)
-
-
+- [Sending an Email]({{root_url}}/ui/sending-email/how-to-send-email-with-marketing-campaigns/)
+- [A/B Testing]({{root_url}}/ui/sending-email/a-b-testing/)
+- [Campaign Statistics]({{root_url}}/ui/analytics-and-reporting/marketing-campaigns-stats/)
+- [Marketing Templates]({{root_url}}/ui/sending-email/working-with-marketing-templates/)

--- a/content/docs/ui/sending-email/getting-started-with-automation.md
+++ b/content/docs/ui/sending-email/getting-started-with-automation.md
@@ -68,6 +68,12 @@ If you select “no longer meet entry criteria”, before each email in your ser
 6. Select an [Unsubscribe Group]({{root_url}}/ui/sending-email/create-and-manage-unsubscribe-groups/#create-an-unsubscribe-group). This Unsubscribe Group will apply to all emails in your Automation.
 7. Add a [category]({{root_url}}/glossary/categories/) to the automation (optional). Categories are useful for [comparing performance]({{root_url}}/ui/analytics-and-reporting/category-comparison/) across different types of email you send.
 
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
 <call-out>
 
 If you have dedicated IPs, you can set up [IP Pools]({{root_url}}/ui/account-and-settings/ip-pools/) that allow you separate your traffic and potentially enhance your deliverability by protecting your sender reputation. To utilize IP pools for Automations, select the IP Pool you wish to use for the entire automation series from the IP Pool drop-down.
@@ -90,17 +96,24 @@ The pre-built Welcome Series automation provides a jumping off point to inspire 
 _To create a Welcome Series:_
 
 1. Navigate to **Automations** and then click **Create an Automation**.
-1. Under Welcome, click **Select**.
-1. Update the automation name (this is for your reference and will not be visible to your contacts).
-1. Review the entry criteria to decide if you’d like to update it. The default entry criteria is “The first time a contact is added to All Contacts”.
-1. Review the exit criteria to decide if you’d like to update it.
-1. Select an [Unsubscribe Group]({{root_url}}/ui/sending-email/create-and-manage-unsubscribe-groups/#create-an-unsubscribe-group). This Unsubscribe Group will apply to all emails in your Automation.
-1. Add a [category]({{root_url}}/glossary/categories/) to the automation (optional). Categories are useful for [comparing performance]({{root_url}}/ui/analytics-and-reporting/category-comparison/) across different types of email you send.
-1. The pre-built Welcome Series has three placeholder emails by default. You’ll need to edit the subject line and content of each email. You may decide to remove or add emails to the pre-built.
-1. If you did not do so within the editor, you can add a subject line and select a sender from the Edit Automation page.
-1. To add more emails to this automated series, click **Add an Email**.
-1. Choose how long to wait between each email in the series. This time will be relative to the preceding email.
-1. Once you have created all of your emails for the automation, click **Set Live**.
+2. Under Welcome, click **Select**.
+3. Update the automation name (this is for your reference and will not be visible to your contacts).
+4. Review the entry criteria to decide if you’d like to update it. The default entry criteria is “The first time a contact is added to All Contacts”.
+5. Review the exit criteria to decide if you’d like to update it.
+6. Select an [Unsubscribe Group]({{root_url}}/ui/sending-email/create-and-manage-unsubscribe-groups/#create-an-unsubscribe-group). This Unsubscribe Group will apply to all emails in your Automation.
+7. Add a [category]({{root_url}}/glossary/categories/) to the automation (optional). Categories are useful for [comparing performance]({{root_url}}/ui/analytics-and-reporting/category-comparison/) across different types of email you send.
+
+<call-out type="warning">
+
+Categories will be stored as a “Not PII” field and may be used for counting or other operations as SendGrid runs its systems. These fields generally cannot be redacted or removed. You should take care not to place PII in this field. SendGrid does not treat this data as PII, and its value may be visible to SendGrid employees, stored long-term, and may continue to be stored after you’ve left SendGrid’s platform.
+
+</call-out>
+
+8. The pre-built Welcome Series has three placeholder emails by default. You’ll need to edit the subject line and content of each email. You may decide to remove or add emails to the pre-built.
+9. If you did not do so within the editor, you can add a subject line and select a sender from the Edit Automation page.
+10. To add more emails to this automated series, click **Add an Email**.
+11. Choose how long to wait between each email in the series. This time will be relative to the preceding email.
+12. Once you have created all of your emails for the automation, click **Set Live**.
 
 <call-out type="warning">
 
@@ -161,7 +174,6 @@ When you re-enable the automation, contacts who previously entered the series wi
 
 </call-out>
 
-
 ## Automation Use Cases and Examples
 
 ### Segment-triggered nurture series
@@ -169,8 +181,8 @@ When you re-enable the automation, contacts who previously entered the series wi
 A valuable use case for Automation is to nurture your free customers to become paid using a drip series. The series will send automatically to free users until they reach the end of the email sequence or they upgrade to paid, whichever comes first. Here's how:
 
 1. Create a segment of all contacts whose custom field “Plan Type” value is “Free”
-1. Set entry criteria to the first time a contact "is added to a segment" and select the “Free customers" segment you just created. 
+1. Set entry criteria to the first time a contact "is added to a segment" and select the “Free customers" segment you just created.
 1. Set the exit criteria as “Contacts no longer meet entry criteria”
 1. Craft a series of emails to nurture contacts to become paid.
 
-From there, any time you add a new contact whose plan type is "Free", they are automatically added to the relevant segment and entered into the automation. If they upgrade their plan during the drip series, Automation automatically removes them from the series. 
+From there, any time you add a new contact whose plan type is "Free", they are automatically added to the relevant segment and entered into the automation. If they upgrade their plan during the drip series, Automation automatically removes them from the series.


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Add an alert box informing customers that Categories and Unique Arguments are not PII.
**Reason for the change**: This information is needed to maintain transparency and inform customers about how to properly use the API.
**Link to original source**: NA
