### PR TITLE
add SendGrid4Android to the list of community libraries

### DIFF
--- a/content/docs/for-developers/sending-email/libraries.md
+++ b/content/docs/for-developers/sending-email/libraries.md
@@ -72,6 +72,7 @@ If you create a library, please let us know, by editing this page [in our GitHub
  ### 	Android
 
 -   [sendgrid-android](https://github.com/danysantiago/sendgrid-android) - The Android library for SendGrid by [DannySantiago](https://github.com/danysantiago)
+-   [SendGrid4Android](https://github.com/fredericojssilva/SendGrid4Android) *by Frederico Silva* - Simple SendGrid client for Android
 
  ### 	ColdFusion
 


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Add SendGrid4Android to the list of community libraries
**Reason for the change**: The existent android library is deprecated, so I decided to create a new one and will try to improve it will all available feature
**Link to original source**: https://github.com/fredericojssilva/SendGrid4Android