### PR TITLE
Change port for SMTP

### DIFF
--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -95,7 +95,7 @@ ActionMailer::Base.smtp_settings = {
   :api_key => 'your_sendgrid_api_key',
   :domain => 'yourdomain.com',
   :address => 'smtp.sendgrid.net',
-  :port => 465,
+  :port => 587,
   :authentication => :plain,
   :enable_starttls_auto => true
 }


### PR DESCRIPTION
Using port 465 doesn't work, using 587 works.

### Checklist
**Required**
- [X] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Change port from 465 to 587
**Reason for the change**: Port 465 doesn't work
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/integrating-with-the-smtp-api/

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
