### PR TITLE
Update rubyonrails.md

### DIFF
--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -92,7 +92,7 @@ In `config/environment.rb` specify your ActionMailer settings to point to SendGr
 ``` ruby
 ActionMailer::Base.smtp_settings = {
   :user_name => 'apikey',
-  :api_key => 'your_sendgrid_api_key',
+  :password => 'your_sendgrid_api_key',
   :domain => 'yourdomain.com',
   :address => 'smtp.sendgrid.net',
   :port => 465,


### PR DESCRIPTION
Update smtp_settings key from api_key to password (fails to work on rails 5 and rails 6 without password)

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Update smtp_settings key from api_key to password
**Reason for the change**: Rails apps fail to send sendgrid emails without this change (in development not tested in production)
**Link to original source**:

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
