### PR TITLE
Update Event Webhook table and sample responses for accuracy

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -103,8 +103,7 @@ Here is an event response that includes an example of each type of event:
     "category": "cat facts",
     "sg_event_id": "sg_event_id",
     "sg_message_id": "sg_message_id",
-    "reason": "Bounced Address",
-    "status": "5.0.0"
+    "reason": "Bounced Address"
   },
   {
     "email": "example@test.com",
@@ -134,7 +133,6 @@ Here is an event response that includes an example of each type of event:
     "sg_message_id": "sg_message_id",
     "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
     "ip": "255.255.255.255",
-    "url": "http://www.sendgrid.com/",
     "asm_group_id": 10
   },
   {
@@ -147,7 +145,6 @@ Here is an event response that includes an example of each type of event:
     "sg_message_id": "sg_message_id",
     "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
     "ip": "000.000.000.000",
-    "url": "http://www.sendgrid.com/",
     "asm_group_id": 10
   }
 ]
@@ -155,7 +152,7 @@ Here is an event response that includes an example of each type of event:
 
 ### Delivery events
 
-Delivery events include processed, dropped, delivered, deferred, and bounce.
+Delivery events include `processed`, `dropped`, `delivered`, `deferred`, and `bounce`.
 
 <table class="table">
   <colgroup>
@@ -207,7 +204,6 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
       "sg_event_id":"zmzJhfJgAfUSOW80yEbPyw==",
       "sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0",
       "reason":"Bounced Address",
-      "status":"5.0.0"
   }
 ]
 ```
@@ -303,7 +299,7 @@ Delivery events include processed, dropped, delivered, deferred, and bounce.
 
 ### Engagement events
 
-Engagement events include open, click, spam report, unsubscribe, group unsubscribe, and group resubscribe.
+Engagement events include `open`, `click`, `spamreport`, `unsubscribe`, `group_unsubscribe`, and `group_resubscribe`.
 
 <table class="table">
   <colgroup>
@@ -326,7 +322,6 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"open",
       "category":"cat facts",
       "sg_event_id":"FOTFFO0ecsBE-zxFXfs6WA==",
@@ -347,7 +342,6 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"click",
       "category":"cat facts",
       "sg_event_id":"kCAi1KttyQdEKHhdC-nuEA==",
@@ -369,7 +363,6 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"spamreport",
       "category":"cat facts",
       "sg_event_id":"37nvH5QBz858KGVYCM4uOA==",
@@ -388,7 +381,6 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"unsubscribe",
       "category":"cat facts",
       "sg_event_id":"zz_BjPgU_5pS-J8vlfB1sg==",
@@ -407,14 +399,12 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"group_unsubscribe",
       "category":"cat facts",
       "sg_event_id":"ahSCB7xYcXFb-hEaawsPRw==",
       "sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0",
       "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
       "ip":"255.255.255.255",
-      "url":"http://www.sendgrid.com/",
       "asm_group_id":10
    }
 ]
@@ -430,14 +420,12 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
    {
       "email":"example@test.com",
       "timestamp":1513299569,
-      "smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>",
       "event":"group_resubscribe",
       "category":"cat facts",
       "sg_event_id":"w_u0vJhLT-OFfprar5N93g==",
       "sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0",
       "useragent":"Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
       "ip":"255.255.255.255",
-      "url":"http://www.sendgrid.com/",
       "asm_group_id":10
    }
 ]
@@ -457,12 +445,12 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <th><a href="#delivered">Delivered</a></th>
     <th><a href="#deferred">Deferred</a></th>
     <th><a href="#bounce">Bounce</a></th>
-    <th><a href="#opened">Opened</a></th>
-    <th><a href="#clicked">Clicked</a></th>
+    <th><a href="#open">Open</a></th>
+    <th><a href="#click">Click</a></th>
     <th><a href="#spamreport">Spam Report</a></th>
     <th><a href="#unsubscribe">Unsubscribe</a></th>
-    <th><a href="#groupunsubscribe">Group Unsubscribe</a></th>
-    <th><a href="#groupresubscribe">Group Resubscribe</a></th>
+    <th><a href="#group_unsubscribe">Group Unsubscribe</a></th>
+    <th><a href="#group_resubscribe">Group Resubscribe</a></th>
   </tr>
   <tr>
     <td><a href="#email">email</a></td>
@@ -507,12 +495,12 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
   </tr>
   <tr>
-    <td><a href="#smtpid">smtp-id</a></td>
+    <td><a href="#smtp-id">smtp-id</a></td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
-    <td>X</td>
+    <td>X*</td>
     <td></td>
     <td></td>
     <td></td>
@@ -530,7 +518,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td></td>
-    <td></td>
+    <td>X</td>
     <td>X</td>
     <td>X</td>
   </tr>
@@ -539,31 +527,31 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
     <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
     <td></td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td></td>
-    <td></td>
-    <td>X</td>
-    <td>X</td>
-  </tr>
-  <tr>
-    <td><a href="#sgeventid">sg_event_id</a></td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
     <td></td>
     <td>X</td>
     <td>X</td>
   </tr>
   <tr>
-    <td><a href="#sgmessageid">sg_message_id</a></td>
+    <td><a href="#sg_event_id">sg_event_id</a></td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td><a href="#sg_message_id">sg_message_id</a></td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
@@ -572,16 +560,30 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td><a href="#type">type</a></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td></td>
     <td>X</td>
-    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
   </tr>
   <tr>
     <td><a href="#reason">reason</a></td>
     <td></td>
     <td>X</td>
     <td></td>
-    <td>X</td>
+    <td></td>
     <td>X</td>
     <td></td>
     <td></td>
@@ -609,7 +611,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
     <td>X</td>
-    <td></td>
+    <td>X</td>
     <td></td>
     <td></td>
     <td></td>
@@ -623,7 +625,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
     <td>X</td>
-    <td></td>
+    <td>X</td>
     <td>X</td>
     <td></td>
     <td></td>
@@ -639,7 +641,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
+    <td>X</td>
     <td>X</td>
     <td></td>
     <td></td>
@@ -657,25 +659,11 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td>X</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="#asmgroupid">asm_group_id</a></td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td></td>
-    <td></td>
     <td>X</td>
     <td>X</td>
   </tr>
   <tr>
-    <td><a href="#uniqueargs">unique_args</a></td>
+    <td><a href="#asm_group_id">asm_group_id</a></td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
@@ -683,13 +671,13 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td>X</td>
-    <td>X</td>
-    <td>X</td>
+    <td></td>
+    <td></td>
     <td>X</td>
     <td>X</td>
   </tr>
   <tr>
-    <td><a href="#marketingcampaignid">marketing_campaign_id</a></td>
+    <td><a href="#unique_args">unique_args**</a></td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
@@ -703,7 +691,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
   </tr>
   <tr>
-    <td><a href="#marketingcampaignname">marketing_campaign_name</a></td>
+    <td><a href="#newsletter">newsletter</a></td>
     <td>X</td>
     <td>X</td>
     <td>X</td>
@@ -713,8 +701,22 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td>X</td>
     <td>X</td>
     <td>X</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="#url_offset">url_offset</a></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>X</td>
-    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
   </tr>
   <tr>
     <td><a href="#attempt">attempt</a></td>
@@ -733,7 +735,7 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <tr>
     <td><a href="#pool">pool</a></td>
     <td>X</td>
-    <td></td>
+    <td>X</td>
     <td></td>
     <td></td>
     <td></td>
@@ -744,29 +746,80 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
   </tr>
+  <tr>
+    <td><a href="#send_at">send_at</a></td>
+    <td>X</td>
+    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="#cert_err">cert_err</a></td>
+    <td></td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a ref="#reseller_id">reseller_id</a></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>X</td>
+    <td></td>
+    <td></td>
+  </tr>
 </table>
 
-\* In the case of a delayed or asynchronous bounce, the message ID will be unavailable.
+\* In the case of a delayed or asynchronous bounce, the `sg_message_id` and `smtp-id` will be unavailable.
+
+\** The `unique_args` field is shorthand for any unique arguments you make available. You will not see a `unique_args` field but will instead see all of your unique arguments at the root level of the returned JSON.
 
 ### JSON objects
 
-- <a name="email"></a>`email` - the email address of the recipient
-- <a name="timestamp"></a>`timestamp` - the <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX timestamp</a> of when the message was sent
-- <a name="event"></a>`event` - the event type. Possible values are processed, dropped, delivered, deferred, bounce, open, click, spam report, unsubscribe, group unsubscribe, and group resubscribe.
-- <a name="smtpid"></a>`smtp-id` - a unique ID attached to the message by the originating system.
-- <a name="useragent"></a>`useragent` - the user agent responsible for the event. This is usually a web browser. For example, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36".
-- <a name="ip"></a>`ip` - the IP address used to send the email. For `open` and `click` events, it is the IP address of the recipient who engaged with the email.
-- <a name="sgeventid"></a>`sg_event_id` - a unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.
-- <a name="sgmessageid"></a>`sg_message_id` - a unique, internal SendGrid ID for the message. The first half of this ID is pulled from the `smtp-id`. The message ID will be included in most cases. In the event of an asynchronous bounce, the message ID will not be available. An asynchronous bounce occurs when a message is first accepted by the receiving mail server and then bounced at a later time. When this happens, there is less information available about the bounce.
-- <a name="reason"></a>`reason` - any sort of error response returned by the receiving server that describes the reason this event type was triggered.
-- <a name="status"></a>`status` - status code string. Corresponds to HTTP status code - for example, a JSON response of 5.0.0 is the same as a 500 error response.
-- <a name="response"></a>`response` - the full text of the HTTP response error returned from the receiving server.
-- <a name="tls"></a>`tls` - indicates whether TLS encryption was used in sending this message. For more information about TLS, see the [TLS Glossary page]({{root_url}}/glossary/tls/).
-- <a name="url"></a>`url` - the URL where the event originates. For click events, this is the URL clicked on by the recipient.
-- <a name="url_offset"</a>`url_offset` - if there is more than one of the same links in an email, this tells you which of those identical links was clicked.
-- <a name="attempt"></a>`attempt` - the number of times SendGrid has attempted to deliver this message.
+- <a name="email"></a>`email` - The email address associated with this event.
+- <a name="timestamp"></a>`timestamp` - The <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX timestamp</a> of when the message was sent.
+- <a name="event"></a>`event` - The event type. Possible values are `processed`, `dropped`, `delivered`, `deferred`, `bounce`, `open`, `click`, `spamreport`, `unsubscribe`, `group_unsubscribe`, and `group_resubscribe`.
+- <a name="smtp-id"></a>`smtp-id` - A unique ID attached to the message by the originating system. In the event of an asynchronous bounce, the `smtp-id` will not be available. An asynchronous bounce occurs when a message is first accepted by the receiving mail server and then bounced at a later time. When this happens, there is less information available about the bounce.
+- <a name="useragent"></a>`useragent` - The user agent responsible for the event. This is usually a web browser. For example, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36".
+- <a name="ip"></a>`ip` - The IP address used to send the email. For `open` and `click` events, it is the IP address of the recipient who engaged with the email.
+- <a name="sg_event_id"></a>`sg_event_id` - A unique ID for this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.
+- <a name="sg_message_id"></a>`sg_message_id` - A unique, internal SendGrid ID for the message. The first half of this ID is pulled from the `smtp-id`. The `sg_message_id` will be included in most cases. In the event of an asynchronous bounce, the message ID will not be available. An asynchronous bounce occurs when a message is first accepted by the receiving mail server and then bounced at a later time. When this happens, there is less information available about the bounce.
+- <a name="type"></a>`type` - Indicates whether the bounce event was a hard bounce (type=bounce) or block (type=blocked)
+- <a name="reason"></a>`reason` - Any error response returned by the receiving server that describes the reason this event type was triggered.
+- <a name="status"></a>`status` - A status code string. Corresponds to HTTP status code - for example, a JSON response of 5.0.0 is the same as a 500 error response.
+- <a name="response"></a>`response` - The full text of the HTTP response error returned from the receiving server.
+- <a name="tls"></a>`tls` - Indicates whether TLS encryption was used when sending this message. For more information about TLS, see the [TLS Glossary page]({{root_url}}/glossary/tls/).
+- <a name="url"></a>`url` - The URL where the event originates. For click events, this is the URL clicked on by the recipient.
 - <a name="category"></a>`category` - [Categories]({{root_url}}/glossary/categories/) are custom tags that you set for the purpose of organizing your emails. If you send single categories as an array, they will be returned by the webhook as an array. If you send single categories as a string, they will be returned by the webhook as a string.
-- <a name="type"></a>`type` - indicates whether the bounce event was a hard bounce (type=bounce) or block (type=blocked)
+- <a name="asm_group_id"></a>`asm_group_id` - The ID associated with the suppression group. For more on suppression groups, see our [suppression groups documentation]({{root_url}}/for-developers/sending-email/suppressions/).
+- <a name="unique_args"></a>`unique_args` - Any unique arguments included by the sender. The `unique_args` field is shorthand for any unique arguments you make available. You will not see a `unique_args` field but will instead see all of your unique arguments at the root level of the returned JSON. For more information, see the [unique arguments section of this page](#unique-arguments-and-custom-arguments).
+- <a name="newsletter"></a>`newsletter` - Indicates if the email was sent with the newsletter tool. The newsletter tool has been retired.
+- <a name="url_offset"</a>`url_offset` - A number assigned to a click event URL. If there is more than one of the same links in an email, this offset number helps you identify which of those identical links was clicked.
+- <a name="attempt"></a>`attempt` - The number of times SendGrid has attempted to deliver this message.
+- <a name="pool"></a>`pool` - The IP pool used to deliver the message.
+- <a name="send_at"></a>`send_at` - The send time of a scheduled send.
+- <a name="cert_err"></a>`cert_err` - Indicates if there was a certificate error on the receiving server.
+- <a name="reseller_id"></a>`reseller_id` - The ID associated with a reseller.
 
 String categories:
 
@@ -856,7 +909,7 @@ You can create unique arguments with the same words as reserved keys, such as "e
 
 </call-out>
 
-### Reserved Keys in Unique Arguments
+#### Reserved Keys in Unique Arguments
 
 ```json
 //for this example, assume we're sending to john.doe@sendgrid.com
@@ -871,7 +924,7 @@ You can create unique arguments with the same words as reserved keys, such as "e
 }
 ```
 
-### The resulting webhook call
+#### The resulting webhook call
 
 ```json
 [
@@ -935,12 +988,14 @@ The Event Webhook response:
 ]
 ```
 
+#### Custom Arguments and Marketing Campaigns
+
 For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook.
 
-- <a name="singlesendid"></a>`singlesend_id`
-- <a name="singlesendname"></a>`singlesend_name`
+- <a name="singlesend_id"></a>`singlesend_id`
+- <a name="singlesend_name"></a>`singlesend_name`
 
-### Example event from a Single Send:
+##### Example event from a Single Send:
 
 ```json
 [
@@ -971,7 +1026,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 - <a name="marketingcampaignid"></a>`marketing_campaign_id`
 - <a name="marketingcampaignname"></a>`marketing_campaign_name`
 
-### Example event from a standard (non-A/B test) campaign send:
+##### Example event from a standard (non-A/B test) campaign send:
 
 ```json
 {
@@ -989,7 +1044,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 }
 ```
 
-### Example event from an A/B Test:
+##### Example event from an A/B Test:
 
 `marketing_campaign_version` is displayed in the event data for emails sent as part of an A/B Test. The value for `marketing_campaign_version` are returned as `A`, `B`, `C`, etc.
 
@@ -1011,7 +1066,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 }
 ```
 
-### Example event from the winning phase of an A/B Test:
+##### Example event from the winning phase of an A/B Test:
 
 ```json
 {
@@ -1030,7 +1085,7 @@ For emails sent through our Marketing Campaigns feature, we add Marketing Campai
 }
 ```
 
-### Legacy Marketing Email Unsubscribes
+##### Legacy Marketing Email Unsubscribes
 
 For emails sent through our Legacy Marketing Email tool, unsubscribes look like the following example:
 
@@ -1065,54 +1120,6 @@ For emails sent through our Legacy Marketing Email tool, unsubscribes look like 
     "sg_event_id": "RHFZB1IrTD2Y9Q7bUdZxUw",
     "sg_message_id": "14c583da911.2c36.1c804d.filter-406.22375.55148AA99.0",
     "event": "processed"
-  }
-]
-```
-
-### Click
-
-<table class="table table-bordered table-striped">
-   <thead>
-      <tr>
-         <th>event</th>
-         <th>email</th>
-         <th>url</th>
-         <th>category</th>
-      </tr>
-   </thead>
-   <tbody>
-      <tr>
-         <td>click</td>
-         <td>Message recipient</td>
-         <td>URL Clicked</td>
-         <td>The category you assigned</td>
-      </tr>
-   </tbody>
-</table>
-
-```json
-[
-  {
-    "sg_event_id": "sendgrid_internal_event_id",
-    "sg_message_id": "sendgrid_internal_message_id",
-    "ip": "255.255.255.255",
-    "useragent": "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
-    "event": "click",
-    "email": "email@example.com",
-    "timestamp": 1249948800,
-    "url": "http://yourdomain.com/blog/news.html",
-    "url_offset": {
-      "index": 0,
-      "type": "html"
-    },
-    "unique_arg_key": "unique_arg_value",
-    "category": ["category1", "category2"],
-    "newsletter": {
-      "newsletter_user_list_id": "10557865",
-      "newsletter_id": "1943530",
-      "newsletter_send_id": "2308608"
-    },
-    "asm_group_id": 1
   }
 ]
 ```


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Update Event Webhook table and sample responses for accuracy
**Reason for the change**: The table was missing fields, and code samples included fields that were not available on the event type.
**Link to original source**: https://sendgrid.com/docs/for-developers/tracking-events/event

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #5890 Closes #5889 Closes #5896 
