### PR TITLE
Sendmail requires "apikey" as the username when using an API key, not your username

### DIFF
--- a/content/docs/for-developers/sending-email/sendmail.md
+++ b/content/docs/for-developers/sending-email/sendmail.md
@@ -22,7 +22,7 @@ We have had reports that some customers have needed to install `cyrus-sasl-plain
 </call-out>
 
 ```bash
-AuthInfo:smtp.sendgrid.net "U:yourUserName" "P:yourAPIKey" "M:PLAIN"
+AuthInfo:smtp.sendgrid.net "U:apikey" "P:yourAPIKey" "M:PLAIN"
 ```
 
 Define the Smart Host in **/etc/mail/sendmail.mc** You should add these lines just after the commented "\#dnl define('SMART_HOST', 'smtp.your.provider')dnl" line in the file


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
This changes the documentation for using SendGrid with the CLI sendmail to correct an issue with the suggested username.

**Reason for the change**:
Providing your username while using an API key for authentication will result in a "Bad username / password" error. When suggesting people use their API keys, the [SMTP documentation](https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/) says they should use "apikey" instead, as this change notes.

**Link to original source**:
https://github.com/sendgrid/docs/blob/develop/content/docs/for-developers/sending-email/sendmail.md

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
