### PR TITLE
Clarify usage of greaterThan / length

### DIFF
--- a/content/docs/for-developers/sending-email/using-handlebars.md
+++ b/content/docs/for-developers/sending-email/using-handlebars.md
@@ -968,7 +968,7 @@ The length helper will return the number of characters in a given string or arra
 <!-- Templates -->
 <p>
 Hello Ben!
-{{#greaterThan 0 length cartItems}}
+{{#greaterThan (length cartItems) 0}}
  It looks like you still have some items in your shopping cart. Sign back in to continue checking out at any time.
 {{else}}
  Thanks for browsing our site. We hope you'll come back soon.


### PR DESCRIPTION
The `greaterThan` helper takes 2 arguments `arg1` and `arg2` and evaluates to `arg1 > arg2`, when working with helpers it is important to group the helper such that your comparison is expected.

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
Updates code sample for `Length` and `greaterThan`
**Reason for the change**:
The code sample for `Length` utilizes `greaterThan` as well, but transposes the arguments, and misses a grouping that is required to behave as expected (based on the sample copy provided in the code)
**Link to original source**: N/A

