### PR TITLE
Fix: #6252 Broken link to build smtpapi header

### DIFF
--- a/content/docs/glossary/drops.md
+++ b/content/docs/glossary/drops.md
@@ -32,7 +32,7 @@ If the email address is on the Unsubscribe list the reason will say "Unsubscribe
 
 1. Email triggers SendGrid's spam filters if you have the [Spam Checker filter]({{root_url}}/ui/account-and-settings/mail/#spam-checker) enabled. You can identify these drops only through the data received through the [Event Webhook]({{root_url}}/for-developers/tracking-events/event/) or in [Email Activity]({{root_url}}/ui/analytics-and-reporting/email-activity-feed/). In both cases, the reason displayed will say "Spam Content".
 
-2. The SMTPAPI header is built incorrectly - this will cause the emails to be dropped with the reason "Invalid SMTPAPI header". For more details about how to build the SMTPAPI header, please view our documentation on [SMTP API]({{root_url}}/for-developers/sending-email/building-an-smtp-email/).
+2. The SMTPAPI header is built incorrectly - this will cause the emails to be dropped with the reason "Invalid SMTPAPI header". For more details about how to build the SMTPAPI header, please view our documentation on [SMTP API]({{root_url}}/for-developers/sending-email/building-an-x-smtpapi-header/).
 
 3. Duplicate message - emails are dropped with this reason only when they are sent through the Marketing Email App or through the Marketing API. If a recipient's address is showing on multiple lists and you assign those lists to one campaign, our systems automatically identify that the address is on multiple lists and drops the duplicate messages. This prevents having the same message sent to the same recipient multiple times.
 


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
Fix Broken link to Building an X-SMTPAPI Header

**Reason for the change**:
Link was broken

**Link to original source**:
https://sendgrid.com/docs/glossary/drops/#other-reasons-for-dropped-emails

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #6252
