### PR TITLE
Correcting Signature -> Timestamp header in docs

### DIFF
--- a/content/docs/for-developers/tracking-events/getting-started-event-webhook-security-features.md
+++ b/content/docs/for-developers/tracking-events/getting-started-event-webhook-security-features.md
@@ -96,7 +96,7 @@ When verifying the signature, be aware that we deliver a payload that must be us
 s := http.Request.Header.Get("X-Twilio-Email-Event-Webhook-Signature")
 ```
 
-2. Get the timestamp from the "`"X-Twilio-Email-Event-Webhook-Signature"` HTTP header.
+2. Get the timestamp from the "`"X-Twilio-Email-Event-Webhook-Timestamp"` HTTP header.
 
 ```go
 // Golang Example

--- a/content/docs/for-developers/tracking-events/getting-started-event-webhook-security-features.md
+++ b/content/docs/for-developers/tracking-events/getting-started-event-webhook-security-features.md
@@ -96,7 +96,7 @@ When verifying the signature, be aware that we deliver a payload that must be us
 s := http.Request.Header.Get("X-Twilio-Email-Event-Webhook-Signature")
 ```
 
-2. Get the timestamp from the "`"X-Twilio-Email-Event-Webhook-Timestamp"` HTTP header.
+2. Get the timestamp from the `"X-Twilio-Email-Event-Webhook-Timestamp"` HTTP header.
 
 ```go
 // Golang Example


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: The [`Getting Started with the Event Webhook Security Features`](https://sendgrid.com/docs/for-developers/tracking-events/getting-started-event-webhook-security-features/) document has a typo, where it's instructing you to get the timestamp of a Webhook event from `X-Twilio-Email-Event-Webhook-Signature`, whereas it should be `X-Twilio-Email-Event-Webhook-Timestamp`. It additionally has an extra stray quotation mark. This PR fixes both.
**Reason for the change**: Clean up a typo in the docs
**Link to original source**: [`Getting Started with the Event Webhook Security Features`](https://sendgrid.com/docs/for-developers/tracking-events/getting-started-event-webhook-security-features/)

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
