### PR TITLE
Add bounce type to table

### DIFF
--- a/content/docs/for-developers/tracking-events/event.md
+++ b/content/docs/for-developers/tracking-events/event.md
@@ -744,6 +744,21 @@ Engagement events include open, click, spam report, unsubscribe, group unsubscri
     <td></td>
     <td></td>
   </tr>
+  </tr>
+    <tr>
+    <td><a href="#type">type</a></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>X</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
 </table>
 
 \* In the case of a delayed or asynchronous bounce, the message ID will be unavailable.


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: There are two kinds of bounces, a `bounce` and a `blocked`. That's mentioned in the docs, but it's not in the table.
**Reason for the change**: To make the docs more consistent about event structure / schema.
**Link to original source**: [Webhook Reference](https://sendgrid.com/docs/for-developers/tracking-events/event/)

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
