### PR TITLE
Fix typo in Handlebars Documentation

### DIFF
--- a/content/docs/for-developers/sending-email/using-handlebars.md
+++ b/content/docs/for-developers/sending-email/using-handlebars.md
@@ -233,7 +233,7 @@ The formatDate helper takes a time in either epoch or ISO8601 format and convert
       </th>
     </tr>
     <tr>
-      <td>YYYYY</td>
+      <td>YYYY</td>
       <td>2020</td>
     </tr>
     <tr>


### PR DESCRIPTION
Date formatting section had a minor typo in the displaying of the year. Changed YYYYY to YYYY

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
**Reason for the change**:
**Link to original source**:

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
