### PR TITLE
Fix upgrade-your-authentication-method-to-api-keys.md

### DIFF
--- a/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
+++ b/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
@@ -49,8 +49,7 @@ Follow these steps to identify and replace your authentication method to API Key
 ## Upgrade to API Keys for your SMTP integration 
 
 1. Generate API Keys in the SendGrid UI or programmatically with the least privileged permissions required for each of the endpoints you will be updating. For more information, see [API Key Permissions]({{root_url}}/ui/account-and-settings/api-keys/#api-key-permissions). 
-1. Convert your API key to Base64. It is not secure to put your API key into an external webpage for a conversion, so we recommend using a bash conversion. If you are on Mac or Linux, you can use the pre-installed OpenSSL package. Use this cmd to convert your API key using OpenSSL: echo -n '<<YOUR_API_KEY>>' | openssl base64.
-1. Replace your username and password credentials with the newly-converted API key. You will want to use a converted version of your username for SMTP integration as well. Everyone's username is `apikey` which is `YXBpa2V5` in Base64.
+1. Replace your username and password credentials with the newly-converted API key. You will want to use a converted version of your username for SMTP integration as well. Everyone's username is `apikey`.
 
 Once the previous steps are completed, enable Two-Factor Authentication for all of your users, including [subusers]({{root_url}}/ui/account-and-settings/subusers/) and [teammates]({{root_url}}/ui/account-and-settings/teammates/).
 


### PR DESCRIPTION
Remove instructions to convert API key to base64 for SMTP (which causes login failures).  This conflicts with the instructions at https://sendgrid.com/docs/for-developers/sending-email/integrating-with-the-smtp-api/ (which actually do work).

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
**Reason for the change**:
**Link to original source**:

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
