### PR TITLE
Bug fix string concatenation for $attachment.

### DIFF
--- a/content/docs/for-developers/tracking-events/php-code-example.md
+++ b/content/docs/for-developers/tracking-events/php-code-example.md
@@ -33,7 +33,7 @@ $num_attachments = $_POST["attachments"];
 
 if($num_attachments){
   for($i = 1; $i <= $num_attachments; $i++) {
-    $attachment = $_FILES['attachment' + $i];
+    $attachment = $_FILES['attachment' . $i];
 	  // $attachment will have all the parameters expected in a the PHP $_FILES object
 	  // http://www.php.net/manual/en/features.file-upload.post-method.php#example-369
   }


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: String concatenation in PHP utilizes "." instead of "+". 
**Reason for the change**: This code will set the attachment properly in PHP.
**Link to original source**: https://sendgrid.com/docs/for-developers/tracking-events/php-code-example/
