### PR TITLE
Lowercase unsubscribe tag

### DIFF
--- a/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
+++ b/content/docs/ui/sending-email/create-and-manage-unsubscribe-groups.md
@@ -71,7 +71,7 @@ If you would like to use a custom URL for your unsubscribe link, from the Editor
 
 This will expand a new field where you can insert a URL for one of your own pages where recipients can manage their subscription preferences.
 
-To place your Custom Unsubscribe link into your email, highlight any text within the body of your email and click the small link icon to specify a hyperlink. In the URL field that appears, enter the tag `{{{Unsubscribe}}}`. Since you've specified your Custom Unsubscribe Link in the Settings panel, SendGrid will replace the Unsubscribe Tag with your custom URL.
+To place your Custom Unsubscribe link into your email, highlight any text within the body of your email and click the small link icon to specify a hyperlink. In the URL field that appears, enter the tag `{{{unsubscribe}}}`. Since you've specified your Custom Unsubscribe Link in the Settings panel, SendGrid will replace the Unsubscribe Tag with your custom URL.
 
 ## Add recipients to an Unsubscribe Group
 


### PR DESCRIPTION
The tag `{{{Unsubscribe}}}` only works in lowercase: `{{{unsubscribe}}}`

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
**Reason for the change**:
**Link to original source**:

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
