### PR TITLE
Update references to Basic Auth username/password usage

### DIFF
--- a/content/docs/for-developers/sending-email/postfix.md
+++ b/content/docs/for-developers/sending-email/postfix.md
@@ -36,10 +36,10 @@ We highly recommend using an API key as your credential for any service that sup
 
 </call-out>
 
-Now you need to specify your credentials (optionally, use `apikey` as username and an API Key as password) in the separate file **/etc/postfix/sasl_passwd** (you'll likely need to create it):
+Now you need to specify your credentials (use `apikey` as username and an API Key as password) in the separate file **/etc/postfix/sasl_passwd** (you'll likely need to create it):
 
 ```
-[smtp.sendgrid.net]:587 yourSendGridUsername:yourSendGridPassword
+[smtp.sendgrid.net]:587 apikey:yourSendGridApiKey
 ```
 
 Next, make sure the file has restricted read and write access only for root, and use the `postmap` command to update Postfix's hashtables to use this new file:


### PR DESCRIPTION


### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Removed optional aspects of using `apikey` and an API Key as username + password combinations for authentication alternative to API Key authentications.
**Reason for the change**: As of 20 January 2021, Basic Authentication with account username + password combination will no longer work, documentation should be changed to require username: `apikey` and an API Key generated from the account as the password. If the integration does not permit a password of 69 characters (API Key length) that should be noted and further discussion should be had to determine SendGrid compatibility.
**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/postfix/

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
