### PR TITLE
Update drupal.md

### DIFF
--- a/content/docs/for-developers/sending-email/drupal.md
+++ b/content/docs/for-developers/sending-email/drupal.md
@@ -30,7 +30,7 @@ Open your modules page, find the SMTP module, and configure it with the followin
 -   **SMTP Server** - smtp.sendgrid.net
 -   **SMTP Port** - 587
 -   **Use Encrypted Protocol** - No. If you want encryption choose "Use SSL" and set SMTP Port to 465
--   **Username** - SendGrid Username: "api_user"
+-   **Username** - SendGrid Username: "apikey"
 -   **Password** - SendGrid API Key
 
 ![]({{root_url}}/images/drupal_2.png "SMTP Module Configuration")
@@ -59,6 +59,6 @@ Once installed access `admin/config/system/phpmailer-smtp` to configure the modu
 
 Under **SMTP Authentication**, set your username and password (API key):
 
--   **Username** - SendGrid Username: "api_user"
+-   **Username** - SendGrid Username: "apikey"
 -   **Password** - SendGrid API Key
 

--- a/content/docs/for-developers/sending-email/drupal.md
+++ b/content/docs/for-developers/sending-email/drupal.md
@@ -30,7 +30,7 @@ Open your modules page, find the SMTP module, and configure it with the followin
 -   **SMTP Server** - smtp.sendgrid.net
 -   **SMTP Port** - 587
 -   **Use Encrypted Protocol** - No. If you want encryption choose "Use SSL" and set SMTP Port to 465
--   **Username** - SendGrid Username
+-   **Username** - SendGrid Username: "api_user"
 -   **Password** - SendGrid API Key
 
 ![]({{root_url}}/images/drupal_2.png "SMTP Module Configuration")
@@ -59,6 +59,6 @@ Once installed access `admin/config/system/phpmailer-smtp` to configure the modu
 
 Under **SMTP Authentication**, set your username and password (API key):
 
--   **Username** - SendGrid Username
+-   **Username** - SendGrid Username: "api_user"
 -   **Password** - SendGrid API Key
 


### PR DESCRIPTION
api_user as username is not clear, but v2 api docs show it should always be api_user @ https://www.twilio.com/docs/sendgrid/api/v2/using_the_web_api#authentication

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
api_user as username is not clear, but v2 api docs show it should always be api_user @ https://www.twilio.com/docs/sendgrid/api/v2/using_the_web_api#authentication
**Reason for the change**:
Swapping over to API authentication (the only auth available now) from old auth leaves username unclear.
**Link to original source**:

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
