### PR TITLE
Minimum password character length is now 16

### DIFF
--- a/content/docs/ui/account-and-settings/account.md
+++ b/content/docs/ui/account-and-settings/account.md
@@ -23,7 +23,7 @@ To edit your name and email address, click  **Change Contact Info**.
 
 **Username** - Your SendGrid Username is used to access our API and our SMTP Relay. Changing this will immediately cause all of your calls to SendGrid to stop working.
 
-**Password** -  The minimum password criterion that your SendGrid password must meet include 8 to 128 characters, at least one number, and one letter.
+**Password** -  The password criterion that your SendGrid password must include: 16 to 128 characters, at least one number, and one letter.
 
 **Company** - The name of your company.
 


### PR DESCRIPTION
Updated **password** line to reflect new minimum character length requirement of 16 characters.

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Changed **password** line to reflect new minimum 16 character limit.
**Reason for the change**: Updating documentation to be accurate.
**Link to original source**: [https://sendgrid.com/docs/ui/account-and-settings/account/#:~:text=Password%20%2D%20The%20minimum%20password%20criterion,one%20number%2C%20and%20one%20letter.](https://sendgrid.com/docs/ui/account-and-settings/account/#:~:text=Password%20%2D%20The%20minimum%20password%20criterion,one%20number%2C%20and%20one%20letter.)

Incorrect information also shows on this page - but can't click to edit this page: [https://d2w67tjf43xwdp.cloudfront.net/Classroom/Basics/Security/password.html](https://d2w67tjf43xwdp.cloudfront.net/Classroom/Basics/Security/password.html)

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
