### PR TITLE
Update upgrade-your-authentication-method-to-api-keys.md

### DIFF
--- a/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
+++ b/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
@@ -45,7 +45,7 @@ Follow these steps to identify and replace your authentication method to API Key
 1. Replace your username and password credentials with API Keys.
 
 - For v3 API: Follow [these instructions](https://sendgrid.api-docs.io/v3.0/how-to-use-the-sendgrid-v3-api/api-authentication).
-- For v2: Follow [these instructions](https://www.twilio.com/docs/sendgrid/api/v2/using_the_web_api#authentication).
+- For v2: Follow [these instructions](https://www.twilio.com/docs/sendgrid/api/v2/mail#sending-email).
 
 ## Upgrade to API Keys for your SMTP integration
 


### PR DESCRIPTION
Current docs point here: https://www.twilio.com/docs/sendgrid/api/v2/using_the_web_api#authentication



### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Correcting the v2 API Auth docs link, updated to: https://www.twilio.com/docs/sendgrid/api/v2/mail#sending-email

**Reason for the change**: 
Current link is leading to incorrect/outdated info, which is then leading to increased support tickets where we have to link them to the correct bit of information :(
v2 users should be using Bearer Auth in order to successfully upgrade to using API keys and the "api_user=apikey" bit should _not_ be included:
>When using an API Key, pass it in an Authorization header and omit the api_user and api_key parameters from your request. You can pass the API Key as a Bearer Token: "Authorization: Bearer <Your API Key>"

**Link to original source**: https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
