### PR TITLE
Fix user_name parameter typo in upgrading to API keys doc

### DIFF
--- a/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
+++ b/content/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys.md
@@ -53,7 +53,7 @@ Follow these steps to identify and replace your authentication method to API Key
 2. To use your API key with the SMTP integration, you must set your username to the string, `apikey`. Your password will be the API key you generated in the previous step.
 
 ```
-username: "apikey"
+user_name: "apikey"
 password: <Your API Key>
 ```
 


### PR DESCRIPTION
### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**:
The SMTP settings in the upgrade docs should be
```
user_name: "apikey"
password: <Your API Key>
```
but the docs reference the `user_name` as `username` which is wrong. 

**Reason for the change**:
If you implement as per the current doc, you get **ArgumentError SMTP-AUTH requested but missing user name**

**Link to original source**:
[https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/](https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/)

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #6464
