### PR TITLE
Fix confusing use of string literals

### DIFF
--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -91,8 +91,8 @@ In `config/environment.rb` specify your ActionMailer settings to point to SendGr
 
 ``` ruby
 ActionMailer::Base.smtp_settings = {
-  :user_name => 'apikey',
-  :password => 'your_sendgrid_api_key',
+  :user_name => 'apikey', # This is the string literal 'apikey', NOT the ID of your API key
+  :password => ENV['SENDGRID_SECRET_API_KEY'], # This is the secret sendgrid API key which was issued during API key creation
   :domain => 'yourdomain.com',
   :address => 'smtp.sendgrid.net',
   :port => 587,

--- a/content/docs/for-developers/sending-email/rubyonrails.md
+++ b/content/docs/for-developers/sending-email/rubyonrails.md
@@ -92,7 +92,7 @@ In `config/environment.rb` specify your ActionMailer settings to point to SendGr
 ``` ruby
 ActionMailer::Base.smtp_settings = {
   :user_name => 'apikey', # This is the string literal 'apikey', NOT the ID of your API key
-  :password => ENV['SENDGRID_SECRET_API_KEY'], # This is the secret sendgrid API key which was issued during API key creation
+  :password => '<SENDGRID_API_KEY>', # This is the secret sendgrid API key which was issued during API key creation
   :domain => 'yourdomain.com',
   :address => 'smtp.sendgrid.net',
   :port => 587,


### PR DESCRIPTION
### PR Details
The current documentations use of `apikey` as a string literal instead of a substitution like the use of `your_sendgrid_api_key` creates unnecessary confusion on how to properly implement the mailer.

This does two things:
1. Adds a comment reminding the reader that `apikey` is a literal and not a substitution
2. Uses a reference to a stored `ENV` variable for the actual secret API key to differentiate from point 1 above and also follow more closely to best practices with secrets

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.
