### PR TITLE
Adding missing parenthesis

### DIFF
--- a/content/docs/for-developers/sending-email/quickstart-python.md
+++ b/content/docs/for-developers/sending-email/quickstart-python.md
@@ -219,7 +219,7 @@ Note that the `Content()` helper takes two arguments: the content type and the c
 from_email = Email("test@example.com")  # Change to your verified sender
 to_email = To("test@example.com")  # Change to your recipient
 subject = "Sending with SendGrid is Fun"
-content = Content("text/plain", "and easy to do anywhere, even with Python"
+content = Content("text/plain", "and easy to do anywhere, even with Python")
 ```
 
 To properly construct the message, pass each of the previous variables into the SendGrid library's Mail constructor. You can assign this to a variable named `mail`. You can then use the the Mail constructor's `get()` method to get a JSON-ready representation of the Mail object.


### PR DESCRIPTION
Adding missing parenthesis in "build your api call" section, reported by customer.

### Checklist
**Required**
- [x] I acknowledge that all my contributions will be made under the project's license.

### PR Details
**Description of the change**: Adding a missing parenthesis, reported by customer
**Reason for the change**: Missing parenthesis makes the code incorrect in the documentation
**Link to original source**:  https://sendgrid.com/docs/for-developers/sending-email/quickstart-python/#build-your-api-call

<!-- 
If this pull request closes an issue, add the issue number here:  
-->
Closes #
